### PR TITLE
Remove dev tests in drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -126,20 +126,6 @@ steps:
     event:
     - push
 
-- name: run_test_dev
-  pull: always
-  image: quay.io/ukhomeofficedigital/cop-cypress:6.3.0-node13
-  commands:
-    - export CYPRESS_CACHE_FOLDER=/home/node/.cache/Cypress
-    - npm ci
-    - npm run cypress:test:dev
-  when:
-    branch:
-      exclude:
-        - master
-    event:
-      - push
-
 - name: deploy_to_dev
   pull: if-not-exists
   image: quay.io/ukhomeofficedigital/kd


### PR DESCRIPTION
## Description
As a temporary measure, the tests that run against the dev environment as part of drone have been removed

NGINX seems to be bringing the Dev environment to its knees, which means that with every PR the drone build triggers the E2E tests on the Dev environment and since it might be down at the time of running the tests will fail.

With that said as a temporary measure, the E2E tests that run against the Dev environment as part of drone have been removed
from drone until the NGINX configurations gets sorted.

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
