### PR TITLE
COP-6287 Remove logo and make responsive

### DIFF
--- a/src/__assets__/index.scss
+++ b/src/__assets__/index.scss
@@ -6,3 +6,11 @@
 .govuk-width-container {
   max-width: 1280px;
 }
+
+@media (min-width: 48.0625em) {
+  .govuk-header__content {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useKeycloak } from '../utils/keycloak';
@@ -6,51 +6,46 @@ import NavigationItem from './NavigationItem';
 
 const Header = () => {
   const { createLogoutUrl } = useKeycloak();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const toggleMenu = (e) => {
+    e.preventDefault();
+    setMobileMenuOpen(!mobileMenuOpen);
+  };
 
   return (
     <header className="govuk-header" role="banner" data-module="govuk-header">
       <a href="#main-content" className="govuk-skip-link">Skip to main content</a>
 
       <div className="govuk-header__container govuk-width-container">
-        <div className="govuk-header__logo">
-          <Link to="/" className="govuk-header__link govuk-header__link--homepage">
-            <span className="govuk-header__logotype">
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                className="govuk-header__logotype-crown"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 132 97"
-                height="30"
-                width="36"
-              >
-                <path fill="currentColor" fillRule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z" />
-                <image src="/assets/images/govuk-logotype-crown.png" className="govuk-header__logotype-crown-fallback-image" width="36" height="32" />
-              </svg>
-              &nbsp;
-              <span className="govuk-header__logotype-text">
-                GOV.UK
-              </span>
-            </span>
-          </Link>
-        </div>
         <div className="govuk-header__content">
           <Link to="/" className="govuk-header__link govuk-header__link--service-name">
             Cerberus
+            <span style={{ display: 'block', fontSize: '0.55em' }}>powered by the Central Operations Platform</span>
           </Link>
-          <span style={{ fontSize: '10pt' }}> &nbsp; powered by the Central Operations Platform</span>
           <button
             type="button"
-            className="govuk-header__menu-button govuk-js-header-toggle"
+            className={
+                mobileMenuOpen
+                  ? 'govuk-header__menu-button govuk-js-header-toggle govuk-header__menu-button--open'
+                  : 'govuk-header__menu-button govuk-js-header-toggle'
+              }
             aria-controls="navigation"
             aria-label="Show or hide navigation menu"
+            onClick={(e) => {
+              toggleMenu(e);
+            }}
           >
             Menu
           </button>
           <nav>
             <ul
               id="navigation"
-              className="govuk-header__navigation "
+              className={
+                mobileMenuOpen
+                  ? 'govuk-header__navigation govuk-header__navigation--open'
+                  : 'govuk-header__navigation'
+              }
               aria-label="Navigation menu"
             >
               <NavigationItem href="/tasks">Tasks</NavigationItem>

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html lang='en' class='govuk-template'>
   <head>
     <meta charset='UTF-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Cerberus Service</title>
     <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
     <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">


### PR DESCRIPTION
## Description
- Internal products should not have the GovUK logo - removed that
- Updated header to match style on prototype with service name on left and nav on right
- Updated index and header to include mobile responsiveness and collapse nav into a menu button as per GDS guidelines

## To Test
- Check cerberus header against prototype
- Collapse page to mobile view
- nav should change to `menu` button
- click menu, nav should open and appear below the header

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
