### PR TITLE
COP-5769 Update notes component to show logs across task ID's and after task is completed

### DIFF
--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -522,7 +522,7 @@ const TaskDetailsPage = () => {
           ...parsedTaskVariables,
         }]);
       } catch (e) {
-        setError(e.response.status === 404 ? "Task doesn't exist." : e.message);
+        setError(e.response?.status === 404 ? "Task doesn't exist." : e.message);
         setTaskVersions([]);
       } finally {
         setLoading(false);

--- a/src/routes/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetailsPage.jsx
@@ -388,14 +388,32 @@ const TaskManagementForm = ({ camundaClient, onCancel, taskId, taskData, keycloa
   />
 );
 
-const NotesForm = ({ camundaClient, taskId }) => (
+const NotesForm = ({ camundaClient, businessKey, keycloak }) => (
   <>
     <h2 className="govuk-heading-m">Notes</h2>
     <RenderForm
       formName="noteCerberus"
-      onSubmit={async ({ data: { note } }) => {
-        await camundaClient.post(`/task/${taskId}/comment/create`, {
-          message: note,
+      onSubmit={async (data, form) => {
+        const { versionId, id, title, name } = form;
+        await camundaClient.post('/message', {
+          messageName: 'addNotes',
+          businessKey,
+          processVariables: {
+            note: {
+              value: JSON.stringify({
+                form: {
+                  formVersionId: versionId,
+                  formId: id,
+                  title,
+                  name,
+                  submissionDate: new Date(),
+                },
+                submittedBy: keycloak.tokenParsed.email,
+                ...data.data,
+              }),
+              type: 'Json',
+            },
+          },
         });
       }}
     />
@@ -460,6 +478,14 @@ const TaskDetailsPage = () => {
           ),
         ]);
 
+        const parsedNotes = JSON.parse(variableInstanceResponse.data.find((processVar) => {
+          return processVar.name === 'notes';
+        }).value).map((note) => ({
+          date: moment(note.timeStamp).format(),
+          user: note.userId,
+          note: note.note,
+        }));
+
         const parsedOperationsHistory = operationsHistoryResponse.data.map((operation) => {
           const getNote = () => {
             if ([OPERATION_TYPE_CLAIM, OPERATION_TYPE_ASSIGN].includes(operation.operationType)) {
@@ -481,6 +507,7 @@ const TaskDetailsPage = () => {
         setActivityLog([
           ...parsedOperationsHistory,
           ...parsedTaskHistory,
+          ...parsedNotes,
         ].sort((a, b) => -a.date.localeCompare(b.date)));
 
         const whitelistedCamundaVars = ['taskSummary', 'vehicleHistory', 'orgHistory', 'ruleHistory', 'targetInformationSheet'];
@@ -631,7 +658,8 @@ const TaskDetailsPage = () => {
                 <NotesForm
                   camundaClient={camundaClient}
                   setDismissFormOpen={setDismissFormOpen}
-                  taskId={taskVersions[0].id}
+                  businessKey={taskVersions[0].taskSummary?.businessKey}
+                  keycloak={keycloak}
                 />
               )}
 

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -13,7 +13,7 @@ jest.mock('react-router-dom', () => ({
 describe('TaskDetailsPage', () => {
   const mockAxios = new MockAdapter(axios);
   beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => { });
     mockAxios.reset();
   });
 
@@ -36,6 +36,10 @@ describe('TaskDetailsPage', () => {
           value: '{"mode":"RoRo accompanied freight","businessKey":"CERB-123543","movementStatus":"Pre-Arrival","movementId":"ROROTSV:S=Test Message 1686","matchedSelectors":[{"threatType":"National Security at the Border","priority":"Tier 2"}],"departureTime":1596459900000,"arrivalTime":1596548700000,"people":[{"gender":"M","fullName":"Bob Brown","dateOfBirth":435,"role":"DRIVER"}],"vehicles":[{"registrationNumber":"GB09KLT","description":null},{"registrationNumber":"GB09KLT","description":null}],"trailers":[{"registrationNumber":"NL-234-392","description":null}],"organisations":[{"name":null,"type":"ORGBOOKER"},{"name":"Uni Print","type":"ORGACCOUNT"},{"name":"Matthesons","type":"ORGHAULIER"}],"freight":{"hazardousCargo":"false","descriptionOfCargo":"Printed Paper"},"bookingDateTime":"2020-08-02T09:15:00","aggregateVehicleTrips":null,"aggregateTrailerTrips":null,"voyage":{"departFrom":"DOV","arriveAt":"CAL","description":"DFDS voyage of DOVER SEAWAYS"}}',
           id: '04ed2b9c-7b64-11eb-877e-767b03e5e1af',
           name: 'taskSummary',
+        },
+        {
+          value: '[{"note":"Target received","timeStamp":1619004165579,"userId":"Cerberus - Rules Based Targetting"}]',
+          name: 'notes',
         }])
       .onGet('/history/user-operation', { params: { processInstanceId: '123', deserializeValues: false } })
       .reply(200,


### PR DESCRIPTION
## Description
Change the notes component to use the non interrupting event sub-process so that activity logs can be shown across task Id's and after the task is completed (future story requirements).  
## To Test
Run Camunda-Cereberus locally and populate with RBT generated tasks via postman using branch COP-5769 (other PR)
Deploy raise-movement and assign-a-target
Run Cerberus-Service locally
Populate Camunda with an RBT generated task via postman to raise-movement
Open task details page
Submit a note
Refresh the page
See the note in date order following similar style to the rest

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
