### PR TITLE
COP-7114: Add test to verify Cerberus-UI doesn't break when form api returns 404

### DIFF
--- a/cypress/integration/cerberus/formapi-404.spec.js
+++ b/cypress/integration/cerberus/formapi-404.spec.js
@@ -1,0 +1,37 @@
+describe('Login', () => {
+  before(() => {
+    cy.login(Cypress.env('userName'));
+    cy.fixture('tasks.json').then((task) => {
+      cy.postTasks(task, 'CERB-AUTOTEST');
+    });
+  });
+
+  it('should show an error when Form API does not respond', () => {
+    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+
+    cy.intercept('GET', 'https://form-api-server.dev.cop.homeoffice.gov.uk/form/name/*', {
+      statusCode: 404,
+    }).as('formAPI');
+
+    cy.get('.govuk-grid-row').eq(0).within(() => {
+      cy.get('a').invoke('text').as('taskName');
+      cy.get('a').click();
+    });
+
+    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+
+    cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
+
+    cy.wait('@claim').then(({ response }) => {
+      expect(response.statusCode).to.equal(204);
+    });
+
+    cy.contains('Issue target').click();
+
+    cy.wait('@formAPI').then(({ response }) => {
+      expect(response.statusCode).to.equal(404);
+    });
+
+    cy.get('.govuk-error-summary a').eq(0).should('contain.text', 'Request failed with status code 404');
+  });
+});

--- a/scripts/env-setup-dev.sh
+++ b/scripts/env-setup-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 context="acp-notprod_COP"
-namespace=$1
+namespace="cop-ops-dev"
 
 rm .env
 
@@ -13,7 +13,7 @@ do
       echo "export $varName=$varValue" >> .env
   fi
 
-done < <(kubectl --context=$context --namespace=$namespace get secret cerberus-service -o yaml | awk 'BEGIN {FS=": ";output=0} {  if ($0 ~ /^kind*/) { output=0 }; if (output) { varName=toupper($1); gsub(/\./, "_", varName); printf " %s:%s\n", varName, $2  }; if ($0 == "data:") { output=1} ;  }')
+done < <(kubectl --context=$context --namespace=$namespace get secret formio-integration-test -o yaml | awk 'BEGIN {FS=": ";output=0} {  if ($0 ~ /^kind*/) { output=0 }; if (output) { varName=toupper($1); gsub(/\./, "_", varName); printf " %s:%s\n", varName, $2  }; if ($0 == "data:") { output=1} ;  }')
 
 mkdir -p cypress/fixtures/users
 source .env

--- a/scripts/env-setup-sit.sh
+++ b/scripts/env-setup-sit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 context="acp-notprod_COP"
-namespace="cop-ops-dev"
+namespace=$1
 
 rm .env
 
@@ -13,7 +13,7 @@ do
       echo "export $varName=$varValue" >> .env
   fi
 
-done < <(kubectl --context=$context --namespace=$namespace get secret formio-integration-test -o yaml | awk 'BEGIN {FS=": ";output=0} {  if ($0 ~ /^kind*/) { output=0 }; if (output) { varName=toupper($1); gsub(/\./, "_", varName); printf " %s:%s\n", varName, $2  }; if ($0 == "data:") { output=1} ;  }')
+done < <(kubectl --context=$context --namespace=$namespace get secret cerberus-service -o yaml | awk 'BEGIN {FS=": ";output=0} {  if ($0 ~ /^kind*/) { output=0 }; if (output) { varName=toupper($1); gsub(/\./, "_", varName); printf " %s:%s\n", varName, $2  }; if ($0 == "data:") { output=1} ;  }')
 
 mkdir -p cypress/fixtures/users
 source .env


### PR DESCRIPTION
## Description
This PR has test to verify Cerberus-UI doesn't break when form api returns 404.
Form API mocked with Cypress route to return 404 before hitting the form API service.

## To Test
npm run cypress:runner
select formapi-404.spec.js and run

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
