### PR TITLE
COP-5080 Add click functionality for issue target button

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -13,10 +13,11 @@ import ErrorSummary from '../govuk/ErrorSummary';
 
 Formio.use(gds);
 
-const RenderForm = ({ formName, onSubmit, onCancel, children, alterForm = () => {} }) => {
+const RenderForm = ({ formName, onSubmit, onCancel, preFillData, children, alterForm = () => {} }) => {
   const [error, setError] = useState(null);
   const [form, setForm] = useState({});
   const [isLoaderVisible, setLoaderVisibility] = useState(true);
+  const [formattedPreFillData, setPreFillData] = useState();
   const [submitted, setSubmitted] = useState(false);
   const keycloak = useKeycloak();
   const formApiClient = useAxiosInstance(keycloak, config.formApiUrl);
@@ -40,7 +41,18 @@ const RenderForm = ({ formName, onSubmit, onCancel, children, alterForm = () => 
       }
     };
 
+    const formatPreFillData = () => {
+      if (!preFillData) {
+        setPreFillData(null);
+      } else {
+        let element = {};
+        element.data = { ...preFillData };
+        setPreFillData(element);
+      }
+    };
+
     loadForm();
+    formatPreFillData();
     return () => {
       source.cancel('Cancelling request');
     };
@@ -64,6 +76,7 @@ const RenderForm = ({ formName, onSubmit, onCancel, children, alterForm = () => 
         {!isEmpty(form) && (
           <Form
             form={form}
+            submission={formattedPreFillData}
             onSubmit={async (data) => {
               setLoaderVisibility(true);
               try {

--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -112,6 +112,13 @@ const RenderForm = ({ formName, onSubmit, onCancel, preFillData, children }) => 
                 setLoaderVisibility(false);
               }
             }}
+            onNextPage={() => {
+              window.scrollTo(0, 0);
+            }}
+            onPrevPage={() => {
+              window.scrollTo(0, 0);
+              setError(null);
+            }}
             options={{
               noAlerts: true,
               hooks: {

--- a/src/routes/IssueTargetPage.jsx
+++ b/src/routes/IssueTargetPage.jsx
@@ -1,41 +1,15 @@
 import React from 'react';
-import { isEmpty } from 'lodash';
 
-import config from '../config';
-import { useKeycloak } from '../utils/keycloak';
-import { interpolate, useFormSubmit } from '../utils/formioSupport';
+import { useFormSubmit } from '../utils/formioSupport';
 import RenderForm from '../components/RenderForm';
 import Panel from '../govuk/Panel';
 
 const IssueTargetPage = () => {
   const submitForm = useFormSubmit();
-  const keycloak = useKeycloak();
 
   return (
     <RenderForm
       formName="targetInformationSheet"
-      alterForm={(form) => {
-        if (!isEmpty(form)) {
-          interpolate(form, {
-            keycloakContext: {
-              accessToken: keycloak.token,
-              refreshToken: keycloak.refreshToken,
-              sessionId: keycloak.tokenParsed.session_state,
-              email: keycloak.tokenParsed.email,
-              givenName: keycloak.tokenParsed.given_name,
-              familyName: keycloak.tokenParsed.family_name,
-              subject: keycloak.subject,
-              url: keycloak.authServerUrl,
-              realm: keycloak.realm,
-              roles: keycloak.tokenParsed.realm_access.roles,
-              groups: keycloak.tokenParsed.groups,
-            },
-            environmentContext: {
-              referenceDataUrl: config.refdataApiUrl,
-            },
-          });
-        }
-      }}
       onSubmit={async (data, form) => {
         await submitForm(
           'assignTarget',

--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -534,19 +534,31 @@ const TaskDetailsPage = () => {
                 <>
                   <Button
                     className="govuk-!-margin-right-1"
-                    onClick={() => setIssueTargetFormOpen(true)}
+                    onClick={() => {
+                      setIssueTargetFormOpen(true);
+                      setCompleteFormOpen(false);
+                      setDismissFormOpen(false);
+                    }}
                   >
                     Issue target
                   </Button>
                   <Button
                     className="govuk-button--secondary govuk-!-margin-right-1"
-                    onClick={() => setCompleteFormOpen(true)}
+                    onClick={() => {
+                      setIssueTargetFormOpen(false);
+                      setCompleteFormOpen(true);
+                      setDismissFormOpen(false);
+                    }}
                   >
                     Assessment complete
                   </Button>
                   <Button
                     className="govuk-button--warning"
-                    onClick={() => setDismissFormOpen(true)}
+                    onClick={() => {
+                      setIssueTargetFormOpen(false);
+                      setCompleteFormOpen(false);
+                      setDismissFormOpen(true);
+                    }}
                   >
                     Dismiss
                   </Button>

--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import moment from 'moment';
 import * as pluralise from 'pluralise';
 import axios from 'axios';
@@ -388,18 +388,6 @@ const TaskManagementForm = ({ camundaClient, onCancel, taskId, taskData, keycloa
   />
 );
 
-const TaskCompletedSuccessMessage = ({ message }) => (
-  <>
-    <Panel title={message} />
-    <p className="govuk-body">We have sent your request to the relevant team.</p>
-    <h2 className="govuk-heading-m">What happens next</h2>
-    <p className="govuk-body">The task is now paused pending a response.</p>
-    <Link to="/tasks" className="govuk-button" data-module="govuk-button">
-      Finish
-    </Link>
-  </>
-);
-
 const NotesForm = ({ camundaClient, taskId }) => (
   <>
     <h2 className="govuk-heading-m">Notes</h2>
@@ -429,6 +417,27 @@ const TaskDetailsPage = () => {
   const [isDismissFormOpen, setDismissFormOpen] = useState();
   const [isIssueTargetFormOpen, setIssueTargetFormOpen] = useState();
   const source = axios.CancelToken.source();
+
+  const TaskCompletedSuccessMessage = ({ message }) => {
+    return (
+      <>
+        <Panel title={message} />
+        <p className="govuk-body">We have sent your request to the relevant team.</p>
+        <h2 className="govuk-heading-m">What happens next</h2>
+        <p className="govuk-body">The task is now paused pending a response.</p>
+        <Button
+          className="govuk-button"
+          onClick={() => {
+            setIssueTargetFormOpen(false);
+            setCompleteFormOpen(false);
+            setDismissFormOpen(false);
+          }}
+        >
+          Finish
+        </Button>
+      </>
+    );
+  };
 
   useEffect(() => {
     const loadTask = async () => {

--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -424,8 +424,9 @@ const TaskDetailsPage = () => {
   const currentUser = keycloak.tokenParsed.email;
   const assignee = taskVersions?.[0]?.assignee;
   const currentUserIsOwner = assignee === currentUser;
-  const [isDismissFormOpen, setDismissFormOpen] = useState();
   const [isCompleteFormOpen, setCompleteFormOpen] = useState();
+  const [isDismissFormOpen, setDismissFormOpen] = useState();
+  const [isIssueTargetFormOpen, setIssueTargetFormOpen] = useState();
   const source = axios.CancelToken.source();
 
   useEffect(() => {
@@ -528,9 +529,14 @@ const TaskDetailsPage = () => {
             </div>
 
             <div className="govuk-grid-column-one-half task-actions--buttons">
-              <Button className="govuk-!-margin-right-1">Issue target</Button>
               {currentUserIsOwner && (
                 <>
+                  <Button
+                    className="govuk-!-margin-right-1"
+                    onClick={() => setIssueTargetFormOpen(true)}
+                  >
+                    Issue target
+                  </Button>
                   <Button
                     className="govuk-button--secondary govuk-!-margin-right-1"
                     onClick={() => setCompleteFormOpen(true)}
@@ -550,17 +556,6 @@ const TaskDetailsPage = () => {
 
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-two-thirds">
-              {isDismissFormOpen && (
-                <TaskManagementForm
-                  formName="dismissTarget"
-                  camundaClient={camundaClient}
-                  onCancel={() => setDismissFormOpen(false)}
-                  taskId={taskVersions[0].id}
-                  keycloak={keycloak}
-                >
-                  <TaskCompletedSuccessMessage message="Task has been dismissed" />
-                </TaskManagementForm>
-              )}
               {isCompleteFormOpen && (
                 <TaskManagementForm
                   formName="assessmentComplete"
@@ -572,7 +567,32 @@ const TaskDetailsPage = () => {
                   <TaskCompletedSuccessMessage message="Task has been completed" />
                 </TaskManagementForm>
               )}
-              {!isDismissFormOpen && !isCompleteFormOpen && (
+              {isDismissFormOpen && (
+                <TaskManagementForm
+                  formName="dismissTarget"
+                  camundaClient={camundaClient}
+                  onCancel={() => setDismissFormOpen(false)}
+                  taskId={taskVersions[0].id}
+                  keycloak={keycloak}
+                >
+                  <TaskCompletedSuccessMessage message="Task has been dismissed" />
+                </TaskManagementForm>
+              )}
+              {isIssueTargetFormOpen && (
+                <>
+                  <h2 className="govuk-heading-m">Check the details before issuing target</h2>
+                  <TaskManagementForm
+                    formName="targetInformationSheet"
+                    camundaClient={camundaClient}
+                    onCancel={() => setIssueTargetFormOpen(false)}
+                    taskId={taskVersions[0].id}
+                    keycloak={keycloak}
+                  >
+                    <TaskCompletedSuccessMessage message="Target created successfully" />
+                  </TaskManagementForm>
+                </>
+              )}
+              {!isCompleteFormOpen && !isDismissFormOpen && !isIssueTargetFormOpen && (
                 <TaskVersions taskVersions={taskVersions} />
               )}
             </div>

--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -474,7 +474,7 @@ const TaskDetailsPage = () => {
           ...parsedTaskHistory,
         ].sort((a, b) => -a.date.localeCompare(b.date)));
 
-        const whitelistedCamundaVars = ['taskSummary', 'vehicleHistory', 'orgHistory', 'ruleHistory'];
+        const whitelistedCamundaVars = ['taskSummary', 'vehicleHistory', 'orgHistory', 'ruleHistory', 'targetInformationSheet'];
         const parsedTaskVariables = variableInstanceResponse.data
           .filter((t) => whitelistedCamundaVars.includes(t.name))
           .reduce((acc, camundaVar) => {
@@ -606,7 +606,7 @@ const TaskDetailsPage = () => {
                     onCancel={() => setIssueTargetFormOpen(false)}
                     taskId={taskVersions[0].id}
                     keycloak={keycloak}
-                    taskData={taskVersions[0].taskSummary}
+                    taskData={taskVersions[0].targetInformationSheet}
                   >
                     <TaskCompletedSuccessMessage message="Target created successfully" />
                   </TaskManagementForm>

--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -358,9 +358,10 @@ const TaskVersions = ({ taskVersions }) => (
   />
 );
 
-const TaskManagementForm = ({ camundaClient, onCancel, taskId, keycloak, ...props }) => (
+const TaskManagementForm = ({ camundaClient, onCancel, taskId, taskData, keycloak, ...props }) => (
   <RenderForm
     onCancel={() => onCancel(false)}
+    preFillData={taskData}
     onSubmit={async (data, form) => {
       const { versionId, id, title, name } = form;
       await camundaClient.post(`/task/${taskId}/submit-form`, {
@@ -580,13 +581,20 @@ const TaskDetailsPage = () => {
               )}
               {isIssueTargetFormOpen && (
                 <>
-                  <h2 className="govuk-heading-m">Check the details before issuing target</h2>
+                  <div className="govuk-warning-text">
+                    <span className="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong className="govuk-warning-text__text">
+                      <span className="govuk-warning-text__assistive">Warning</span>
+                      Check the details before issuing target
+                    </strong>
+                  </div>
                   <TaskManagementForm
                     formName="targetInformationSheet"
                     camundaClient={camundaClient}
                     onCancel={() => setIssueTargetFormOpen(false)}
                     taskId={taskVersions[0].id}
                     keycloak={keycloak}
+                    taskData={taskVersions[0].taskSummary}
                   >
                     <TaskCompletedSuccessMessage message="Target created successfully" />
                   </TaskManagementForm>

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TaskDetailsPage from '../TaskDetailsPage';
+
+// mock useParams
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn().mockReturnValue({ taskId: 'taskId' }),
+}));
+
+describe('TaskDetailsPage', () => {
+  const mockAxios = new MockAdapter(axios);
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAxios.reset();
+  });
+
+  it('should render TaskDetailsPage component with a loading state', () => {
+    render(<TaskDetailsPage />);
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+  });
+
+  it('should render Issue Target button when current user is assigned user, and open issue target form on click', async () => {
+    mockAxios
+      .onGet('/task/taskId')
+      .reply(200, {
+        processInstanceId: '123',
+        assignee: 'test',
+        id: 'task123',
+      })
+      .onGet('/variable-instance', { params: { processInstanceIdIn: '123', deserializeValues: false } })
+      .reply(200,
+        [{
+          value: '{"mode":"RoRo accompanied freight","businessKey":"CERB-123543","movementStatus":"Pre-Arrival","movementId":"ROROTSV:S=Test Message 1686","matchedSelectors":[{"threatType":"National Security at the Border","priority":"Tier 2"}],"departureTime":1596459900000,"arrivalTime":1596548700000,"people":[{"gender":"M","fullName":"Bob Brown","dateOfBirth":435,"role":"DRIVER"}],"vehicles":[{"registrationNumber":"GB09KLT","description":null},{"registrationNumber":"GB09KLT","description":null}],"trailers":[{"registrationNumber":"NL-234-392","description":null}],"organisations":[{"name":null,"type":"ORGBOOKER"},{"name":"Uni Print","type":"ORGACCOUNT"},{"name":"Matthesons","type":"ORGHAULIER"}],"freight":{"hazardousCargo":"false","descriptionOfCargo":"Printed Paper"},"bookingDateTime":"2020-08-02T09:15:00","aggregateVehicleTrips":null,"aggregateTrailerTrips":null,"voyage":{"departFrom":"DOV","arriveAt":"CAL","description":"DFDS voyage of DOVER SEAWAYS"}}',
+          id: '04ed2b9c-7b64-11eb-877e-767b03e5e1af',
+          name: 'taskSummary',
+        }])
+      .onGet('/history/user-operation', { params: { processInstanceId: '123', deserializeValues: false } })
+      .reply(200,
+        [{
+          operationType: 'Claim',
+          property: 'assignee',
+          orgValue: null,
+          timestamp: '2021-04-06T15:30:42.420+0000',
+          userId: 'testuser@email.com',
+        }])
+      .onGet('/history/task', { params: { processInstanceId: '123', deserializeValues: false } })
+      .reply(200,
+        [{
+          assignee: 'testuser@email.com',
+          startTime: '2021-04-20T10:50:25.869+0000',
+          name: 'Investigate Error',
+        }])
+      .onGet('/form/name/noteCerberus')
+      .reply(200,
+        { test });
+
+    render(<TaskDetailsPage />);
+    await waitFor(() => expect(screen.getByText(/Task details/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Assigned to you/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Issue target/i)).toBeTruthy());
+
+    // Click the button
+    const issueTargetButton = screen.getByText(/Issue target/i);
+    fireEvent.click(issueTargetButton);
+    expect(screen.getByText(/Check the details before issuing target/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description

When `currentUser` is the same as task `assignedUser`
- show the `Issue target button`
- on button click open the `Target Information Sheet form` and prefill it with the task details that are available

## To Test

- create yourself a target task
- go to task list
- claim the task
- go to task details
- click on Issue target button
- > you should see the left hand panel be replaced with the Target Information Sheet form
- review the form
- > you should see some fields populated, based on what was in the task data
- > you will not see Mode or Port populated due to a bug in the data we receive from Camunda (Mark G working on this)
- submit the form (populate any required fields if needed)
- > you should see a success page
- click finish button
- > you should remain on task details page, and the main panel should show the task details again

## Notes

This differs from the prototype in the following ways
- there is no check your answers page, we don't have this feature yet
- there are breadcrumbs on the form, we have not looked into removing breadcrumbs from embedded forms yet
- the form is a 2 page wizard, as it is the same form as used for issuing a new target and that is a wizard

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
