### PR TITLE
COP-6567 Display task details page based on process instance not task id

### DIFF
--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -5,7 +5,7 @@ import useAxiosInstance from '../utils/axiosInstance';
 import config from '../config';
 import { useKeycloak } from '../utils/keycloak';
 
-const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, ...props }) => {
+const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, processInstanceId, ...props }) => {
   const history = useHistory();
   const [isAssignmentInProgress, setAssignmentProgress] = useState(false);
   const keycloak = useKeycloak();
@@ -26,8 +26,8 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, ...props }) =>
       await camundaClient.post(`task/${taskId}/claim`, {
         userId: currentUser,
       });
-      if (history.location.pathname !== `/tasks/${taskId}`) {
-        history.push(`/tasks/${taskId}`);
+      if (history.location.pathname !== `/tasks/${processInstanceId}`) {
+        history.push(`/tasks/${processInstanceId}`);
       } else {
         history.go(0);
       }

--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -62,7 +62,7 @@ const TaskNotesForm = ({ businessKey, processInstanceId, ...props }) => {
 };
 
 const TaskDetailsPage = () => {
-  const { taskId } = useParams();
+  const { processInstanceId } = useParams();
   const [error, setError] = useState(null);
   const [taskVersions, setTaskVersions] = useState([]);
   const [activityLog, setActivityLog] = useState([]);
@@ -101,12 +101,13 @@ const TaskDetailsPage = () => {
   useEffect(() => {
     const loadTask = async () => {
       try {
-        const taskResponse = await camundaClient.get(`/task/${taskId}`);
-        const processInstanceId = taskResponse.data.processInstanceId;
-
-        const [variableInstanceResponse, operationsHistoryResponse, taskHistoryResponse] = await Promise.all([
+        const [taskResponse, variableInstanceResponse, operationsHistoryResponse, taskHistoryResponse] = await Promise.all([
           camundaClient.get(
-            '/variable-instance',
+            '/task',
+            { params: { processInstanceId } },
+          ),
+          camundaClient.get(
+            '/history/variable-instance',
             { params: { processInstanceIdIn: processInstanceId, deserializeValues: false } },
           ),
           camundaClient.get(
@@ -158,7 +159,7 @@ const TaskDetailsPage = () => {
             return acc;
           }, {});
         setTaskVersions([{
-          ...taskResponse.data,
+          ...taskResponse.data[0],
           ...parsedTaskVariables,
         }]);
       } catch (e) {
@@ -188,6 +189,7 @@ const TaskDetailsPage = () => {
     }
     return `Assigned to ${assignee}`;
   };
+  const taskId = 'hello';
 
   return (
     <>

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -195,6 +195,7 @@ const TasksTab = ({ taskStatus, setError }) => {
                   assignee={target.assignee}
                   taskId={target.id}
                   setError={setError}
+                  processInstanceId={target.processInstanceId}
                 />
               </div>
             </div>

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -38,6 +38,7 @@ const TasksTab = ({ taskStatus, setError }) => {
   const keycloak = useKeycloak();
   const camundaClient = useAxiosInstance(keycloak, config.camundaApiUrl);
   const source = axios.CancelToken.source();
+  const isTargetTaskComplete = taskStatus === TASK_STATUS_COMPLETED;
 
   const camundaRequest = async (url, params = {}) => {
     return camundaClient.get(url, { params });
@@ -190,13 +191,15 @@ const TasksTab = ({ taskStatus, setError }) => {
                 </h4>
               </div>
               <div className="govuk-grid-column-one-quarter govuk-!-font-size-19">
-                <ClaimButton
-                  className="govuk-!-font-weight-bold"
-                  assignee={target.assignee}
-                  taskId={target.id}
-                  setError={setError}
-                  processInstanceId={target.processInstanceId}
-                />
+                {!isTargetTaskComplete && (
+                  <ClaimButton
+                    className="govuk-!-font-weight-bold"
+                    assignee={target.assignee}
+                    taskId={target.id}
+                    setError={setError}
+                    processInstanceId={target.processInstanceId}
+                  />
+                )}
               </div>
             </div>
             <div className="govuk-grid-row">

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -181,7 +181,7 @@ const TasksTab = ({ taskStatus, setError }) => {
                 <h3 className="govuk-heading-m task-heading">
                   <Link
                     className="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold"
-                    to={`/tasks/${target.id}`}
+                    to={`/tasks/${target.processInstanceId || target.id}`}
                   >{target.businessKey || target.id}
                   </Link>
                 </h3>

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -8,15 +8,54 @@ import taskDetailsVariableInstanceResponse from '../__fixtures__/taskDetailsVari
 // mock useParams
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn().mockReturnValue({ taskId: 'taskId' }),
+  useParams: jest.fn().mockReturnValue({ processInstanceId: '123' }),
 }));
 
 describe('TaskDetailsPage', () => {
   const mockAxios = new MockAdapter(axios);
+  let mockTaskDetailsAxiosResponses;
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => { });
     mockAxios.reset();
+    mockTaskDetailsAxiosResponses = {
+      taskResponse: [{
+        processInstanceId: '123',
+        assignee: 'test',
+        id: 'task123',
+      }],
+      variableInstanceResponse: taskDetailsVariableInstanceResponse,
+      operationsHistoryResponse: [{
+        operationType: 'Claim',
+        property: 'assignee',
+        orgValue: null,
+        timestamp: '2021-04-06T15:30:42.420+0000',
+        userId: 'testuser@email.com',
+      }],
+      taskHistoryResponse: [{
+        assignee: 'testuser@email.com',
+        startTime: '2021-04-20T10:50:25.869+0000',
+        name: 'Investigate Error',
+      }],
+      processInstanceResponse: [{ id: '123' }],
+      noteFormResponse: { test },
+    };
   });
+
+  const mockTaskDetailsAxiosCalls = ({ taskResponse, variableInstanceResponse, operationsHistoryResponse, taskHistoryResponse, processInstanceResponse, noteFormResponse }) => {
+    mockAxios
+      .onGet('/task', { params: { processInstanceId: '123' } })
+      .reply(200, taskResponse)
+      .onGet('/history/variable-instance', { params: { processInstanceIdIn: '123', deserializeValues: false } })
+      .reply(200, variableInstanceResponse)
+      .onGet('/history/user-operation', { params: { processInstanceId: '123', deserializeValues: false } })
+      .reply(200, operationsHistoryResponse)
+      .onGet('/history/task', { params: { processInstanceId: '123', deserializeValues: false } })
+      .reply(200, taskHistoryResponse)
+      .onGet('/process-instance', { params: { processInstanceIds: '123', variables: 'processState_neq_Complete' } })
+      .reply(200, processInstanceResponse)
+      .onGet('/form/name/noteCerberus')
+      .reply(200, noteFormResponse);
+  };
 
   it('should render TaskDetailsPage component with a loading state', () => {
     render(<TaskDetailsPage />);
@@ -24,43 +63,65 @@ describe('TaskDetailsPage', () => {
   });
 
   it('should render Issue Target button when current user is assigned user, and open issue target form on click', async () => {
-    mockAxios
-      .onGet('/task/taskId')
-      .reply(200, {
-        processInstanceId: '123',
-        assignee: 'test',
-        id: 'task123',
-      })
-      .onGet('/variable-instance', { params: { processInstanceIdIn: '123', deserializeValues: false } })
-      .reply(200, taskDetailsVariableInstanceResponse)
-      .onGet('/history/user-operation', { params: { processInstanceId: '123', deserializeValues: false } })
-      .reply(200,
-        [{
-          operationType: 'Claim',
-          property: 'assignee',
-          orgValue: null,
-          timestamp: '2021-04-06T15:30:42.420+0000',
-          userId: 'testuser@email.com',
-        }])
-      .onGet('/history/task', { params: { processInstanceId: '123', deserializeValues: false } })
-      .reply(200,
-        [{
-          assignee: 'testuser@email.com',
-          startTime: '2021-04-20T10:50:25.869+0000',
-          name: 'Investigate Error',
-        }])
-      .onGet('/form/name/noteCerberus')
-      .reply(200,
-        { test });
+    mockTaskDetailsAxiosCalls({ ...mockTaskDetailsAxiosResponses });
 
-    render(<TaskDetailsPage />);
-    await waitFor(() => expect(screen.getByText(/Task details/i)).toBeTruthy());
-    await waitFor(() => expect(screen.getByText(/Assigned to you/i)).toBeTruthy());
-    await waitFor(() => expect(screen.getByText(/Issue target/i)).toBeTruthy());
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.getByText(/Task details/i)).toBeInTheDocument();
+    expect(screen.getByText(/Assigned to you/i)).toBeInTheDocument();
+    expect(screen.getByText(/Issue target/i)).toBeInTheDocument();
 
     // Click the button
     const issueTargetButton = screen.getByText(/Issue target/i);
     fireEvent.click(issueTargetButton);
-    expect(screen.getByText(/Check the details before issuing target/i)).toBeTruthy();
+    expect(screen.getByText(/Check the details before issuing target/i)).toBeInTheDocument();
+  });
+
+  it('should render "Claim" button when user is not assigned to the task, the task assignee is null and the process has not completed', async () => {
+    mockTaskDetailsAxiosResponses.taskResponse[0].assignee = null;
+
+    mockTaskDetailsAxiosCalls({ ...mockTaskDetailsAxiosResponses });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Unassigned')).toBeInTheDocument();
+    expect(screen.queryByText('Claim')).toBeInTheDocument();
+    expect(screen.queryByText('Unclaim')).not.toBeInTheDocument();
+  });
+
+  it('should render "Unclaim" button when user is not assigned to the task and the process has not completed', async () => {
+    mockTaskDetailsAxiosCalls({ ...mockTaskDetailsAxiosResponses });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Assigned to you')).toBeInTheDocument();
+    expect(screen.queryByText('Unclaim')).toBeInTheDocument();
+    expect(screen.queryByText('Claim')).not.toBeInTheDocument();
+  });
+
+  it('should render "Assigned to ANOTHER_USER" when user is not assigned to the task, the task assignee is not null and the process has not completed', async () => {
+    mockTaskDetailsAxiosResponses.taskResponse[0].assignee = 'ANOTHER_USER';
+
+    mockTaskDetailsAxiosCalls({ ...mockTaskDetailsAxiosResponses });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Assigned to ANOTHER_USER')).toBeInTheDocument();
+    expect(screen.queryByText('Unclaim')).not.toBeInTheDocument();
+    expect(screen.queryByText('Claim')).not.toBeInTheDocument();
+  });
+
+  it('should not render user or claim/unclaim buttons when a process is not complete (come from complete tab in task list)', async () => {
+    mockTaskDetailsAxiosResponses.taskResponse[0].assignee = 'ANOTHER_USER';
+    mockTaskDetailsAxiosResponses.taskResponse = [];
+    mockTaskDetailsAxiosResponses.processInstanceResponse = [];
+
+    mockTaskDetailsAxiosCalls({ ...mockTaskDetailsAxiosResponses });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Assigned to ANOTHER_USER')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unclaim')).not.toBeInTheDocument();
+    expect(screen.queryByText('Claim')).not.toBeInTheDocument();
   });
 });

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -23,7 +23,7 @@ const AppRouter = () => {
     <BrowserRouter>
       <Route path="/" exact><Redirect to="/tasks" /></Route>
       <Route path="/tasks" exact><Layout><TaskListPage /></Layout></Route>
-      <Route path="/tasks/:taskId" exact>
+      <Route path="/tasks/:processInstanceId" exact>
         <Layout beforeMain={<Link className="govuk-back-link" to="/tasks">Back to task list</Link>}>
           <TaskDetailsPage />
         </Layout>


### PR DESCRIPTION
## Description
This PR changes the id in the task detail url to reflect the process instance id and not the task id anymore. Subsequently, API calls to camunda have changed to support this change. As well this, the PR also includes work for COP-6536 whereby doing this work in isolation would introduce breaking changes
## To Test
- Pull and run natively
- Scenario 1: Task owner views task details page
-- GIVEN I have claimed a task that is "in progress"
-- WHEN I view the task details page
-- THEN I have an option to 'Un-claim" the task

- Scenario 2: View an un-claimed task details page
-- GIVEN an "Outstanding" task is NOT claimed
-- WHEN I view the task details page
-- THEN I have an option to 'Claim" the task

- Scenario 3: Non-owner views a claimed task details page
-- GIVEN a task is claimed by another targeter
-- WHEN I view the task details page
-- THEN there is no option to "Claim" OR "Un-claim" the task

- Scenario 4: Task owner views task details page
-- GIVEN I have claimed the task
-- WHEN I have completed a task form (dismiss, assess comp and issue targ) and refreshed the page
-- THEN I should still see the task I actioned

- Scenario 5: View completed target in task list page
-- GIVEN a target in the Complete tab
-- WHEN I see the target
-- THEN I should not be able to claim the target

- Scenario 6: View a completed target in the task details page
-- GIVEN a completed target in the Task Details page
-- WHEN I see the target 
-- THEN I should not be able to claim the target or see an assignee (as there is not an assignee)
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
