### PR TITLE
COP-6420: Update tests for complete assessment where options changed from checkboxes to radio buttons

### DIFF
--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -1,5 +1,5 @@
 describe('Issue target from cerberus UI using target sheet information form', () => {
-  before(() => {
+  beforeEach(() => {
     cy.login(Cypress.env('userName'));
     cy.fixture('tasks.json').then((task) => {
       cy.postTasks(task, 'CERB-AUTOTEST');
@@ -65,6 +65,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
     cy.get('.task-actions--buttons button').should('not.exist');
 
     cy.contains('Back to task list').click();
+
+    cy.reload();
 
     cy.get('a[href="#target-issued"]').click();
 

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -187,9 +187,9 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   it('Should complete assessment of a task with a reason as take no further action', () => {
     const reasons = [
-      'Credibility checks carried out - no target required',
+      'Credibility checks carried out no target required',
+      'False BSM/selector match',
       'Vessel arrived',
-      'False BSM or selector match',
       'Other',
     ];
 
@@ -212,9 +212,10 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for completing your assessment');
 
-    cy.get('.formio-component-nfaReason .govuk-checkboxes__item label').each((reason, index) => {
-      cy.wrap(reason)
-        .should('contain.text', reasons[index]).and('be.visible');
+    cy.get('.formio-component-reason .govuk-radios__label').each(($reason, index) => {
+      expect($reason).to.be.visible;
+      let reasonText = $reason.text().replace(/^\s+|\s+$/g, '');
+      expect(reasonText).to.contain(reasons[index]);
     });
 
     cy.selectRadioButton('reason', 'Vessel arrived');

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -212,16 +212,12 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for completing your assessment');
 
-    cy.selectCheckBox('reason', 'No further action');
-
-    cy.clickNext();
-
     cy.get('.formio-component-nfaReason .govuk-checkboxes__item label').each((reason, index) => {
       cy.wrap(reason)
         .should('contain.text', reasons[index]).and('be.visible');
     });
 
-    cy.selectCheckBox('nfaReason', 'Vessel arrived');
+    cy.selectRadioButton('reason', 'Vessel arrived');
 
     cy.clickNext();
 
@@ -237,7 +233,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       'Vessel arrived',
       'False rule match',
       'Resource redirected',
-      'Other (please specify)',
+      'Other',
     ];
 
     cy.get('.govuk-grid-row').eq(0).within(() => {
@@ -271,7 +267,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for dismissing the task');
 
-    cy.selectRadioButton('reason', 'Other (please specify)');
+    cy.selectRadioButton('reason', 'Other');
 
     cy.typeValueInTextField('otherReason', 'other reason for testing');
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -152,8 +152,6 @@ function findItem(taskName, action) {
   function findInPage(count) {
     let found = false;
 
-    const nextPage = 'a[data-test="next"]';
-
     cy.get('.pagination').invoke('attr', 'aria-label').as('pages');
 
     cy.get('@pages').then((pages) => {
@@ -162,22 +160,22 @@ function findItem(taskName, action) {
         return false;
       }
       if (count > 0) {
-        cy.get(nextPage).as('next');
-        cy.get('@next').click();
+        cy.contains('Next').click();
+        cy.wait(1000);
       }
       cy.get('.govuk-link--no-visited-state').each((item) => {
-        if (action !== null) {
+        if (action === null) {
           cy.wrap(item).invoke('text').then((text) => {
+            cy.log('task text', text);
             if (taskName === text) {
-              cy.wait(2000);
-              cy.contains(action).click();
               found = true;
             }
           });
         } else {
           cy.wrap(item).invoke('text').then((text) => {
-            cy.log('task text', text);
             if (taskName === text) {
+              cy.wait(2000);
+              cy.contains(action).click();
               found = true;
             }
           });


### PR DESCRIPTION
## Description
Assessment complete and dismiss a task tests are updated to match with the latest changes.
Fix added for the Flaky tests to find a task in the respective tabs. 

## To Test
npm run cypress:runner
execute tests from spec, task-details.spec.js 

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
