### PR TITLE
COP-6747: Update tests for Refactor target status for cerberus

### DIFF
--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -38,6 +38,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.selectDropDownValue('nominalType', 'Account');
 
+    cy.selectDropDownValue('threatIndicators', 'Cash Paid');
+
     cy.selectDropDownValue('checks', 'Anti Fraud Information System');
 
     cy.typeValueInTextArea('comments', 'Nominal type commnets for testing');
@@ -45,6 +47,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
     cy.selectRadioButton('warningsIdentified', 'No');
 
     cy.clickNext();
+
+    cy.waitForNoErrors();
 
     cy.selectDropDownValue('teamToReceiveTheTarget', 'Aberdeen Commodity team - DN02G5');
 
@@ -67,9 +71,24 @@ describe('Issue target from cerberus UI using target sheet information form', ()
     cy.waitForTaskManagementPageToLoad();
 
     cy.get('@taskName').then(($text) => {
+      cy.wait(2000);
       cy.findTaskInAllThePages($text, null).then((taskFound) => {
         expect(taskFound).to.equal(true);
       });
     });
+  });
+
+  it('Should verify all the action buttons not available when task loaded from Issued tab', () => {
+    cy.get('a[href="#target-issued"]').click();
+
+    cy.get('.govuk-grid-row').eq(0).within(() => {
+      cy.get('a').click();
+    });
+
+    cy.get('.task-actions--buttons button').should('not.exist');
+
+    cy.get('button.link-button').should('not.exist');
+
+    cy.get('.formio-component-note textarea').should('not.exist');
   });
 });

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -262,7 +262,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.contains('Dismiss').click();
 
-    cy.get('.formio-component-reason .govuk-checkboxes__item label').each((reason, index) => {
+    cy.get('.formio-component-reason .govuk-radios__label').each((reason, index) => {
       cy.wrap(reason)
         .should('contain.text', reasons[index]).and('be.visible');
     });
@@ -271,9 +271,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for dismissing the task');
 
-    cy.selectCheckBox('reason', 'False rule match');
+    cy.selectRadioButton('reason', 'Other (please specify)');
+
+    cy.typeValueInTextField('otherReason', 'other reason for testing');
 
     cy.clickNext();
+
+    cy.waitForNoErrors();
 
     cy.typeValueInTextArea('addANote', 'This is for testing');
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -281,3 +281,11 @@ Cypress.Commands.add('checkTaskDisplayed', (processInstanceId, businessKey) => {
 Cypress.Commands.add('waitForNoErrors', () => {
   cy.get(formioErrorText).should('not.exist');
 });
+
+Cypress.Commands.add('typeValueInTextField', (elementName, value) => {
+  cy.get(`${formioComponent}textfield${formioComponent}${elementName} input`)
+
+    .should('be.visible')
+    .clear()
+    .type(value);
+});


### PR DESCRIPTION
## Description
Tests updated to cover all the following scenarios,

open a task from the `Issued` tab
> you should have no `claim` or `unclaim` button
> you should not see an `assigned to` message
> you should not have the action buttons (Issue target, Assessment complete, Dismiss)
> you should not have a notes form
 
open a task from the 'Completed` tab
> you should have no `claim` or `unclaim` button
> you should not see an `assigned to` message
> you should not have the action buttons (Issue target, Assessment complete, Dismiss)
> you should not have a notes form
 
open a task from the `in progress` tab that is not assigned to you
> you should have no `claim` or `unclaim` button
> you should see the text 'Assigned to <user>'
> you should not have the action buttons (Issue target, Assessment complete, Dismiss)
> you should not have a notes form
 

open a task from the `new` tab
> you should have a `claim` button but no other buttons
> you should see the text 'Unassigned'
 

click `claim`
> you should now see the text 'Assigned to you'
> you should have an 'unclaim' button
> you should have the action buttons
> you should have a notes form

## To Test
npm run cypress:test:report -- -b electron  or
npm run cypress:test:local

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
