### PR TITLE
COP-6009 Null due dates sort to bottom of target list

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -140,7 +140,11 @@ const TasksTab = ({ taskStatus, setError }) => {
          * sorting we had before. As a result, the amalgamation of /tasks and /variable api calls
          * is sorted by the 'due' property to ensure the task list is in asc order
         */
-        setTargetTasks(parsedTargetTaskSummariesValues.sort((a, b) => new Date(a.due) - new Date(b.due)));
+        setTargetTasks(parsedTargetTaskSummariesValues.sort((a, b) => {
+          const dateA = new Date(a.due);
+          const dateB = new Date(b.due);
+          return (a.due === null) - (b.due === null) || +(dateA > dateB) || -(dateA < dateB);
+        }));
       } catch (e) {
         setError(e.message);
         setTargetTasks([]);


### PR DESCRIPTION
## Description
When the due date for a target is null, it is placed lower in the target list than a due date that is truthy.
## To Test
- Pull and run natively
- Navigate to target list
- Move through pages until you find a page containing both null arrival dates and valid arrival dates (null dates expressed as `Unknown` in the target list)
- *You should see the unknown arrival dates appear below the valid arrival dates*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
