### PR TITLE
Enable Keycloak mocking

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
 const config = {
   keycloak: {
+    mock: JSON.parse(process.env.MOCK_KEYCLOAK || false),
     clientConfig: {
       realm: process.env.KEYCLOAK_REALM || 'cop-dev',
       url: process.env.KEYCLOAK_AUTH_URL || 'https://sso-dev.notprod.homeoffice.gov.uk/auth',

--- a/src/utils/keycloak.js
+++ b/src/utils/keycloak.js
@@ -11,13 +11,20 @@ const KeycloakProvider = ({ children }) => {
   const keycloakInstance = Keycloak(config.keycloak.clientConfig);
 
   useEffect(() => {
-    keycloakInstance.init(config.keycloak.initOptions).then(authenticated => {
-      if (authenticated) {
-        setKeycloak(keycloakInstance);
-      } else {
-        keycloakInstance.login();
-      }
-    });
+    if (config.keycloak.mock) {
+      setKeycloak({
+        createLogoutUrl: () => '',
+        loadUserInfo: () => Promise.resolve({ name: 'Cerberus' }),
+      });
+    } else {
+      keycloakInstance.init(config.keycloak.initOptions).then(authenticated => {
+        if (authenticated) {
+          setKeycloak(keycloakInstance);
+        } else {
+          keycloakInstance.login();
+        }
+      });
+    }
   }, []);
 
   return <KeycloakContext.Provider value={keycloak}>{children}</KeycloakContext.Provider>;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const webpack = require('webpack');
 
-
 module.exports = {
   devtool: 'source-map',
   entry: ['./src/', './src/assets/styles/main.scss'],
@@ -45,6 +44,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env': {
+        MOCK_KEYCLOAK: JSON.stringify(process.env.MOCK_KEYCLOAK),
         KEYCLOAK_AUTH_URL: JSON.stringify(process.env.KEYCLOAK_AUTH_URL),
         KEYCLOAK_CLIENT_ID: JSON.stringify(process.env.KEYCLOAK_CLIENT_ID),
         KEYCLOAK_REALM: JSON.stringify(process.env.KEYCLOAK_REALM),


### PR DESCRIPTION
## Description

Make it easier to test the app without authenticaiton.

## To Test

1. Start the app with `MOCK_KEYCLOAK=true npm run start`
2. Keycloak authentication shouldn't be required

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
