### PR TITLE
COP-4093: Add FieldDate component

### DIFF
--- a/src/forms/FieldDate.jsx
+++ b/src/forms/FieldDate.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { castArray } from 'lodash';
+
+import useField from './useField';
+import DateInput from '../govuk/DateInput';
+import { validLongDate, validShortDate } from './validators';
+
+const FieldDate = ({
+  id,
+  name,
+  validate,
+  required,
+  defaultValue,
+  invalidDateMessage = 'Enter a valid date',
+  isShort = false,
+  ...attributes
+}) => {
+  const {
+    value = {}, error, setFieldValue,
+  } = useField({
+    name,
+    validate: [
+      isShort ? validShortDate(invalidDateMessage) : validLongDate(invalidDateMessage),
+      ...castArray(validate),
+    ],
+    required,
+    defaultValue,
+  });
+
+  const getInputProps = (datePartName) => ({
+    defaultValue: value[datePartName],
+    onChange: (e) => {
+      setFieldValue(name, {
+        ...value,
+        [datePartName]: e.target.value,
+      });
+    },
+  });
+
+  return (
+    <DateInput
+      key={name}
+      id={id || `field-${name}`}
+      name={name}
+      errorMessage={error}
+      dayInput={isShort ? null : { placeholder: 'DD', ...getInputProps('day') }}
+      monthInput={{ placeholder: 'MM', ...getInputProps('month') }}
+      yearInput={{ placeholder: 'YYYY', ...getInputProps('year') }}
+      {...attributes}
+    />
+  );
+};
+
+export default FieldDate;

