### PR TITLE
COP-6761: Add tests for Unclaim a task Successfully from In Progress tab & verify it moved to New tab

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -79,6 +79,18 @@ Cypress.Commands.add('getTasksAssignedToMe', () => {
   });
 });
 
+Cypress.Commands.add('navigateToTaskDetails', (processInstanceId, index) => {
+  cy.get('a[href="#in-progress"]').click();
+
+  cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[index]}`).as('tasksDetails');
+  cy.visit(`/tasks/${processInstanceId[index]}`);
+  cy.wait('@tasksDetails').then(({ response }) => {
+    expect(response.statusCode).to.equal(200);
+  });
+
+  cy.wait(2000);
+});
+
 Cypress.Commands.add('selectCheckBox', (elementName, value) => {
   if (value !== undefined && value !== '') {
     cy.get(`${formioComponent}${elementName}`)


### PR DESCRIPTION
## Description
This has tests for the following scenarios,
**Scenario 1:**
- claim a task from new tab
- find it on in progress tab
- unclaim it
- you should be taken to the new tab, at the top
**Scenario 2:**
- find a task towards the end of the in progress pages
- unclaim it
- you should be taken to the new tab, at the top

## To Test
npm run cypress:runner 
execute task-details.spec.js

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
