### PR TITLE
COP-6009 Sort targets on single page in task list

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -134,7 +134,7 @@ const TasksTab = ({ taskStatus, setError }) => {
           parsedTargetTaskSummariesValues = targetTaskSummaryValues;
         }
 
-        setTargetTasks(parsedTargetTaskSummariesValues);
+        setTargetTasks(parsedTargetTaskSummariesValues.sort((a, b) => new Date(a.due) - new Date(b.due)));
       } catch (e) {
         setError(e.message);
         setTargetTasks([]);

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -134,6 +134,12 @@ const TasksTab = ({ taskStatus, setError }) => {
           parsedTargetTaskSummariesValues = targetTaskSummaryValues;
         }
 
+        /*
+         * We initially grab the tasks from camunda in a sorted order (by 'due' asc)
+         * However after using the tasks data to query the variable endpoint we lose the
+         * sorting we had before. As a result, the amalgamation of /tasks and /variable api calls
+         * is sorted by the 'due' property to ensure the task list is in asc order
+        */
         setTargetTasks(parsedTargetTaskSummariesValues.sort((a, b) => new Date(a.due) - new Date(b.due)));
       } catch (e) {
         setError(e.message);


### PR DESCRIPTION
## Description
Currently, cerberus sorts the targets by page correctly. However the 10 targets that appear in the list are not guaranteed to be sorted themselves. This PR solves this issue
## To Test
- Pull and run cerberus natively
- Submit targets to cerberus with varying scheduled arrival times (note the business key and the associated arrival time)
- *The targets you submitted should appear in the correct order in the list (earlier arrival first)*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
