### PR TITLE
COP-5754: Add tests for Refresh tasklist page

### DIFF
--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -2,7 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 describe('Verify Task Management Page', () => {
-  const MAX_TASK_PER_PAGE = 3;
+  const MAX_TASK_PER_PAGE = 10;
 
   beforeEach(() => {
     cy.fixture('users/cypressuser@lodev.xyz.json').then((user) => {
@@ -33,11 +33,17 @@ describe('Verify Task Management Page', () => {
   });
 
   it('Should navigate to task details page', () => {
+    cy.intercept('POST', '/camunda/variable-instance?*').as('tasks');
+
     cy.navigation('Tasks');
 
-    cy.get('.task-heading a.task-view').eq(0).invoke('text').then((text) => {
+    cy.wait('@tasks').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    cy.get('.task-heading a').eq(0).invoke('text').then((text) => {
       cy.contains(text).click();
-      cy.url().should('include', text);
+      cy.get('.govuk-caption-xl').should('have.text', text);
     });
   });
 
@@ -49,7 +55,7 @@ describe('Verify Task Management Page', () => {
       expect(texts).not.to.contain(['First', 'Previous']);
     });
 
-    cy.get('.pagination--summary').should('contain.text', 'Showing 1 - 3');
+    cy.get('.pagination--summary').should('contain.text', `Showing 1 - ${MAX_TASK_PER_PAGE}`);
   });
 
   it('Should hide last and next buttons on last page', () => {

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -74,6 +74,33 @@ describe('Verify Task Management Page', () => {
     });
   });
 
+  it('Should verify refresh task list page', () => {
+    cy.clock();
+    cy.intercept('POST', '/camunda/variable-instance?*').as('tasks');
+
+    cy.navigation('Tasks');
+
+    cy.wait('@tasks').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    cy.tick(60000);
+
+    cy.wait('@tasks').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    cy.get('.pagination--list a').eq(1).click();
+
+    cy.tick(60000);
+
+    cy.wait('@tasks').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    cy.url().should('contain', 'page=2');
+  });
+
   after(() => {
     cy.contains('Sign out').click();
     cy.get('#kc-page-title').should('contain.text', 'Log In');


### PR DESCRIPTION
## Description
This PR has tests for following scenarios,
1. Tasks refresh at 60 seconds
go to /tasks
after 60 seconds the list should refresh
after another 60 seconds the list should refresh again
(this can be seen in the network tab if there are no new tasks coming in)
2. User is kept on the page they are on

go to /tasks
go to page 2
after 60 seconds the list should refresh and user should still be on page 2 (url and pagination)
(this can be seen in the network tab if there are no new tasks coming in)

## To Test
npm run cypress:runner

run test it('Should verify refresh task list page') in task-management.spec.js


## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
