### PR TITLE
COP-6534: Add tests for Hide / Show action buttons

### DIFF
--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -54,6 +54,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.get('.govuk-caption-xl').should('have.text', $text);
     });
 
+    cy.get('.task-actions--buttons button').should('not.exist');
+
     cy.contains('Back to task list').click();
 
     cy.get('a[href="#target-issued"]').click();

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -60,6 +60,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.get('a[href="#target-issued"]').click();
 
+    cy.waitForTaskManagementPageToLoad();
+
     cy.get('@taskName').then(($text) => {
       cy.findTaskInAllThePages($text, null);
     });

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -70,6 +70,8 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   });
 
   it('Should hide Claim/UnClaim button for the tasks assigned to others', () => {
+    cy.get('a[href="#in-progress"]').click();
+
     cy.getTasksAssignedToOtherUsers().then((tasks) => {
       const processInstanceId = tasks.map(((item) => item.processInstanceId));
       expect(processInstanceId.length).to.not.equal(0);

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -109,6 +109,56 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
+  it('Should verify all the action buttons available when task loaded from In Progress', () => {
+    const actionItems = [
+      'Issue target',
+      'Assessment complete',
+      'Dismiss',
+    ];
+
+    cy.get('a[href="#in-progress"]').click();
+
+    cy.getTasksAssignedToMe().then((tasks) => {
+      const processInstanceId = tasks.map((item) => item.processInstanceId);
+      expect(processInstanceId.length).to.not.equal(0);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.visit(`/tasks/${processInstanceId[0]}`);
+      cy.wait('@tasksDetails').then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    cy.wait(2000);
+
+    cy.get('.task-actions--buttons button').each(($items, index) => {
+      expect($items.text()).to.equal(actionItems[index]);
+    });
+  });
+
+  it('Should verify all the action buttons not available when task loaded from Complete tab', () => {
+    cy.get('a[href="#complete"]').click();
+
+    cy.get('.govuk-grid-row').eq(0).within(() => {
+      cy.get('a').click();
+    });
+
+    cy.get('.task-actions--buttons button').should('not.exist');
+  });
+
+  it('Should verify all the action buttons not available for non-task owner', () => {
+    cy.getTasksAssignedToOtherUsers().then((tasks) => {
+      const processInstanceId = tasks.map(((item) => item.processInstanceId));
+      expect(processInstanceId.length).to.not.equal(0);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.visit(`/tasks/${processInstanceId[0]}`);
+      cy.wait('@tasksDetails').then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    cy.get('.task-actions--buttons button').should('not.exist');
+  });
+
   it('Should Unclaim a task Successfully from task details page', () => {
     cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
 


### PR DESCRIPTION
## Description
Tests added for the following scenario,

Scenario: Task owner views task "In-progress"
GIVEN I am a task owner AND the task is "In-progress"
WHEN I view the task details
THEN there are options to Issue target/Complete/Dismiss

Scenario: Task owner views a "Target Issued" task
GIVEN I am a task owner AND the task is "Target Issued"
WHEN I view the task details
THEN there are NO options to Issue target/Complete/Dismiss
(NOTE: We may want to re-visit this acceptance criteria to allow users to complete or dismiss issued targets, but there are bigger implications)

Scenario: Task owner views "Complete" task
GIVEN I am a task owner AND the task is "Complete"
WHEN I view the task details
THEN there are NO options to Issue target/Complete/Dismiss

Scenario: Non-Task owner views task
GIVEN I am NOT a task owner
WHEN I view the task details
THEN there are NO options to Issue target/Complete/Dismiss

## To Test
npm run cypress:test:local OR  npm run cypress:test:dev

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
