### PR TITLE
COP-5053: Add tests for task notes functionality

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,6 +74,8 @@ module.exports = {
         'cypress/no-unnecessary-waiting': 'off',
         'jest/valid-expect': 'off',
         'jest/valid-expect-in-promise': 'off',
+        'jest/no-standalone-expect': 'off',
+        'no-return-assign': 'off',
       },
     },
   ],

--- a/cypress.json
+++ b/cypress.json
@@ -6,8 +6,10 @@
     "auth_client_id":"formbuilder"
   },
   "defaultCommandTimeout": 10000,
-  "requestTimeout": 20000,
-  "responseTimeout": 20000,
+  "requestTimeout": 60000,
+  "responseTimeout": 60000,
+  "execTimeout": 120000,
+  "pageLoadTimeout": 600000,
   "chromeWebSecurity": false,
   "testFiles": "**/cerberus/*.js",
   "video": false,

--- a/cypress/config/dev.json
+++ b/cypress/config/dev.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "https://www.dev.cerberus.cop.homeoffice.gov.uk",
   "env": {
+    "keycloakUrl": "https://sso-dev.notprod.homeoffice.gov.uk",
     "envname": "development"
   }
 }

--- a/cypress/config/local.json
+++ b/cypress/config/local.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://localhost:8080",
   "env": {
+    "keycloakUrl": "https://sso-dev.notprod.homeoffice.gov.uk",
     "envname": "local"
   }
 }

--- a/cypress/integration/cerberus/login.spec.js
+++ b/cypress/integration/cerberus/login.spec.js
@@ -1,11 +1,11 @@
-describe('Sign-in to cerberus UI', () => {
+describe('Log-in to cerberus UI', () => {
   beforeEach(() => {
     cy.fixture('users/cypressuser@lodev.xyz.json').then((user) => {
       cy.login(user.username);
     });
   });
 
-  it('Should Sign-in Successfully', () => {
+  it('Should Log-in Successfully into cerberus UI', () => {
     cy.url().should('include', '/tasks');
 
     cy.get('.govuk-heading-xl').should('contain.text', 'Task management');

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -104,7 +104,8 @@ describe('Render tasks from Camunda and manage them on task management and detai
     cy.getUnassignedTasks().then((tasks) => {
       const taskId = tasks.map(((item) => item.id));
       expect(taskId.length).to.not.equal(0);
-      cy.window().then((win) => win.location.href = `/tasks/${taskId[0]}`);
+
+      cy.visit(`/tasks/${taskId[0]}`);
       cy.wait('@tasksDetails').then(({ response }) => {
         expect(response.statusCode).to.equal(200);
       });
@@ -112,14 +113,15 @@ describe('Render tasks from Camunda and manage them on task management and detai
 
     cy.get('.govuk-heading-xl').should('have.text', 'Task details');
 
-    cy.get('.link-button').focus().should('have.text', 'Claim').focused()
-      .click();
+    cy.wait(2000);
+
+    cy.get('button.link-button').should('be.visible').click();
 
     cy.get('.formio-component-note textarea')
       .should('be.visible')
       .type(taskNotes, { force: true });
 
-    cy.get('.formio-component-submit button').click();
+    cy.get('.formio-component-submit button').click('top');
 
     cy.wait('@notes').then(({ response }) => {
       expect(response.statusCode).to.equal(200);
@@ -128,6 +130,8 @@ describe('Render tasks from Camunda and manage them on task management and detai
         expect(message).to.equal(taskNotes);
       });
     });
+
+    cy.get('button.link-button').should('be.visible').click();
   });
 
   it('Should not show Notes for the tasks which is not assigned', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -5,9 +5,9 @@ let token;
 Cypress.Commands.add('login', (userName) => {
   cy.kcLogout();
   cy.kcLogin(userName).as('tokens');
+  cy.log(`${Cypress.env('keycloakUrl')}/auth/realms/cop-dev/protocol/openid-connect/token`);
+  cy.intercept('POST', `${Cypress.env('keycloakUrl')}/auth/realms/cop-dev/protocol/openid-connect/token`).as('token');
   cy.visit('/');
-
-  cy.intercept('POST', '/auth/realms/cop-dev/protocol/openid-connect/token').as('token');
 
   cy.wait('@token').then(({ response }) => {
     token = response.body.access_token;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,11 +1,73 @@
 import 'cypress-keycloak-commands';
 
+let token;
+
 Cypress.Commands.add('login', (userName) => {
   cy.kcLogout();
   cy.kcLogin(userName).as('tokens');
   cy.visit('/');
+
+  cy.intercept('POST', '/auth/realms/cop-dev/protocol/openid-connect/token').as('token');
+
+  cy.wait('@token').then(({ response }) => {
+    token = response.body.access_token;
+  });
 });
 
 Cypress.Commands.add('navigation', (option) => {
   cy.contains('a', option).click();
+});
+
+Cypress.Commands.add('waitForTaskManagementPage', () => {
+  cy.intercept('POST', '/camunda/variable-instance?*').as('tasks');
+  cy.navigation('Tasks');
+
+  cy.wait('@tasks').then(({ response }) => {
+    expect(response.statusCode).to.equal(200);
+  });
+});
+
+Cypress.Commands.add('getTaskNotes', (taskId) => {
+  const authorization = `bearer ${token}`;
+  const options = {
+    method: 'GET',
+    url: `https://cerberus-service.dev.cerberus.cop.homeoffice.gov.uk/camunda/engine-rest/task/${taskId}/comment`,
+    headers: {
+      authorization,
+    },
+  };
+
+  cy.request(options).then((response) => {
+    return response.body[0].message;
+  });
+});
+
+Cypress.Commands.add('getUnassignedTasks', () => {
+  const authorization = `bearer ${token}`;
+  const options = {
+    method: 'GET',
+    url: '/camunda/task?firstResult=0&maxResults=20',
+    headers: {
+      authorization,
+    },
+  };
+
+  cy.request(options).then((response) => {
+    return response.body.filter((item) => item.assignee === null);
+  });
+});
+
+Cypress.Commands.add('getAssignedTasks', () => {
+  const authorization = `bearer ${token}`;
+  const options = {
+    method: 'GET',
+    url: '/camunda/task?firstResult=0&maxResults=20',
+    headers: {
+      authorization,
+    },
+  };
+
+  cy.request(options).then((response) => {
+    return response.body.filter((item) => item.assignee !== 'cypressuser@lodev.xyz');
+  });
 });


### PR DESCRIPTION
## Description
Added tests for tasks notes functionality and it would cover the following scenarios,
Scenario 1: Assignee action
GIVEN I am assigned to a task
WHEN I view the task
THEN I am able to enter notes against the task and save them

Scenario 1: Non-assignee action
GIVEN I am NOT assigned to a task
WHEN I view the task
THEN I am NOT able to enter notes against the task

## To Test
npm run cypress:runner
select task-management.spec.js and run the tests

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
