### PR TITLE
COP-7460 targetTask threat indicators not appearing in summary

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -69,12 +69,21 @@ const RenderForm = ({ formName, onSubmit, onCancel, preFillData, children }) => 
         /*
          * Due to formio prefilling issues, findAndFormat is used in order to correctly
          * prefill the form dob and docExpiry fields
+         * Threat indicators arrives as an array of strings, this prepoulates correctly
+         * however it does not match the formatting expected by workflows further down the
+         * line. This means it needs to be changed to match the expected data structure
+         * THESE ARE ALL TEMPORARY FIXES
         */
         findAndFormat(preFillData, 'dob', (dob) => dob.split('-').reverse().join('/'));
         findAndFormat(
           preFillData,
           'docExpiry',
           (docExpiry) => dayjs(0).add(docExpiry, 'days').format(SHORT_DATE_FORMAT),
+        );
+        findAndFormat(
+          preFillData,
+          'threatIndicators',
+          (threatIndicators) => threatIndicators.map((threatIndicator) => ({ indicator: threatIndicator })),
         );
         setFormattedPreFillData(
           {

--- a/src/utils/__tests__/findAndFormat.test.js
+++ b/src/utils/__tests__/findAndFormat.test.js
@@ -27,6 +27,11 @@ describe('findAndFormat', () => {
       ],
       prop9: 'blah',
       prop10: 13933,
+      prop11: [
+        'string1',
+        'string2',
+        'string3',
+      ],
     };
   });
 
@@ -36,7 +41,7 @@ describe('findAndFormat', () => {
     expect(input.prop9).toBe('halb');
   });
   it('should handle unfound keys gracefully', () => {
-    expect(() => findAndFormat(input, 'does-not-exist', () => {})).not.toThrow();
+    expect(() => findAndFormat(input, 'does-not-exist', () => { })).not.toThrow();
   });
   it('should format fields with provided callback', () => {
     findAndFormat(
@@ -44,6 +49,22 @@ describe('findAndFormat', () => {
       'prop10',
       (prop) => dayjs(0).add(prop, 'days').format(SHORT_DATE_FORMAT),
     );
+    findAndFormat(
+      input,
+      'prop11',
+      (prop) => prop.map((string) => ({ customProp: string })),
+    );
     expect(input.prop10).toBe('24/02/2008');
+    expect(input.prop11).toEqual([
+      {
+        customProp: 'string1',
+      },
+      {
+        customProp: 'string2',
+      },
+      {
+        customProp: 'string3',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Description
This PR add formatting for the `threatIndicators` property on the `targetInformationSheet` sent from camunda. Due to time constraints, the formatting has been done here until a fix is implemented in the relevant workflow.
## To Test
- Pull and run natively
- Submit new target and navigate to target in UI
- Issue a target selecting several threat indicators
- Submit and assign task raised in v2 to yourself
- Navigate to COP UI v2 and find task assigned to yourself
- *You SHOULD see the threat indicators selected in the target task form summary*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
