### PR TITLE
COP-7114 Handle form service errors gracefully

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -53,7 +53,6 @@ const RenderForm = ({ formName, onSubmit, onCancel, preFillData, children }) => 
         const formResponse = await formApiClient.get(`/form/name/${formName}`);
         setForm(formResponse.data);
       } catch (e) {
-        setForm(null);
         setError(e.message);
       } finally {
         setLoaderVisibility(false);

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, wait, waitFor } from '@testing-library/react';
 import TaskDetailsPage from '../TaskDetails/TaskDetailsPage';
 import variableInstanceStatusNew from '../__fixtures__/variableInstanceStatusNew.fixture.json';
 import variableInstanceStatusComplete from '../__fixtures__/variableInstanceStatusComplete.fixture.json';
@@ -211,5 +211,27 @@ describe('TaskDetailsPage', () => {
     expect(screen.queryByText('Issue target')).not.toBeInTheDocument();
     expect(screen.queryByText('Assessment complete')).not.toBeInTheDocument();
     expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
+  });
+
+  it('should handle form service errors gracefully', async () => {
+    mockTaskDetailsAxiosCalls({
+      taskResponse: [{
+        processInstanceId: '123',
+        assignee: 'test',
+        id: 'task123',
+        taskDefinitionKey: 'developTarget',
+      }],
+      variableInstanceResponse: variableInstanceStatusNew,
+      operationsHistoryResponse: operationsHistoryFixture,
+      taskHistoryResponse: taskHistoryFixture,
+      noteFormResponse: { test },
+    });
+
+    // Overwrite response defined in mockTaskDetailsAxiosCalls for notes form to test form service error handling
+    mockAxios.onGet('/form/name/noteCerberus').reply(404);
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('There is a problem')).toBeInTheDocument();
   });
 });

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { fireEvent, render, screen, wait, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import TaskDetailsPage from '../TaskDetails/TaskDetailsPage';
 import variableInstanceStatusNew from '../__fixtures__/variableInstanceStatusNew.fixture.json';
 import variableInstanceStatusComplete from '../__fixtures__/variableInstanceStatusComplete.fixture.json';


### PR DESCRIPTION
## Description
When the form service returns an error code, this PR handles the error gracefully. Before, the `form` state was set to null after an error code was returned from the form service however, this has now been removed thus the `form` state remains an empty object. As a result the subsequent form.io methods a now being called against an empty object and not `null`
## To Test
- Pull and run natively
- Claim a target from the target list
- *Task details page should render without error*
- Cause an error to be returned from the form service (via secrets or by changing the form name used to query the form service)
- Navigate to the same target claimed
- *The task details page should not break*
- *An error code should be returned matching the method used to cause the error i.e. form name change equalling a 404 or 500 for incorrect env set*

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
