### PR TITLE
COP-6536: Add test to hide claim & unclaim button on task details page

### DIFF
--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -143,11 +143,10 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       'Other',
     ];
 
-    cy.getUnassignedTasks().then((tasks) => {
-      const processInstanceId = tasks.map((item) => item.processInstanceId);
-      expect(processInstanceId.length).to.not.equal(0);
-      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-      cy.visit(`/tasks/${processInstanceId[0]}`);
+    cy.get('.govuk-grid-row').eq(0).within(() => {
+      cy.intercept('GET', '/camunda/task?processInstanceId=*').as('tasksDetails');
+      cy.get('a').invoke('text').as('taskName');
+      cy.get('a').click();
       cy.wait('@tasksDetails').then(({ response }) => {
         expect(response.statusCode).to.equal(200);
       });

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -69,6 +69,20 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.get('.formio-component-note textarea').should('not.exist');
   });
 
+  it('Should hide Claim/UnClaim button for the tasks assigned to others', () => {
+    cy.getTasksAssignedToOtherUsers().then((tasks) => {
+      const processInstanceId = tasks.map(((item) => item.processInstanceId));
+      expect(processInstanceId.length).to.not.equal(0);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.visit(`/tasks/${processInstanceId[0]}`);
+      cy.wait('@tasksDetails').then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    cy.get('button.link-button').should('not.exist');
+  });
+
   it('Should Claim a task Successfully from task details page', () => {
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
 

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -76,7 +76,6 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
 
   it('Should Claim & Unclaim a task Successfully from task management page', () => {
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
-    cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
 
     cy.get('.task-list--item').eq(0).within(() => {
       cy.get('.govuk-link--no-visited-state').eq(0).invoke('text').as('taskName');
@@ -96,11 +95,11 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
     cy.waitForTaskManagementPageToLoad();
 
     cy.get('@taskName').then((value) => {
+      cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
       cy.findTaskInAllThePages(value, 'Unclaim');
-    });
-
-    cy.wait('@unclaim').then(({ response }) => {
-      expect(response.statusCode).to.equal(204);
+      cy.wait('@unclaim').then(({ response }) => {
+        expect(response.statusCode).to.equal(204);
+      });
     });
   });
 


### PR DESCRIPTION
## Description
Test added to cover the following scenarios,
Scenario: Task owner views task details page
GIVEN I have claimed a task that is "in progress"
WHEN I view the task details page
THEN I have an option to 'Un-claim" the task

Scenario: View an un-claimed task details page
GIVEN an "Outstanding" task is NOT claimed
WHEN I view the task details page
THEN I have an option to 'Claim" the task

Scenario: Non-owner views a claimed task details page
GIVEN a task is claimed by another targeter
WHEN I view the task details page
THEN there is no option to "Claim" OR "Un-claim" the task

## To Test
npm run cypress:runner
execute all tests in task-details.spec.js 

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
