### PR TITLE
COP-7375 RoRo-accompanied task driver details DOB and travel doc expiry date not populated correctly

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -10,6 +10,7 @@ import LoadingSpinner from '../forms/LoadingSpinner';
 import { useKeycloak } from '../utils/keycloak';
 import { augmentRequest, interpolate } from '../utils/formioSupport';
 import ErrorSummary from '../govuk/ErrorSummary';
+import findAndFormat from '../utils/findAndFormat';
 
 Formio.use(gds);
 
@@ -63,13 +64,21 @@ const RenderForm = ({ formName, onSubmit, onCancel, preFillData, children }) => 
       if (!preFillData) {
         setFormattedPreFillData(null);
       } else {
+        /*
+         * Due to formio prefilling issues, findAndFormat is used in order to correctly
+         * prefill the form dob and docExpiry fields
+        */
+        findAndFormat(preFillData, 'dob', (dob) => dob.split('-').reverse().join('/'));
+        findAndFormat(preFillData, 'docExpiry', (dob) => dob.split('-').reverse().join('/'));
         setFormattedPreFillData(
-          { data: {
-            environmentContext: {
-              referenceDataUrl: config.refdataApiUrl,
+          {
+            data: {
+              environmentContext: {
+                referenceDataUrl: config.refdataApiUrl,
+              },
+              ...preFillData,
             },
-            ...preFillData,
-          } },
+          },
         );
       }
     };

--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { Form, Formio } from 'react-formio';
 import gds from '@ukhomeoffice/formio-gds-template/lib';
 import { isEmpty } from 'lodash';
+import dayjs from 'dayjs';
 
 import config from '../config';
 import useAxiosInstance from '../utils/axiosInstance';
@@ -11,6 +12,7 @@ import { useKeycloak } from '../utils/keycloak';
 import { augmentRequest, interpolate } from '../utils/formioSupport';
 import ErrorSummary from '../govuk/ErrorSummary';
 import findAndFormat from '../utils/findAndFormat';
+import { SHORT_DATE_FORMAT } from '../constants';
 
 Formio.use(gds);
 
@@ -69,7 +71,11 @@ const RenderForm = ({ formName, onSubmit, onCancel, preFillData, children }) => 
          * prefill the form dob and docExpiry fields
         */
         findAndFormat(preFillData, 'dob', (dob) => dob.split('-').reverse().join('/'));
-        findAndFormat(preFillData, 'docExpiry', (dob) => dob.split('-').reverse().join('/'));
+        findAndFormat(
+          preFillData,
+          'docExpiry',
+          (docExpiry) => dayjs(0).add(docExpiry, 'days').format(SHORT_DATE_FORMAT),
+        );
         setFormattedPreFillData(
           {
             data: {

--- a/src/utils/__tests__/findAndFormat.test.js
+++ b/src/utils/__tests__/findAndFormat.test.js
@@ -1,0 +1,38 @@
+import findAndFormat from '../findAndFormat';
+
+describe('findAndFormat', () => {
+  let input;
+
+  beforeEach(() => {
+    input = {
+      prop1: {
+        prop2: {
+          prop3: {
+            prop4: 'hello',
+            prop5: 'world',
+          },
+        },
+      },
+      prop6: [
+        {
+          prop7: 'foo',
+          prop8: 'bar',
+        },
+        {
+          prop7: 'cheese',
+          prop9: 'tea',
+        },
+      ],
+      prop9: 'blah',
+    };
+  });
+
+  it('should find the key specified and apply provided function', () => {
+    findAndFormat(input, 'prop9', (prop) => prop.split('').reverse().join(''));
+    expect(input.prop6[1].prop9).toBe('aet');
+    expect(input.prop9).toBe('halb');
+  });
+  it('should handle unfound keys gracefully', () => {
+    expect(() => findAndFormat(input, 'does-not-exist', () => {})).not.toThrow();
+  });
+});

--- a/src/utils/__tests__/findAndFormat.test.js
+++ b/src/utils/__tests__/findAndFormat.test.js
@@ -1,4 +1,6 @@
+import dayjs from 'dayjs';
 import findAndFormat from '../findAndFormat';
+import { SHORT_DATE_FORMAT } from '../../constants';
 
 describe('findAndFormat', () => {
   let input;
@@ -24,6 +26,7 @@ describe('findAndFormat', () => {
         },
       ],
       prop9: 'blah',
+      prop10: 13933,
     };
   });
 
@@ -34,5 +37,13 @@ describe('findAndFormat', () => {
   });
   it('should handle unfound keys gracefully', () => {
     expect(() => findAndFormat(input, 'does-not-exist', () => {})).not.toThrow();
+  });
+  it('should format fields with provided callback', () => {
+    findAndFormat(
+      input,
+      'prop10',
+      (prop) => dayjs(0).add(prop, 'days').format(SHORT_DATE_FORMAT),
+    );
+    expect(input.prop10).toBe('24/02/2008');
   });
 });

--- a/src/utils/findAndFormat.js
+++ b/src/utils/findAndFormat.js
@@ -1,0 +1,11 @@
+const findAndFormat = (obj, propName, fn) => {
+  for (const key in obj) {
+    if (key === propName) {
+      obj[key] = fn(obj[key]);
+    } else if (typeof obj[key] === 'object' && obj[key]) {
+      findAndFormat(obj[key], propName, fn);
+    }
+  }
+};
+
+export default findAndFormat;


### PR DESCRIPTION
## Description
The date of birth and document expiry fields do not prefill correctly on the target information sheet. This is due to the provided date being in ISO format (excluding time) which formbuilder is not able to pre-populate the fields with. Formbuilder accepts the date as `DD/MM/YYYY` whereas it was receiving `YYYY-MM-DD`. This code just formats the dob and docExpiry to match the date format expected by formbuilder.
## To Test
- Go to cerberus dev and submit a target information sheet via a task (have dev tools open and check the req payload's dob and docExpiry fields)
- Pull and run natively
- Select task from task list and click `Issue a Target`
- Navigate to the dob and doc expiry fields
- *The fields should be populated correctly*
- Submit the form
- *The req payload dob and docExpiry should have the same format as the req payload submitted in dev*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
