### PR TITLE
COP-5502: Add test for Dismiss a task & Claimed task moved to In progress tab

### DIFF
--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -18,7 +18,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   it('Should add notes for the selected tasks', () => {
     const taskNotes = 'Add notes for testing & check it stored';
     cy.intercept('POST', '/camunda/process-definition/key/noteSubmissionWrapper/submit-form').as('notes');
-
     cy.getUnassignedTasks().then((tasks) => {
       const taskId = tasks.map(((item) => item.id));
       expect(taskId.length).to.not.equal(0);
@@ -77,19 +76,31 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       cy.wait('@tasksDetails').then(({ response }) => {
         expect(response.statusCode).to.equal(200);
       });
+
+      cy.wait(2000);
+
+      cy.get('.govuk-caption-xl').invoke('text').then((text) => {
+        cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+
+        cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
+
+        cy.wait('@claim').then(({ response }) => {
+          expect(response.statusCode).to.equal(204);
+        });
+
+        cy.wait(2000);
+
+        cy.contains('Back to task list').click();
+
+        cy.get('a[href="#in-progress"]').click();
+
+        cy.waitForTaskManagementPageToLoad();
+
+        cy.get('a[data-test="last"]').click();
+
+        cy.contains(text);
+      });
     });
-
-    cy.wait(2000);
-
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
-
-    cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
-
-    cy.wait('@claim').then(({ response }) => {
-      expect(response.statusCode).to.equal(204);
-    });
-
-    cy.wait(2000);
   });
 
   it('Should Unclaim a task Successfully from task details page', () => {
@@ -121,6 +132,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   });
 
   it('Should complete assessment of a task with a reason as take no further action', () => {
+    const reasons = [
+      'Credibility checks carried out - no target required',
+      'Vessel arrived',
+      'False BSM or selector match',
+      'Other',
+    ];
+
     cy.getUnassignedTasks().then((tasks) => {
       const taskId = tasks.map(((item) => item.id));
       expect(taskId.length).to.not.equal(0);
@@ -137,9 +155,18 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.contains('Assessment complete').click();
 
+    cy.clickNext();
+
+    cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for completing your assessment');
+
     cy.selectCheckBox('reason', 'No further action');
 
     cy.clickNext();
+
+    cy.get('.formio-component-nfaReason .govuk-checkboxes__item label').each((reason, index) => {
+      cy.wrap(reason)
+        .should('contain.text', reasons[index]).and('be.visible');
+    });
 
     cy.selectCheckBox('nfaReason', 'Vessel arrived');
 
@@ -150,6 +177,52 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.clickSubmit();
 
     cy.verifySuccessfulSubmissionHeader('Task has been completed');
+  });
+
+  it('Should dismiss a task with a reason', () => {
+    cy.postTasks();
+    cy.intercept('GET', '/camunda/task/*').as('tasksDetails');
+
+    const reasons = [
+      'Vessel arrived',
+      'False rule match',
+      'Resource redirected',
+      'Other (please specify)',
+    ];
+
+    cy.getUnassignedTasks().then((tasks) => {
+      const taskId = tasks.map(((item) => item.id));
+      expect(taskId.length).to.not.equal(0);
+      cy.visit(`/tasks/${taskId[0]}`);
+      cy.wait('@tasksDetails').then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    cy.wait(2000);
+
+    cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
+
+    cy.contains('Dismiss').click();
+
+    cy.get('.formio-component-reason .govuk-checkboxes__item label').each((reason, index) => {
+      cy.wrap(reason)
+        .should('contain.text', reasons[index]).and('be.visible');
+    });
+
+    cy.clickNext();
+
+    cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for dismissing the task');
+
+    cy.selectCheckBox('reason', 'False rule match');
+
+    cy.clickNext();
+
+    cy.typeValueInTextArea('addANote', 'This is for testing');
+
+    cy.clickSubmit();
+
+    cy.verifySuccessfulSubmissionHeader('Task has been dismissed');
   });
 
   after(() => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -115,7 +115,7 @@ Cypress.Commands.add('verifySuccessfulSubmissionHeader', (value) => {
     .and('have.text', value);
 });
 
-function findItem(value, action) {
+function findItem(taskName, action) {
   function findInPage() {
     let found = false;
 
@@ -132,7 +132,7 @@ function findItem(value, action) {
         cy.get('.govuk-link--no-visited-state').each((item) => {
           if (action !== null) {
             cy.wrap(item).invoke('text').then((text) => {
-              if (value === text) {
+              if (taskName === text) {
                 found = true;
                 cy.wait(2000);
                 cy.contains(action).click();
@@ -141,7 +141,7 @@ function findItem(value, action) {
           } else {
             cy.wrap(item).invoke('text').then((text) => {
               cy.log('task text', text);
-              if (value === text) {
+              if (taskName === text) {
                 found = true;
               }
             });
@@ -159,8 +159,8 @@ function findItem(value, action) {
   findInPage(1);
 }
 
-Cypress.Commands.add('findTaskInAllThePages', (value, action) => {
-  findItem(value, action);
+Cypress.Commands.add('findTaskInAllThePages', (taskName, action) => {
+  findItem(taskName, action);
 });
 
 Cypress.Commands.add('verifyMandatoryErrorMessage', (element, errorText) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -4,6 +4,8 @@ let token;
 
 const cerberusServiceUrl = Cypress.env('cerberusServiceUrl');
 const realm = Cypress.env('auth_realm');
+const formioComponent = '.formio-component-';
+const formioErrorText = '.govuk-error-message > div';
 
 Cypress.Commands.add('login', (userName) => {
   cy.kcLogout();
@@ -21,6 +23,7 @@ Cypress.Commands.add('navigation', (option) => {
 
 Cypress.Commands.add('waitForTaskManagementPageToLoad', () => {
   cy.intercept('GET', '/camunda/variable-instance?deserializeValues=false&variableName=taskSummary&processInstanceIdIn=**').as('tasks');
+
   cy.navigation('Tasks');
 
   cy.wait('@tasks').then(({ response }) => {
@@ -40,6 +43,7 @@ Cypress.Commands.add('getUnassignedTasks', () => {
   };
 
   cy.request(options).then((response) => {
+    console.log(response.body);
     return response.body.filter((item) => item.assignee === null);
   });
 });
@@ -76,7 +80,7 @@ Cypress.Commands.add('getTasksAssignedToMe', () => {
 
 Cypress.Commands.add('selectCheckBox', (elementName, value) => {
   if (value !== undefined && value !== '') {
-    cy.get(`.formio-component-${elementName}`)
+    cy.get(`${formioComponent}${elementName}`)
       .should('be.visible')
       .contains(new RegExp(`^${value}$`, 'g'))
       .closest('div')
@@ -93,7 +97,7 @@ Cypress.Commands.add('clickNext', () => {
 
 Cypress.Commands.add('typeValueInTextArea', (elementName, value) => {
   if (value !== undefined && value !== '') {
-    cy.get(`.formio-component-${elementName} textarea`)
+    cy.get(`${formioComponent}${elementName} textarea`)
       .should('be.visible')
       .type(value, { force: true });
   }
@@ -146,6 +150,12 @@ function findItem(value) {
 
 Cypress.Commands.add('unClaimTaskFromListPage', (value) => {
   findItem(value);
+});
+
+Cypress.Commands.add('verifyMandatoryErrorMessage', (element, errorText) => {
+  cy.get(`${formioComponent}${element} ${formioErrorText}`)
+    .should('be.visible')
+    .contains(errorText);
 });
 
 Cypress.Commands.add('postTasks', (name) => {


### PR DESCRIPTION
## Description
Tests added to check user journey of Dismiss a task
Updated tests to check mandatory error when reason not selected while assessment complete
Check if a task moved into "In progress tab"  after claiming it.
Update tests to adapt latest changes. Following tickets automation covered in this PR, since changes are dependant.
COP-5502
COP-6431
COP-5506

## To Test
npm run cypress:test:local

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