--- a/src/forms/FieldInput.jsx
+++ b/src/forms/FieldInput.jsx
@@ -27,7 +27,7 @@ const FieldInput = ({
       id={id || `field-${name}`}
       type={type}
       name={name}
-      defaultValue={value || defaultValue}
+      defaultValue={value}
       onChange={onChange}
       errorMessage={error}
       {...attributes}

--- a/src/forms/__tests__/FieldDate.test.jsx
+++ b/src/forms/__tests__/FieldDate.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Form from '../Form';
+import FieldDate from '../FieldDate';
+
+const type = (label, text) => fireEvent.input(screen.getByLabelText(label), {
+  target: { value: text },
+});
+
+test('renders long date field', () => {
+  render(<Form><FieldDate name="testDate" /></Form>);
+  expect(screen.getByLabelText('Day')).toBeInTheDocument();
+  expect(screen.getByLabelText('Month')).toBeInTheDocument();
+  expect(screen.getByLabelText('Year')).toBeInTheDocument();
+});
+
+test('renders short date field', () => {
+  render(<Form><FieldDate isShort name="testDate" /></Form>);
+  expect(screen.queryByLabelText('Day')).toBeNull();
+  expect(screen.getByLabelText('Month')).toBeInTheDocument();
+  expect(screen.getByLabelText('Year')).toBeInTheDocument();
+});
+
+test('validates when the field is required but empty', () => {
+  render(
+    <Form>
+      <FieldDate required="Date is required" name="testDate" />
+      <button>Submit</button>
+    </Form>,
+  );
+  fireEvent.click(screen.getByText('Submit'));
+  expect(screen.getByRole('alert')).toHaveTextContent('Date is required');
+});
+
+test('validates long date', () => {
+  render(
+    <Form>
+      <FieldDate name="testDate" />
+      <button>Submit</button>
+    </Form>,
+  );
+
+  type('Day', 1);
+  fireEvent.click(screen.getByText('Submit'));
+  expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid date');
+
+  type('Month', 12);
+  type('Year', 2021);
+  fireEvent.click(screen.getByText('Submit'));
+  expect(screen.queryByRole('alert')).toBeNull();
+});
+
+test('validates short date', () => {
+  render(
+    <Form>
+      <FieldDate isShort name="testDate" />
+      <button>Submit</button>
+    </Form>,
+  );
+
+  type('Month', 12);
+  fireEvent.click(screen.getByText('Submit'));
+  expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid date');
+
+  type('Year', 2021);
+  fireEvent.click(screen.getByText('Submit'));
+  expect(screen.queryByRole('alert')).toBeNull();
+});
+
+test('sets the form values', () => {
+  render(
+    <Form>{({ values }) => (
+      <>
+        <FieldDate name="testDate" />
+        <span data-testid="values">{JSON.stringify(values)}</span>
+      </>
+    )}
+    </Form>,
+  );
+  type('Day', 1);
+  type('Month', 12);
+  type('Year', 2021);
+  expect(screen.getByTestId('values').textContent).toEqual(JSON.stringify({
+    testDate: {
+      day: '1',
+      month: '12',
+      year: '2021',
+    },
+  }));
+});

--- a/src/forms/useField.js
+++ b/src/forms/useField.js
@@ -26,7 +26,7 @@ const useField = ({
       validators.unshift(requireValue(required));
     }
 
-    return validators;
+    return validators.filter((validatorFunction) => typeof validatorFunction === 'function');
   };
 
   useEffect(() => {

--- a/src/forms/validators.js
+++ b/src/forms/validators.js
@@ -1,6 +1,8 @@
 import { isEmpty } from 'lodash';
 
-// eslint-disable-next-line import/prefer-default-export
+export const LONG_DATE_PATTERN = /^(\d{4})(\/|-)(\d{1,2})(\/|-)(\d{1,2})$/;
+export const SHORT_DATE_PATTERN = /^(\d{4})(\/|-)(\d{1,2})$/;
+
 export const requireValue = (errorMessage) => (value) => {
   const isPrimitiveValue = value !== Object(value);
   if (isPrimitiveValue) {
@@ -10,4 +12,14 @@ export const requireValue = (errorMessage) => (value) => {
     return !Object.values(value).some(Boolean) ? errorMessage : null;
   }
   return isEmpty(value) ? errorMessage : null;
+};
+
+export const validShortDate = (errorMessage) => (value = {}) => {
+  const { year, month } = value;
+  return (!year && !month) || `${year}/${month}`.match(SHORT_DATE_PATTERN) ? null : errorMessage;
+};
+
+export const validLongDate = (errorMessage) => (value = {}) => {
+  const { year, month, day } = value;
+  return (!year && !month && !day) || `${year}/${month}/${day}`.match(LONG_DATE_PATTERN) ? null : errorMessage;
 };

--- a/src/govuk/DateInput.jsx
+++ b/src/govuk/DateInput.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import classNames from 'classnames';
+import FormGroup from './FormGroup';
+import Input from './Input';
+
+/**
+ * React implementation of GOV.UK Design System Date Input
+ * Demo: https://design-system.service.gov.uk/components/date-input/
+ * Code: https://github.com/alphagov/govuk-frontend/blob/master/package/govuk/components/date-input/README.md
+ */
+
+const DateInput = ({
+  id, namePrefix, className, dayInput = {}, monthInput = {}, yearInput = {}, legend,
+  fieldset = {}, formGroup = {}, errorMessage, hint, describedBy, ...attributes
+}) => {
+  const inputsToRender = [];
+  if (dayInput) {
+    inputsToRender.push({
+      label: 'Day',
+      name: 'day',
+      className: classNames('govuk-input--width-2', { 'govuk-input--error': errorMessage }),
+      type: 'text',
+      ...dayInput,
+    });
+  }
+  if (monthInput) {
+    inputsToRender.push({
+      label: 'Month',
+      name: 'month',
+      className: classNames('govuk-input--width-2', { 'govuk-input--error': errorMessage }),
+      type: 'text',
+      ...monthInput,
+    });
+  }
+  if (yearInput) {
+    inputsToRender.push({
+      label: 'Year',
+      name: 'year',
+      className: classNames('govuk-input--width-4', { 'govuk-input--error': errorMessage }),
+      type: 'text',
+      ...yearInput,
+    });
+  }
+
+  return (
+    <FormGroup
+      inputId={id}
+      hint={hint}
+      fieldset={{ legend, ...fieldset }}
+      errorMessage={errorMessage}
+      describedBy={describedBy}
+      {...formGroup}
+    >
+      <div className={classNames('govuk-date-input', className)} {...attributes}>
+        {inputsToRender.map(({
+          reactListKey: itemKey,
+          label: itemLabel,
+          id: itemId,
+          name: itemName,
+          pattern: itemPattern = '[0-9]*',
+          value: itemValue,
+          className: itemClassName,
+          ...item
+        }, index) => (
+          <div key={itemKey || index} className="govuk-date-input__item">
+            <Input
+              label={{
+                children: itemLabel,
+                className: 'govuk-date-input__label',
+              }}
+              id={itemId || (`${id}-${itemName}`)}
+              className={classNames('govuk-date-input__input', itemClassName)}
+              name={namePrefix ? namePrefix + itemName : itemName}
+              value={itemValue}
+              type="number"
+              pattern={itemPattern}
+              {...item}
+            />
+          </div>
+        ))}
+      </div>
+    </FormGroup>
+  );
+};
+
+export default DateInput;

--- a/src/govuk/FormGroup.jsx
+++ b/src/govuk/FormGroup.jsx
@@ -7,11 +7,11 @@ import Hint from './Hint';
 import ErrorMessage from './ErrorMessage';
 import Fieldset from './Fieldset';
 
-const FieldsetWrapper = ({ children, ...attributes }) => {
+const FieldsetWrapper = ({ children, describedBy, ...attributes }) => {
   if (isEmpty(attributes)) {
     return children;
   }
-  return <Fieldset {...attributes}>{children}</Fieldset>;
+  return <Fieldset describedBy={describedBy} {...attributes}>{children}</Fieldset>;
 };
 
 const FormGroup = ({
@@ -20,11 +20,11 @@ const FormGroup = ({
   let hintWithId;
   let errorMessageWithId;
   let labelWithId;
-  const describeByElements = [describedBy];
+  const describedByElements = [];
 
   if (hint) {
     const hintId = inputId ? `${inputId}-hint` : '';
-    describeByElements.push(hintId);
+    describedByElements.push(hintId);
 
     hintWithId = typeof hint === 'string' || React.isValidElement(hint)
       ? <Hint id={hintId}>{hint}</Hint>
@@ -33,7 +33,7 @@ const FormGroup = ({
 
   if (errorMessage) {
     const errorId = inputId ? `${inputId}-error` : '';
-    describeByElements.push(errorId);
+    describedByElements.push(errorId);
     errorMessageWithId = typeof errorMessage === 'string' || React.isValidElement(errorMessage)
       ? <ErrorMessage id={errorId}>{errorMessage}</ErrorMessage>
       : <ErrorMessage id={errorId} {...errorMessage} />;
@@ -45,15 +45,25 @@ const FormGroup = ({
       : <Label htmlFor={inputId} {...label} />;
   }
 
+  if (describedBy) {
+    describedByElements.push(describedBy);
+  }
+
+  if (fieldset && fieldset.describedBy) {
+    describedByElements.push(fieldset.describedBy);
+  }
+
+  const computedDescribedBy = describedByElements.join(' ');
+
   return (
     <div className={classNames(className, 'govuk-form-group', { 'govuk-form-group--error': errorMessage })} {...attributes}>
-      <FieldsetWrapper {...fieldset}>
+      <FieldsetWrapper describedBy={computedDescribedBy} {...fieldset}>
         {prefix}
         {labelWithId}
         {hintWithId}
         {errorMessageWithId}
         {typeof children === 'function'
-          ? children({ formGroupDescribeBy: describeByElements.join(' ') })
+          ? children({ formGroupDescribedBy: computedDescribedBy })
           : children}
         {suffix}
       </FieldsetWrapper>

--- a/src/govuk/Input.jsx
+++ b/src/govuk/Input.jsx
@@ -6,13 +6,13 @@ const Input = ({
   id, type = 'text', className, defaultValue, label, hint, errorMessage, formGroup = {}, describedBy, ...attributes
 }) => (
   <FormGroup inputId={id} hint={hint} label={label} errorMessage={errorMessage} describedBy={describedBy} {...formGroup}>
-    {({ describeBy }) => (
+    {({ formGroupDescribedBy }) => (
       <input
         className={classNames(className, 'govuk-input', { 'govuk-input--error': errorMessage })}
         id={id}
         type={type}
         defaultValue={defaultValue}
-        aria-describedby={describeBy}
+        aria-describedby={formGroupDescribedBy}
         {...attributes}
       />
     )}

--- a/src/govuk/Radios.jsx
+++ b/src/govuk/Radios.jsx
@@ -18,13 +18,13 @@ const Radios = ({
 
   return (
     <FormGroup inputId={id} hint={hint} fieldset={{ legend, ...fieldset }} errorMessage={errorMessage} describedBy={describedBy} {...formGroup}>
-      {({ formGroupDescribeBy }) => (
+      {({ formGroupDescribedBy }) => (
         <div
           className={classNames('govuk-radios', className, {
             'govuk-radios--conditional': isConditional,
             'govuk-radios--inline': inline,
           })}
-          aria-describedby={formGroupDescribeBy}
+          aria-describedby={formGroupDescribedBy}
         >
           {items.map((item, index) => {
             const idSuffix = `-${index + 1}`;

--- a/src/govuk/Select.jsx
+++ b/src/govuk/Select.jsx
@@ -14,12 +14,12 @@ const Select = ({
   describedBy, emptyOption = ' ', options, ...attributes
 }) => (
   <FormGroup inputId={id} hint={hint} label={label} errorMessage={errorMessage} describedBy={describedBy} {...formGroup}>
-    {({ formGroupDescribeBy }) => (
+    {({ formGroupDescribedBy }) => (
       <select
         id={id}
         className={classNames(className, 'govuk-select', { 'govuk-select--error': errorMessage })}
         defaultValue={defaultValue}
-        aria-describedby={formGroupDescribeBy}
+        aria-describedby={formGroupDescribedBy}
         {...attributes}
       >
         {emptyOption && (

--- a/src/govuk/__tests__/DateInput.test.jsx
+++ b/src/govuk/__tests__/DateInput.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DateInput from '../DateInput';
+
+test('renders all date inputs', () => {
+  render(<DateInput hint="Test hint" legend="Test legend" errorMessage="Test error" id="testId" />);
+  expect(screen.getByText('Test legend')).toBeInTheDocument();
+  expect(screen.getByText('Test hint')).toBeInTheDocument();
+  expect(screen.getByText('Test error')).toBeInTheDocument();
+  expect(screen.getByLabelText('Day')).toBeInTheDocument();
+  expect(screen.getByLabelText('Month')).toBeInTheDocument();
+  expect(screen.getByLabelText('Year')).toBeInTheDocument();
+});
+
+test('renders date inputs without a day', () => {
+  render(<DateInput dayInput={null} id="testId" />);
+  expect(screen.queryByLabelText('Day')).toBeNull();
+  expect(screen.getByLabelText('Month')).toBeInTheDocument();
+  expect(screen.getByLabelText('Year')).toBeInTheDocument();
+});

--- a/src/routes/IssueTargetPage.jsx
+++ b/src/routes/IssueTargetPage.jsx
@@ -15,6 +15,7 @@ import FieldRadios from '../forms/FieldRadios';
 import FieldAddress from '../forms/FieldAddress';
 import FieldAutocomplete from '../forms/FieldAutocomplete';
 import Details from '../govuk/Details';
+import FieldDate from '../forms/FieldDate';
 
 const IssueTargetPage = () => {
   const history = useHistory();
@@ -47,6 +48,8 @@ const IssueTargetPage = () => {
 
           <FormStep name="one">
             <h2 className="govuk-heading-m">General Target Information</h2>
+
+            <FieldDate required="Enter example date" name="exampleDate" legend="Example date" />
 
             <FieldAddress name="testAddress" />
 


### PR DESCRIPTION
## Description

Add Date input component compatible with GOV.UK Design System.

## To Test
1. Open the `Issue a target form`
2. You should see a date field
3. Entering an invalid or empty date should show an error

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
