### PR TITLE
COP-7460 Handle null target info values

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -74,16 +74,16 @@ const RenderForm = ({ formName, onSubmit, onCancel, preFillData, children }) => 
          * line. This means it needs to be changed to match the expected data structure
          * THESE ARE ALL TEMPORARY FIXES
         */
-        findAndFormat(preFillData, 'dob', (dob) => dob.split('-').reverse().join('/'));
+        findAndFormat(preFillData, 'dob', (dob) => (dob ? dob.split('-').reverse().join('/') : ''));
         findAndFormat(
           preFillData,
           'docExpiry',
-          (docExpiry) => dayjs(0).add(docExpiry, 'days').format(SHORT_DATE_FORMAT),
+          (docExpiry) => (docExpiry ? dayjs(0).add(docExpiry, 'days').format(SHORT_DATE_FORMAT) : ''),
         );
         findAndFormat(
           preFillData,
           'threatIndicators',
-          (threatIndicators) => threatIndicators.map((threatIndicator) => ({ indicator: threatIndicator })),
+          (threatIndicators) => (threatIndicators[0] ? threatIndicators.map((threatIndicator) => ({ indicator: threatIndicator })) : []),
         );
         setFormattedPreFillData(
           {

--- a/src/utils/__tests__/findAndFormat.test.js
+++ b/src/utils/__tests__/findAndFormat.test.js
@@ -32,6 +32,7 @@ describe('findAndFormat', () => {
         'string2',
         'string3',
       ],
+      prop12: [''],
     };
   });
 
@@ -54,6 +55,11 @@ describe('findAndFormat', () => {
       'prop11',
       (prop) => prop.map((string) => ({ customProp: string })),
     );
+    findAndFormat(
+      input,
+      'prop12',
+      (prop) => (prop[0] ? prop.map((p) => ({ newProp: p })) : []),
+    );
     expect(input.prop10).toBe('24/02/2008');
     expect(input.prop11).toEqual([
       {
@@ -66,5 +72,6 @@ describe('findAndFormat', () => {
         customProp: 'string3',
       },
     ]);
+    expect(input.prop12).toEqual([]);
   });
 });


### PR DESCRIPTION
## Description
This PR handles when the target info sheet values are null (in particular for when the threat indicator is an empty string in an array)
## To Test
- Pull and run natively
- Submit target with threatType equal to empty string (escaped)
- claim target created
- Open issue a target
- *The threat indicator dropdown should not be populated with anything*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
