### PR TITLE
COP-6009 Add sorting by arrival time to new tab task list

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -52,6 +52,8 @@ const TasksTab = ({ taskStatus, setError }) => {
       statusRules: {
         processVariables: 'processState_neq_Complete',
         unassigned: true,
+        sortBy: 'dueDate',
+        sortOrder: 'asc',
       },
     },
     inProgress: {


### PR DESCRIPTION
## Description
When the user sees the task list in the new tab it should be sorted by arrival time (if no arrival time exists, camunda falls back to the created time and sets the due date to that)
## To Test
- Pull and run cerberus natively
- Navigate to the new tab
- Have dev tools open, inspect the task api call that gets the list of tasks checking each objects due date
- *The top of the list of tasks should have a due date earlier than those lower in the list*
- Go to the next page
- The tasks rendered should all have a due date later than the ones from the previous page
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
