### PR TITLE
COP-5769: Add test for View user activity about a targeting task (comments) in the task history

### DIFF
--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -48,6 +48,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       expect(response.statusCode).to.equal(200);
     });
 
+    cy.reload();
+
+    cy.get('.govuk-grid-column-one-third').within(() => {
+      cy.get('.govuk-body-s a').first().should('have.text', 'cypressuser-cerberus@lodev.xyz');
+      cy.get('p.govuk-body').first().should('have.text', taskNotes);
+    });
+
     cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim').click();
 
     cy.wait(2000);
@@ -106,8 +113,10 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('a[href="#in-progress"]').click();
 
-    cy.get('@taskName').then(($text) => {
-      cy.findTaskInAllThePages($text, null);
+    cy.get('@taskName').then((value) => {
+      cy.findTaskInAllThePages(value, null).then((returnvalue) => {
+        expect(returnvalue).to.equal(true);
+      });
     });
   });
 

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -114,8 +114,8 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.get('a[href="#in-progress"]').click();
 
     cy.get('@taskName').then((value) => {
-      cy.findTaskInAllThePages(value, null).then((returnvalue) => {
-        expect(returnvalue).to.equal(true);
+      cy.findTaskInAllThePages(value, null).then((taskFound) => {
+        expect(taskFound).to.equal(true);
       });
     });
   });

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -96,9 +96,11 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
 
     cy.get('@taskName').then((value) => {
       cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
-      cy.findTaskInAllThePages(value, 'Unclaim');
-      cy.wait('@unclaim').then(({ response }) => {
-        expect(response.statusCode).to.equal(204);
+      cy.findTaskInAllThePages(value, 'Unclaim').then((returnvalue) => {
+        expect(returnvalue).to.equal(true);
+        cy.wait('@unclaim').then(({ response }) => {
+          expect(response.statusCode).to.equal(204);
+        });
       });
     });
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -153,6 +153,8 @@ function findItem(taskName, action) {
       }).then(() => {
         if (!found) {
           findInPage(count += 1);
+        } else {
+          return found;
         }
       });
     });
@@ -161,7 +163,7 @@ function findItem(taskName, action) {
 }
 
 Cypress.Commands.add('findTaskInAllThePages', (taskName, action) => {
-  findItem(taskName, action);
+  return findItem(taskName, action);
 });
 
 Cypress.Commands.add('verifyMandatoryErrorMessage', (element, errorText) => {


### PR DESCRIPTION
## Description
This PR has test for verifying user comments in the activity history. Improved the logic to find a task in the pagination.

## To Test
npm run cypress:test:report -- -b electron
OR
npm run cypress:runner
select task-details.spec.js and run

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
