### PR TITLE
COP-6242 Implement refresh token functionality

### DIFF
--- a/src/utils/keycloak.jsx
+++ b/src/utils/keycloak.jsx
@@ -26,6 +26,11 @@ const KeycloakProvider = ({ children }) => {
     keycloakInstance.init(config.keycloak.initOptions).then((authenticated) => {
       if (authenticated) {
         setKeycloak(keycloakInstance);
+        /*
+         * Multiplies the unix timestamp (keycloackInstance.tokenParsed.exp) in the token by 1000 milliseconds
+         * e.g: new Date(795601416 * 1000) and subtract it from the current date
+         * timeToExpire then equals the difference between the 2 dates in milliseconds
+        */
         setTimeToExpire(new Date(keycloakInstance.tokenParsed.exp * 1000) - new Date());
       } else {
         keycloakInstance.login();

--- a/src/utils/keycloak.jsx
+++ b/src/utils/keycloak.jsx
@@ -2,6 +2,7 @@ import React, {
   createContext, useState, useContext, useEffect,
 } from 'react';
 import Keycloak from 'keycloak-js';
+import { useInterval } from 'react-use';
 
 import config from '../config';
 
@@ -9,13 +10,23 @@ const KeycloakContext = createContext();
 
 const KeycloakProvider = ({ children }) => {
   const [keycloak, setKeycloak] = useState(null);
+  const [timeToExpire, setTimeToExpire] = useState(null);
 
   const keycloakInstance = Keycloak(config.keycloak.clientConfig);
+
+  useInterval(() => {
+    keycloak
+      .updateToken()
+      .catch(() => {
+        keycloak.logout();
+      });
+  }, keycloak ? timeToExpire : null);
 
   useEffect(() => {
     keycloakInstance.init(config.keycloak.initOptions).then((authenticated) => {
       if (authenticated) {
         setKeycloak(keycloakInstance);
+        setTimeToExpire(new Date(keycloakInstance.tokenParsed.exp * 1000) - new Date());
       } else {
         keycloakInstance.login();
       }


### PR DESCRIPTION
## Description
When the keycloak token expires, a request is made to see if the access token can be updated. If not, the user is logged out. The recommended implementation of token refreshing is to use `onTokenExpired` as detailed in the `keycloak` documentation however, this led to inconsistencies as to when the token was identified as expired. 
## To Test
- (Have dev tools open pre-emptively for testing)
- Pull and run cerberus natively
- Navigate to network tab in dev tools
- *You should see a `token` request made*
- Wait for as long as the access token is valid
- *You should see another `token` request made at the end of the access token's life span*
- Leave cerberus open for as long as the `refreshToken` is valid plus or minus the access token's life span
- *You should be logged out*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
