### PR TITLE
Refactor variables

### DIFF
--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -38,6 +38,10 @@ describe('TaskDetailsPage', () => {
           name: 'taskSummary',
         },
         {
+          value: '{"mode":"RoRo accompanied freight","businessKey":"CERB-123543","movementStatus":"Pre-Arrival","movementId":"ROROTSV:S=Test Message 1686","matchedSelectors":[{"threatType":"National Security at the Border","priority":"Tier 2"}],"departureTime":1596459900000,"arrivalTime":1596548700000,"people":[{"gender":"M","fullName":"Bob Brown","dateOfBirth":435,"role":"DRIVER"}],"vehicles":[{"registrationNumber":"GB09KLT","description":null},{"registrationNumber":"GB09KLT","description":null}],"trailers":[{"registrationNumber":"NL-234-392","description":null}],"organisations":[{"name":null,"type":"ORGBOOKER"},{"name":"Uni Print","type":"ORGACCOUNT"},{"name":"Matthesons","type":"ORGHAULIER"}],"freight":{"hazardousCargo":"false","descriptionOfCargo":"Printed Paper"},"bookingDateTime":"2020-08-02T09:15:00","aggregateVehicleTrips":null,"aggregateTrailerTrips":null,"voyage":{"departFrom":"DOV","arriveAt":"CAL","description":"DFDS voyage of DOVER SEAWAYS"}}',
+          name: 'targetInformationSheet',
+        },
+        {
           value: '[{"note":"Target received","timeStamp":1619004165579,"userId":"Cerberus - Rules Based Targetting"}]',
           name: 'notes',
         }])


### PR DESCRIPTION
## Description
Tidying up code so that the `camundaClient` and `useKeycloak` var are created in the components in which they're used, rather than being attached to the props.

Added mocked test data for TargetInformationSheet

## To Test

- run Cerberus
- go to task details page
- check you can create a note (remember you must refresh to see it in activity list)
- check you can issue a target via the button
- check you can dismiss task
- check you can complete assessment on task

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
