### PR TITLE
COP-5461: Add tests for task management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run lint -- <directory>
 ```
 ### Running UI tests (cypress tests)
 There are two ways to run cypress tests, using the cypress test runner or running cypress tests using the command line.
-(You will need Cerberus-service FE service running before triggering Cypress)
+(You will need the cerberus-service application running before triggering the Cypress tests)
 By default tests run against local environment.
 
 #### Running Cypress Test Runner

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -5,7 +5,7 @@ describe('Verify Task Management Page', () => {
     });
   });
 
-  it('Should check all the tabs on task management page', () => {
+  it('Should render all the tabs on task management page', () => {
     const taskNavigationItems = [
       'New',
       'In progress',

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -1,0 +1,46 @@
+describe('Verify Task Management Page', () => {
+  beforeEach(() => {
+    cy.fixture('users/cypressuser@lodev.xyz.json').then((user) => {
+      cy.login(user.username);
+    });
+  });
+
+  it('Should check all the tabs on task management page', () => {
+    const taskNavigationItems = [
+      'New',
+      'In progress',
+      'Paused',
+      'Complete',
+    ];
+    const urls = [
+      'new',
+      'in-progress',
+      'paused',
+      'complete',
+    ];
+
+    cy.navigation('Tasks');
+
+    cy.get('.govuk-tabs__list li a').each((navigationItem, index) => {
+      cy.wrap(navigationItem).click()
+        .should('contain.text', taskNavigationItems[index]).and('be.visible')
+        .and('have.attr', 'aria-selected', 'true');
+      cy.url().should('include', urls[index]);
+    });
+  });
+
+  it('Should check task details page', () => {
+    cy.navigation('Tasks');
+
+    cy.navigation('New');
+
+    cy.clickOnTask('20201101-141');
+
+    cy.url('include', '/COP-20201101-141');
+  });
+
+  after(() => {
+    cy.contains('Sign out').click();
+    cy.get('#kc-page-title').should('contain.text', 'Log In');
+  });
+});

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -34,9 +34,9 @@ describe('Verify Task Management Page', () => {
 
     cy.navigation('New');
 
-    cy.clickOnTask('20201101-141');
+    cy.contains('2021-58914').click();
 
-    cy.url('include', '/COP-20201101-141');
+    cy.url('include', '/COP-20201101-140');
   });
 
   after(() => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,4 @@
+module.exports = function () {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,7 +9,3 @@ Cypress.Commands.add('login', (userName) => {
 Cypress.Commands.add('navigation', (option) => {
   cy.contains('a', option).click();
 });
-
-Cypress.Commands.add('clickOnTask', (option) => {
-  cy.get(`a[href="/tasks/COP-${option}"]`).click();
-});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -5,3 +5,11 @@ Cypress.Commands.add('login', (userName) => {
   cy.kcLogin(userName).as('tokens');
   cy.visit('/');
 });
+
+Cypress.Commands.add('navigation', (option) => {
+  cy.contains('a', option).click();
+});
+
+Cypress.Commands.add('clickOnTask', (option) => {
+  cy.get(`a[href="/tasks/COP-${option}"]`).click();
+});


### PR DESCRIPTION
## Description
This PR has tests for verifying task management page. It checks all the available tabs & navigating to different page.

## To Test
npm run cypress:runner 
choose the spec to run

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
