### PR TITLE
COP-6243 Migrate formio-gds-template from digital patterns to homeoffice package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,15 +1213,6 @@
         }
       }
     },
-    "@digitalpatterns/formio-gds-template": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@digitalpatterns/formio-gds-template/-/formio-gds-template-1.6.1.tgz",
-      "integrity": "sha512-+rcSORnFrTiNV3otkuauLe8AJsTr69/x2A+DdcVHXSvo0qiTjJWojxzK/FfbiRVqjW+Y/IRhJsh+WfOmlyXnxA==",
-      "requires": {
-        "govuk-frontend": "^3.6.0",
-        "lodash": "^4.17.15"
-      }
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -2511,6 +2502,14 @@
           "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
           "dev": true
         }
+      }
+    },
+    "@ukhomeoffice/formio-gds-template": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/formio-gds-template/-/formio-gds-template-1.0.6.tgz",
+      "integrity": "sha512-nllLQMo6jWsnkbcTMIZ4P9Bjkbq48t0G6n4ENi3ppwtclCpPq+qyZuouRBjYL/R/XRycPRJqIrmhNncIFs4e2A==",
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
   },
   "homepage": "https://github.com/UKHomeOffice/cerberus-service#readme",
   "dependencies": {
-    "@digitalpatterns/formio-gds-template": "^1.6.1",
+    "@ukhomeoffice/formio-gds-template": "^1.0.6",
     "axios": "^0.21.1",
     "classnames": "^2.2.6",
     "formiojs": "^4.12.7",
+    "fs-extra": "^9.0.1",
     "govuk-frontend": "^3.10.2",
     "jwt-decode": "^3.1.2",
     "keycloak-js": "^12.0.1",
@@ -40,8 +41,7 @@
     "react-formio": "^4.3.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^4.0.2",
-    "react-use": "^15.3.8",
-    "fs-extra": "^9.0.1"
+    "react-use": "^15.3.8"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/src/routes/IssueTargetPage.jsx
+++ b/src/routes/IssueTargetPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { Formio, Form } from 'react-formio';
-import gds from '@digitalpatterns/formio-gds-template/lib';
+import gds from '@ukhomeoffice/formio-gds-template/lib';
 import { isEmpty } from 'lodash';
 
 import config from '../config';

--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -5,7 +5,7 @@ import * as pluralise from 'pluralise';
 import axios from 'axios';
 import { get } from 'lodash';
 import { Formio, Form } from 'react-formio';
-import gds from '@digitalpatterns/formio-gds-template/lib';
+import gds from '@ukhomeoffice/formio-gds-template/lib';
 
 import config from '../config';
 import { LONG_DATE_FORMAT } from '../constants';


### PR DESCRIPTION
## Description
This PR removes the existing `@digitalpatterns/formio-gds-template` package and replaces it with the `@ukhomeoffice/formio-gds-template` package
## To Test
- Pull and run natively
- Open the `Issue a target` form
- *You should see the form render as before the changed package*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
