### PR TITLE
COP-6761 Pagination on unclaim click

### DIFF
--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -43,7 +43,8 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, processInstanc
       await camundaClient.post(`task/${taskId}/unclaim`, {
         userId: currentUser,
       });
-      history.go(0);
+      history.push({ pathname: '/tasks' });
+      window.scrollTo(0, 0);
     } catch (e) {
       setError(e.message);
       setAssignmentProgress(false);

--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import LinkButton from '../govuk/LinkButton';
 import useAxiosInstance from '../utils/axiosInstance';
 import config from '../config';
+import { TASK_STATUS_NEW } from '../constants';
 import { useKeycloak } from '../utils/keycloak';
 
 const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, processInstanceId, ...props }) => {
@@ -43,7 +44,10 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, processInstanc
       await camundaClient.post(`task/${taskId}/unclaim`, {
         userId: currentUser,
       });
-      history.push({ pathname: '/tasks' });
+      history.push(
+        { pathname: '/tasks',
+          search: `?tab=${TASK_STATUS_NEW}` },
+      );
       window.scrollTo(0, 0);
     } catch (e) {
       setError(e.message);

--- a/src/components/__tests__/ClaimTaskButton.test.jsx
+++ b/src/components/__tests__/ClaimTaskButton.test.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import ClaimButton from '../ClaimTaskButton';
+import TaskListPage from '../../routes/TaskLists/TaskListPage';
 
 const setError = jest.fn();
 
@@ -85,5 +86,10 @@ describe('Claim/Unclaim buttons', () => {
 
     await waitFor(() => { fireEvent.click(screen.getByText(/Unclaim/i)); });
     expect(mockAxios.history.post[0].url).toEqual(`task/${task.id}/unclaim`);
+    render(<TaskListPage />);
+    expect(screen.getByText('New tasks')).toBeInTheDocument();
+    expect(screen.queryByText('In progress tasks')).not.toBeInTheDocument();
+    expect(screen.queryByText('Target issued tasks')).not.toBeInTheDocument();
+    expect(screen.queryByText('Completed tasks')).not.toBeInTheDocument();
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,7 @@
 export const LONG_DATE_FORMAT = 'D MMM YYYY [at] HH:mm';
 export const SHORT_DATE_FORMAT = 'DD/MM/YYYY';
 export const FORM_NAME_TARGET_INFORMATION_SHEET = 'targetInformationSheet';
+export const TASK_STATUS_NEW = 'new';
+export const TASK_STATUS_IN_PROGRESS = 'inProgress';
+export const TASK_STATUS_TARGET_ISSUED = 'issued';
+export const TASK_STATUS_COMPLETED = 'complete';

--- a/src/govuk/Tabs.jsx
+++ b/src/govuk/Tabs.jsx
@@ -4,11 +4,13 @@
  * Code: https://github.com/alphagov/govuk-frontend/blob/master/package/govuk/components/tabs/README.md
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import classNames from 'classnames';
+import { TASK_STATUS_NEW } from '../constants';
 
 const Tabs = ({
-  id, idPrefix, className, title, items, onTabClick, ...attributes
+  id, idPrefix, className, title, items, onTabClick, tabIndex, ...attributes
 }) => {
   const [currentTabIndex, setCurrentTabIndex] = useState(0);
   const currentTab = items[currentTabIndex];
@@ -16,6 +18,14 @@ const Tabs = ({
   const panelIsReactElement = typeof currentTab.panel === 'string' || Array.isArray(currentTab.panel) || React.isValidElement(currentTab.panel);
   const panelAttributes = panelIsReactElement ? {} : currentTab.panel.attributes;
   const panelContents = panelIsReactElement ? currentTab.panel : currentTab.panel.children;
+  const location = useLocation();
+  const forceTabIndex = location.search?.split('tab=')[1] === TASK_STATUS_NEW;
+
+  useEffect(() => {
+    if (forceTabIndex) {
+      setCurrentTabIndex(0);
+    }
+  }, [forceTabIndex]);
 
   return (
     <div

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -10,17 +10,20 @@ import dayjs from 'dayjs';
 import qs from 'qs';
 
 // App imports
-import config from '../../config';
 import { SHORT_DATE_FORMAT, TASK_STATUS_COMPLETED, TASK_STATUS_IN_PROGRESS, TASK_STATUS_NEW, TASK_STATUS_TARGET_ISSUED } from '../../constants';
+import { useKeycloak } from '../../utils/keycloak';
+
+import '../__assets__/TaskListPage.scss';
+
 import ClaimButton from '../../components/ClaimTaskButton';
 import ErrorSummary from '../../govuk/ErrorSummary';
 import LoadingSpinner from '../../forms/LoadingSpinner';
 import Pagination from '../../components/Pagination';
 import Tabs from '../../govuk/Tabs';
+
+import config from '../../config';
 import formatTaskData from '../../utils/formatTaskSummaryData';
 import useAxiosInstance from '../../utils/axiosInstance';
-import { useKeycloak } from '../../utils/keycloak';
-import '../__assets__/TaskListPage.scss';
 
 const TasksTab = ({ taskStatus, setError }) => {
   const [activePage, setActivePage] = useState(0);

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -10,24 +10,17 @@ import dayjs from 'dayjs';
 import qs from 'qs';
 
 // App imports
-import { SHORT_DATE_FORMAT } from '../../constants';
-import { useKeycloak } from '../../utils/keycloak';
-import '../__assets__/TaskListPage.scss';
-
+import config from '../../config';
+import { SHORT_DATE_FORMAT, TASK_STATUS_COMPLETED, TASK_STATUS_IN_PROGRESS, TASK_STATUS_NEW, TASK_STATUS_TARGET_ISSUED } from '../../constants';
 import ClaimButton from '../../components/ClaimTaskButton';
 import ErrorSummary from '../../govuk/ErrorSummary';
 import LoadingSpinner from '../../forms/LoadingSpinner';
 import Pagination from '../../components/Pagination';
 import Tabs from '../../govuk/Tabs';
-
-import config from '../../config';
 import formatTaskData from '../../utils/formatTaskSummaryData';
 import useAxiosInstance from '../../utils/axiosInstance';
-
-const TASK_STATUS_NEW = 'new';
-const TASK_STATUS_IN_PROGRESS = 'inProgress';
-const TASK_STATUS_TARGET_ISSUED = 'issued';
-const TASK_STATUS_COMPLETED = 'complete';
+import { useKeycloak } from '../../utils/keycloak';
+import '../__assets__/TaskListPage.scss';
 
 const TasksTab = ({ taskStatus, setError }) => {
   const [activePage, setActivePage] = useState(0);


### PR DESCRIPTION
## Description

When user clicks unclaim from the in progress tab, and the page they are on is greater than the total number of pages for the new it shows no new tasks.

Updated tab loading to enable forcing the new tab to display
Updated the unclaim button to trigger the force new tab

## To Test

- claim a task from new tab
- find it on in progress tab
- unclaim it
- > you should be taken to the new tab, at the top
- find a task towards the end of the in progress pages
- unclaim it
- > you should be taken to the new tab, at the top

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
