### PR TITLE
COP-7315: Update tests to choose target indicators and target hub from ref-data list & check matching selectors

### DIFF
--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -32,6 +32,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.selectDropDownValue('eventPort', '135 Dunganno Road');
 
+    cy.selectDropDownValue('issuingHub', 'Vessel Targeting');
+
     cy.typeTodaysDateTime('eta');
 
     cy.selectDropDownValue('strategy', 'Alcohol');

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -15,6 +15,9 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       cy.contains(text).click();
       cy.get('.govuk-caption-xl').should('have.text', text);
     });
+    cy.wait(2000);
+    cy.get('.govuk-accordion__open-all').click();
+    cy.get('h2.govuk-heading-m').last().should('contain.text', 'selector matches');
   });
 
   it('Should add notes for the selected tasks', () => {


### PR DESCRIPTION
## Description
Test to check matching selectors displayed on task details page (COP-5824)
Test updated to choose target indicators and target hub from ref-data list 

## To Test
npm run cypress:runner
execute tests from issue-a-target.spec.js & task-details.spec.js 

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
