### PR TITLE
COP-4093: Add Details component

### DIFF
--- a/src/govuk/Details.jsx
+++ b/src/govuk/Details.jsx
@@ -1,0 +1,28 @@
+/**
+ * React implementation of GOV.UK Design System Details
+ * Demo: https://design-system.service.gov.uk/components/details/
+ * Code: https://github.com/alphagov/govuk-frontend/blob/master/package/govuk/components/details/README.md
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+function Details({
+  open, className, summary, children, ...attributes
+}) {
+  return (
+    <details className={classNames('govuk-details', className)} open={open} data-module="govuk-details" {...attributes}>
+      <summary className="govuk-details__summary">
+        <span className="govuk-details__summary-text">
+          {summary}
+        </span>
+      </summary>
+      <div className="govuk-details__text">
+        {children}
+      </div>
+    </details>
+
+  );
+}
+
+export default Details;

--- a/src/govuk/FormGroup.jsx
+++ b/src/govuk/FormGroup.jsx
@@ -15,7 +15,7 @@ const FieldsetWrapper = ({ children, ...attributes }) => {
 };
 
 const FormGroup = ({
-  inputId, className, label, hint, errorMessage, describedBy, fieldset, children, ...attributes
+  inputId, className, label, hint, errorMessage, describedBy, fieldset, prefix, suffix, children, ...attributes
 }) => {
   let hintWithId;
   let errorMessageWithId;
@@ -48,12 +48,14 @@ const FormGroup = ({
   return (
     <div className={classNames(className, 'govuk-form-group', { 'govuk-form-group--error': errorMessage })} {...attributes}>
       <FieldsetWrapper {...fieldset}>
+        {prefix}
         {labelWithId}
         {hintWithId}
         {errorMessageWithId}
         {typeof children === 'function'
           ? children({ formGroupDescribeBy: describeByElements.join(' ') })
           : children}
+        {suffix}
       </FieldsetWrapper>
     </div>
   );

--- a/src/govuk/__tests__/Details.test.jsx
+++ b/src/govuk/__tests__/Details.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Details from '../Details';
+
+test('renders the closed details', () => {
+  render(<Details summary="Test summary">Test body</Details>);
+  expect(screen.getByText('Test summary')).toBeInTheDocument();
+  expect(screen.getByText('Test body')).not.toBeVisible();
+});
+
+test('renders the open details', () => {
+  render(<Details open summary="Test summary">Test body</Details>);
+  expect(screen.getByText('Test summary')).toBeInTheDocument();
+  expect(screen.getByText('Test body')).toBeVisible();
+});

--- a/src/routes/IssueTargetPage.jsx
+++ b/src/routes/IssueTargetPage.jsx
@@ -14,6 +14,7 @@ import Panel from '../govuk/Panel';
 import FieldRadios from '../forms/FieldRadios';
 import FieldAddress from '../forms/FieldAddress';
 import FieldAutocomplete from '../forms/FieldAutocomplete';
+import Details from '../govuk/Details';
 
 const IssueTargetPage = () => {
   const history = useHistory();
@@ -62,6 +63,23 @@ const IssueTargetPage = () => {
                 { label: 'Option E', value: 'e' },
                 { label: 'Option F', value: 'f' },
               ]}
+            />
+
+            <FieldInput
+              label="Operation name"
+              name="operation"
+              required="Type operation name"
+              formGroup={{
+                suffix: (
+                  <Details
+                    summary="How to find the port from the dropdown list"
+                    className="govuk-!-margin-top-2"
+                  >
+                    To search for a port, enter the first three letters in the search bar of the dropdown list.
+                    This will filter the list based on those letters
+                  </Details>
+                ),
+              }}
             />
 
             <FieldRadios


### PR DESCRIPTION
## Description

Add Details component compatible with GOV.UK Design System.

## To Test
1. Open the `Issue a target form`
2. You should see a details component with summary `How to find the port from the dropdown list`
3. It should open and close

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
