### PR TITLE
Fix broken test due to pagination and enable RoRo tourist task creation tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,7 @@ module.exports = {
         'jest/valid-expect': 0,
         'jest/valid-expect-in-promise': 0,
         'jest/no-standalone-expect': 'off',
+        'jest/no-conditional-expect': 'off',
         'no-unused-expressions': 'off',
         'quote-props': 'off',
         'cypress/no-unnecessary-waiting': 'off',

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -27,7 +27,7 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it.skip('Should create a task with a payload contains RoRo Tourist', () => {
+  it('Should create a task with a payload contains RoRo Tourist', () => {
     cy.fixture('RoRo-Tourist.json').then((task) => {
       cy.postTasks(task, 'AUTOTEST-TOURIST').then((response) => {
         cy.wait(4000);
@@ -38,7 +38,7 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it.skip('Should create a task with a payload contains RoRo Tourist from RBT & SBT', () => {
+  it('Should create a task with a payload contains RoRo Tourist from RBT & SBT', () => {
     cy.fixture('RoRo-Tourist-RBT-SBT.json').then((task) => {
       cy.postTasks(task, 'AUTOTEST-TOURIST-RBT-SBT').then((response) => {
         cy.wait(4000);
@@ -49,7 +49,7 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it.skip('Should create a task with a payload contains RoRo Tourist from SBT', () => {
+  it('Should create a task with a payload contains RoRo Tourist from SBT', () => {
     cy.fixture('RoRo-Tourist-SBT.json').then((task) => {
       cy.postTasks(task, 'AUTOTEST-TOURIST-SBT').then((response) => {
         cy.wait(4000);

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -76,9 +76,16 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.get('@taskName').then(($text) => {
       cy.wait(2000);
-      cy.findTaskInAllThePages($text, null).then((taskFound) => {
-        expect(taskFound).to.equal(true);
-      });
+      const nextPage = 'a[data-test="next"]';
+      if (Cypress.$(nextPage).length > 0) {
+        cy.findTaskInAllThePages($text, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      } else {
+        cy.findTaskInSinglePage($text, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      }
     });
   });
 

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -128,9 +128,16 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.waitForTaskManagementPageToLoad();
 
     cy.get('@taskName').then((value) => {
-      cy.findTaskInAllThePages(value, null).then((taskFound) => {
-        expect(taskFound).to.equal(true);
-      });
+      const nextPage = 'a[data-test="next"]';
+      if (Cypress.$(nextPage).length > 0) {
+        cy.findTaskInAllThePages(value, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      } else {
+        cy.findTaskInSinglePage(value, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      }
     });
   });
 
@@ -326,9 +333,16 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.tick(60000);
 
     cy.get('@taskName').then((text) => {
-      cy.findTaskInAllThePages(text, null).then((taskFound) => {
-        expect(taskFound).to.equal(true);
-      });
+      const nextPage = 'a[data-test="next"]';
+      if (Cypress.$(nextPage).length > 0) {
+        cy.findTaskInAllThePages(text, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      } else {
+        cy.findTaskInSinglePage(text, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      }
     });
   });
 
@@ -355,9 +369,16 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.url().should('contain', '/tasks?tab=new');
 
     cy.get('@taskName').then((text) => {
-      cy.findTaskInAllThePages(text, null).then((taskFound) => {
-        expect(taskFound).to.equal(true);
-      });
+      const nextPage = 'a[data-test="next"]';
+      if (Cypress.$(nextPage).length > 0) {
+        cy.findTaskInAllThePages(text, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      } else {
+        cy.findTaskInSinglePage(text, null).then((taskFound) => {
+          expect(taskFound).to.equal(true);
+        });
+      }
     });
   });
 

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -98,12 +98,22 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
 
     cy.get('@taskName').then((value) => {
       cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
-      cy.findTaskInAllThePages(value, 'Unclaim').then((returnvalue) => {
-        expect(returnvalue).to.equal(true);
-        cy.wait('@unclaim').then(({ response }) => {
-          expect(response.statusCode).to.equal(204);
+      const nextPage = 'a[data-test="next"]';
+      if (Cypress.$(nextPage).length > 0) {
+        cy.findTaskInAllThePages(value, 'Unclaim').then((returnvalue) => {
+          expect(returnvalue).to.equal(true);
+          cy.wait('@unclaim').then(({ response }) => {
+            expect(response.statusCode).to.equal(204);
+          });
         });
-      });
+      } else {
+        cy.findTaskInSinglePage(value, 'Unclaim').then((returnvalue) => {
+          expect(returnvalue).to.equal(true);
+          cy.wait('@unclaim').then(({ response }) => {
+            expect(response.statusCode).to.equal(204);
+          });
+        });
+      }
     });
   });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -287,3 +287,27 @@ Cypress.Commands.add('typeValueInTextField', (elementName, value) => {
     .clear()
     .type(value);
 });
+
+Cypress.Commands.add('findTaskInSinglePage', (taskName, action) => {
+  let found = false;
+  cy.get('.govuk-link--no-visited-state').each((item) => {
+    if (action === null) {
+      cy.wrap(item).invoke('text').then((text) => {
+        cy.log('task text', text);
+        if (taskName === text) {
+          found = true;
+        }
+      });
+    } else {
+      cy.wrap(item).invoke('text').then((text) => {
+        if (taskName === text) {
+          cy.wait(2000);
+          cy.contains(action).click();
+          found = true;
+        }
+      });
+    }
+  }).then(() => {
+    return found;
+  });
+});


### PR DESCRIPTION
## Description
Once the data cleared out on Dev / Local environment, some of the tests failed because it look for an element from Pagination.
Test adapted to work even when there is a single page in each of the tab.
Enable RoRo tourist task creation tasks.
## To Test
npm run cypress:test:report -- -b electron

open the report mochawesome-report/mochawesome.html and check status of all tests.

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
