### PR TITLE
Update NGINX to re-resolve the domain name upon expiry

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,12 +36,9 @@ http {
     }
 
     location /camunda/ {
+      # use google dns to resolve host after IP cached expires
+      resolver 8.8.8.8;
       proxy_pass REPLACE_CERBERUS_API_URL;
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
-      proxy_read_timeout 300;
-      proxy_no_cache 1;
-      proxy_cache_bypass 1;
     }
   }
 }


### PR DESCRIPTION
## Description

Currently on Dev environment, the NGINX will resolve the IP address once, and keep it cached for subsequent requests until the configuration is reloaded.

This commit tells NGINX to use a name server to re-resolve the domain once the cached entry expires.

## To Test

* go to https://www.dev.cerberus.cop.homeoffice.gov.uk/
* wait to see if you get a 503 or 504 error


## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
