### PR TITLE
COP-4093: Add select field compatible with GDS

### DIFF
--- a/src/forms/FieldSelect.jsx
+++ b/src/forms/FieldSelect.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import useField from '../forms/useField';
+import Select from '../govuk/Select';
+
+const FieldSelect = ({
+  id,
+  name,
+  type,
+  validate,
+  required,
+  defaultValue,
+  ...attributes
+}) => {
+  const { value, error, touched, onChange, onBlur } = useField({
+    name,
+    validate,
+    required,
+    defaultValue,
+  });
+
+  return (
+    <Select
+      key={name}
+      id={id || `field-${name}`}
+      name={name}
+      defaultValue={value || defaultValue}
+      onChange={onChange}
+      onBlur={onBlur}
+      errorMessage={error}
+      {...attributes}
+    />
+  );
+}
+
+export default FieldSelect;

--- a/src/govuk/Select.jsx
+++ b/src/govuk/Select.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import classNames from 'classnames';
+import FormGroup from './FormGroup';
+
+const Select = ({ id, className, defaultValue, label, hint, errorMessage, formGroup,
+                  describedBy, emptyOption = ' ', options, ...attributes }) => (
+  <FormGroup inputId={id} hint={hint} label={label} errorMessage={errorMessage} describedBy={describedBy} {...formGroup}>
+    {({ describedBy }) => (
+      <select
+        id={id}
+        className={classNames(className, 'govuk-select', { 'govuk-select--error': errorMessage })}
+        defaultValue={defaultValue}
+        aria-describedby={describedBy}
+        {...attributes}
+      >
+        {emptyOption && (
+          <option key="" value="">
+            {emptyOption}
+          </option>
+        )}
+        {options.map(({ label: optionLabel, value: optionValue }) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </select>
+    )}
+  </FormGroup>
+);
+
+export default Select;

--- a/src/routes/IssueTargetPage.jsx
+++ b/src/routes/IssueTargetPage.jsx
@@ -9,6 +9,7 @@ import FormProgress from '../forms/FormProgress';
 import Button from '../govuk/Button';
 import SecondaryButton from '../govuk/SecondaryButton';
 import FormActions from '../forms/FormActions';
+import FieldSelect from '../forms/FieldSelect';
 
 const IssueTargetPage = () => {
   const history = useHistory();
@@ -36,6 +37,10 @@ const IssueTargetPage = () => {
             <h2 className="govuk-heading-m">General Target Information</h2>
 
             <FieldInput name="test" type="text" label="Test input" />
+            <FieldSelect name="testSelect" options={[
+              { label: 'Option A', value: 'a', },
+              { label: 'Option B', value: 'b', },
+            ]} />
           </FormStep>
 
           <FormStep name="two">


### PR DESCRIPTION
## Description

Add select element compatible with GDS specification.

## To Test

1. Go to the "Issue target sheet form"
2. Check if the select field looks like the field from GOV.UK Design System: https://design-system.service.gov.uk/components/select/

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
