### PR TITLE
COP-6534 Hide form button when no users tasks are available, only show form buttons when user task type is equal to "developTarget"

### DIFF
--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -222,7 +222,7 @@ const TaskDetailsPage = () => {
               )}
             </div>
             <div className="govuk-grid-column-one-half task-actions--buttons">
-              {currentUserIsOwner && !isTargetComplete && !isTargetIssued && (
+              {currentUserIsOwner && !isTargetComplete && !isTargetIssued && targetTask.taskDefinitionKey === 'developTarget' && (
                 <>
                   <Button
                     className="govuk-!-margin-right-1"

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -22,6 +22,7 @@ describe('TaskDetailsPage', () => {
         processInstanceId: '123',
         assignee: 'test',
         id: 'task123',
+        taskDefinitionKey: 'developTarget',
       }],
       variableInstanceResponse: taskDetailsVariableInstanceResponse,
       operationsHistoryResponse: [{
@@ -147,6 +148,23 @@ describe('TaskDetailsPage', () => {
 
     expect(screen.queryByText('Assigned to ANOTHER_USER')).not.toBeInTheDocument();
     expect(screen.queryByText('Unclaim')).not.toBeInTheDocument();
+    expect(screen.queryByText('Claim')).not.toBeInTheDocument();
+  });
+
+  it('should not render action forms when target task type is not equal to "developTarget"', async () => {
+    mockTaskDetailsAxiosResponses.taskResponse = [{
+      processInstanceId: '123',
+      assignee: 'test',
+      id: 'task123',
+      taskDefinitionKey: 'NOT_DEVELOP_TARGET',
+    }];
+
+    mockTaskDetailsAxiosCalls({ ...mockTaskDetailsAxiosResponses });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Assigned to you')).toBeInTheDocument();
+    expect(screen.queryByText('Unclaim')).toBeInTheDocument();
     expect(screen.queryByText('Claim')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description
This PR only renders the form buttons when the user task associated with the process instance has a type of `developTarget`
## To Test
- Pull and run natively
- Claim a target from task list page
- *You should see the form buttons*
- Unclaim the task
- *You should NOT see the form buttons*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
