### PR TITLE
COP-6431 Claim behaviour

### DIFF
--- a/jest.setup.jsx
+++ b/jest.setup.jsx
@@ -26,6 +26,9 @@ jest.mock('react-router-dom', () => ({
   useLocation: jest.fn(() => ({
     pathname: '/example',
   })),
+  useHistory: jest.fn(() => ({
+    pathname: '/example',
+  })),
   Link: ({ children, to, ...props }) => <a href={to} {...props}>{children}</a>,
 }));
 

--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import LinkButton from '../govuk/LinkButton';
 import useAxiosInstance from '../utils/axiosInstance';
 import config from '../config';
 import { useKeycloak } from '../utils/keycloak';
 
 const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, ...props }) => {
+  const history = useHistory();
   const [isAssignmentInProgress, setAssignmentProgress] = useState(false);
   const keycloak = useKeycloak();
   const camundaClient = useAxiosInstance(keycloak, config.camundaApiUrl);
@@ -24,7 +26,7 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, ...props }) =>
       await camundaClient.post(`task/${taskId}/claim`, {
         userId: currentUser,
       });
-      history.go(0);
+      history.push(`/tasks/${taskId}`);
     } catch (e) {
       setError(e.message);
       setAssignmentProgress(false);

--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -26,7 +26,11 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, ...props }) =>
       await camundaClient.post(`task/${taskId}/claim`, {
         userId: currentUser,
       });
-      history.push(`/tasks/${taskId}`);
+      if (history.location.pathname !== `/tasks/${taskId}`) {
+        history.push(`/tasks/${taskId}`);
+      } else {
+        history.go(0);
+      }
     } catch (e) {
       setError(e.message);
       setAssignmentProgress(false);

--- a/src/components/__tests__/ClaimTaskButton.test.jsx
+++ b/src/components/__tests__/ClaimTaskButton.test.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import axios from 'axios';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import ClaimButton from '../ClaimTaskButton';
+
+const setError = jest.fn();
+
+describe('Claim/Unclaim buttons', () => {
+  const mockAxios = new MockAdapter(axios);
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => { });
+    mockAxios.reset();
+  });
+
+  it('should render with text of claim when there is no assignee', async () => {
+    const task = {
+      assignee: null,
+      id: '123',
+    };
+    mockAxios.onPost(`task/${task.id}/claim`).reply(200);
+
+    render(<ClaimButton
+      className="govuk-!-font-weight-bold"
+      assignee={task.assignee}
+      taskId={task.id}
+      setError={setError}
+    />);
+
+    expect(screen.getByText(/Claim/i)).toBeInTheDocument();
+    const unclaimButton = screen.queryByText(/Unclaim/i);
+    expect(unclaimButton).not.toBeInTheDocument();
+  });
+
+  it('should post to the claim api for that task when user clicks claim', async () => {
+    const task = {
+      assignee: null,
+      id: '123',
+    };
+    mockAxios.onPost(`task/${task.id}/claim`).reply(200);
+
+    render(<ClaimButton
+      className="govuk-!-font-weight-bold"
+      assignee={task.assignee}
+      taskId={task.id}
+      setError={setError}
+    />);
+
+    await waitFor(() => { fireEvent.click(screen.getByText(/Claim/i)); });
+    expect(mockAxios.history.post[0].url).toEqual(`task/${task.id}/claim`);
+  });
+
+  it('should render with text of unclaim when the assignee matches the current user', () => {
+    const task = {
+      assignee: 'test',
+      id: '123',
+    };
+
+    render(<ClaimButton
+      className="govuk-!-font-weight-bold"
+      assignee={task.assignee}
+      taskId={task.id}
+      setError={setError}
+    />);
+
+    expect(screen.getByText(/Unclaim/i)).toBeInTheDocument();
+    const claimButton = screen.queryByText('Claim');
+    expect(claimButton).not.toBeInTheDocument();
+  });
+
+  it('should post to the unclaim api for that task when user clicks unclaim', async () => {
+    const task = {
+      assignee: 'test',
+      id: '123',
+    };
+    mockAxios.onPost(`task/${task.id}/unclaim`).reply(200);
+
+    render(<ClaimButton
+      className="govuk-!-font-weight-bold"
+      assignee={task.assignee}
+      taskId={task.id}
+      setError={setError}
+    />);
+
+    await waitFor(() => { fireEvent.click(screen.getByText(/Unclaim/i)); });
+    expect(mockAxios.history.post[0].url).toEqual(`task/${task.id}/unclaim`);
+  });
+});


### PR DESCRIPTION
## Description
redirect user to `TaskDetailsPage` when they click 'claim' from the `TaskListPage`

## To Test
Scenario One
- go to task list
- go to new tab
- click `claim`
- you should be taken to the TaskDetailsPage and see a task with an `unclaim` link
- go back to task list
- go to in progress tab
- find the task by it's businessKey (you might need to go to page 2+ to find it due to sort order)

Scenario Two
- go to task list
- go to new tab
- click on task title
- you should be taken to the TaskDetailsPage and see a task with a `claim` link
- click `claim`
- you should remain on TaskDetailsPage and it will refresh and the link changed to `unclaim`
- go back to task list
- go to in progress tab
- find the task by it's businessKey (you might need to go to page 2+ to find it due to sort order)

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
