### PR TITLE
COP-6820 Reverse task version list

### DIFF
--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -38,7 +38,7 @@ const TaskVersions = ({ taskVersions }) => {
       className="task-versions"
       id="task-versions"
       items={
-        taskVersions.map((version, index) => {
+        taskVersions.reverse().map((version, index) => {
           const booking = version.find((fieldset) => { return fieldset.fieldSetName === 'Booking'; }) || null;
           const bookingDate = booking?.contents.find((field) => { return field.fieldName === 'Date and time'; }) || null;
           const versionNumber = taskVersions.length - index;


### PR DESCRIPTION
## Description
The task version list was rendering in the wrong order. This is due to the latest task version being the last element in the array. To fix this, reversing the array is the fix
## To Test
- Pull and run natively
- Check a target with multiple versions
- *It should render correctly*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
