### PR TITLE
COP-7185: Setup CronJob to run Automation tests against SIT environment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,49 +84,49 @@ steps:
     target:
     - secrets
 
-- name: unit_tests
-  pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
-  commands:
-  - node -v
-  - npm -v
-  - npm ci
-  - npm run test
-  when:
-    event:
-    - push
-
-- name: linting
-  pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
-  commands:
-  - npm run lint -- .
-  when:
-    event:
-    - push
-
-- name: build
-  pull: always
-  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-  commands:
-  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
-  - docker build -t cerberus-ui-service:$${DRONE_COMMIT_SHA} .
-  when:
-    event:
-    - push
-
-- name: vulnerability-scan
-  pull: always
-  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-  environment:
-    DOCKERFILE: Dockerfile
-    IMAGE_NAME: cerberus-ui-service:${DRONE_COMMIT_SHA}
-    LOCAL_IMAGE: true
-    TOLERATE: low
-    WHITELIST_FILE: whitelist
-  when:
-    event:
-    - push
+#- name: unit_tests
+#  pull: if-not-exists
+#  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
+#  commands:
+#  - node -v
+#  - npm -v
+#  - npm ci
+#  - npm run test
+#  when:
+#    event:
+#    - push
+#
+#- name: linting
+#  pull: if-not-exists
+#  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
+#  commands:
+#  - npm run lint -- .
+#  when:
+#    event:
+#    - push
+#
+#- name: build
+#  pull: always
+#  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+#  commands:
+#  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
+#  - docker build -t cerberus-ui-service:$${DRONE_COMMIT_SHA} .
+#  when:
+#    event:
+#    - push
+#
+#- name: vulnerability-scan
+#  pull: always
+#  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
+#  environment:
+#    DOCKERFILE: Dockerfile
+#    IMAGE_NAME: cerberus-ui-service:${DRONE_COMMIT_SHA}
+#    LOCAL_IMAGE: true
+#    TOLERATE: low
+#    WHITELIST_FILE: whitelist
+#  when:
+#    event:
+#    - push
 
 - name: image_to_quay
   image: plugins/docker
@@ -225,6 +225,8 @@ steps:
       from_secret: DEV_CERBERUS_UI_SERVICE_KEYCLOAK_CLIENT_ID
     AUTH_BASE_URL:
       from_secret: DEV_KEYCLOAK_URL
+    FORM_API_URL:
+      from_secret: DEV_API_FORM_URL
     CERBERUS_WORKFLOW_SERVICE_URL:
       from_secret: DEV_CERBERUS_SERVICE_URL
     CERBERUS_SERVICE_URL:
@@ -267,6 +269,43 @@ steps:
     event:
        - push
 
+- name: run_test_sit
+  pull: always
+  image: quay.io/ukhomeofficedigital/cop-cypress:6.3.0-node13
+  commands:
+    - export CYPRESS_CACHE_FOLDER=/home/node/.cache/Cypress
+    - export CYPRESS_AUTH_REALM="$${AUTH_REALM}"
+    - export CYPRESS_AUTH_CLIENT_ID="$${AUTH_CLIENT_ID}"
+    - export CYPRESS_AUTH_BASE_URL="$${AUTH_BASE_URL}"
+    - export JOB_NAME="drone-build"
+    - npm ci
+    - scripts/run-tests.sh
+  environment:
+    AUTH_REALM:
+      from_secret: SIT_KEYCLOAK_REALM
+    AUTH_CLIENT_ID:
+      from_secret: SIT_CERBERUS_UI_SERVICE_KEYCLOAK_CLIENT_ID
+    AUTH_BASE_URL:
+      from_secret: SIT_KEYCLOAK_URL
+    FORM_API_URL:
+      from_secret: SIT_API_FORM_URL
+    CERBERUS_WORKFLOW_SERVICE_URL:
+      from_secret: SIT_CERBERUS_SERVICE_URL
+    CERBERUS_SERVICE_URL:
+      from_secret: SIT_CERBERUS_UI_SERVICE_URL
+    AWS_ACCESS_KEY_ID:
+      from_secret: DEV_FORMIO_INT_TEST_SECRET_AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: DEV_FORMIO_INT_TEST_SECRET_AWS_SECRET_ACCESS_KEY
+    REPORT_BASE_URL:
+      from_secret: TESTS_REPORT_BASE_URL
+    S3_ACCESS_KEY:
+      from_secret: TESTS_S3_ACCESS_KEY
+    S3_BUCKET_NAME:
+      from_secret: TESTS_S3_BUCKET_NAME
+    S3_SECRET_KEY:
+      from_secret: TESTS_S3_SECRET_KEY
+    DEPLOY_ENV: sit
 
 - name: deploy_to_sit
   pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -324,14 +324,16 @@ steps:
       from_secret: SIT_CERBERUS_KUBE_TOKEN
     CERBERUS_UI_NAME: cerberus-ui-service
     CERBERUS_SERVICE_TEST_TAG: cron-${DRONE_COMMIT_SHA}
-    CRON_SCHEDULE: "\"10 8-17/2 * * 1-5\""
+    CRON_SCHEDULE: "\"10 8-18/3 * * 1-5\""
     JOB_NAME: "\"cerberus-functional-tests-sit\""
     TEST_ENV: sit
   when:
     branch:
       - main
     event:
-      - push
+      - promote
+    target:
+      - sit
 
 - name: deploy_to_sit
   pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -84,49 +84,49 @@ steps:
     target:
     - secrets
 
-#- name: unit_tests
-#  pull: if-not-exists
-#  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
-#  commands:
-#  - node -v
-#  - npm -v
-#  - npm ci
-#  - npm run test
-#  when:
-#    event:
-#    - push
-#
-#- name: linting
-#  pull: if-not-exists
-#  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
-#  commands:
-#  - npm run lint -- .
-#  when:
-#    event:
-#    - push
-#
-#- name: build
-#  pull: always
-#  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-#  commands:
-#  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
-#  - docker build -t cerberus-ui-service:$${DRONE_COMMIT_SHA} .
-#  when:
-#    event:
-#    - push
-#
-#- name: vulnerability-scan
-#  pull: always
-#  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-#  environment:
-#    DOCKERFILE: Dockerfile
-#    IMAGE_NAME: cerberus-ui-service:${DRONE_COMMIT_SHA}
-#    LOCAL_IMAGE: true
-#    TOLERATE: low
-#    WHITELIST_FILE: whitelist
-#  when:
-#    event:
-#    - push
+- name: unit_tests
+  pull: if-not-exists
+  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
+  commands:
+  - node -v
+  - npm -v
+  - npm ci
+  - npm run test
+  when:
+    event:
+    - push
+
+- name: linting
+  pull: if-not-exists
+  image: quay.io/ukhomeofficedigital/cop-node:12-alpine
+  commands:
+  - npm run lint -- .
+  when:
+    event:
+    - push
+
+- name: build
+  pull: always
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
+  - docker build -t cerberus-ui-service:$${DRONE_COMMIT_SHA} .
+  when:
+    event:
+    - push
+
+- name: vulnerability-scan
+  pull: always
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
+  environment:
+    DOCKERFILE: Dockerfile
+    IMAGE_NAME: cerberus-ui-service:${DRONE_COMMIT_SHA}
+    LOCAL_IMAGE: true
+    TOLERATE: low
+    WHITELIST_FILE: whitelist
+  when:
+    event:
+    - push
 
 - name: image_to_quay
   image: plugins/docker
@@ -160,6 +160,7 @@ steps:
       from_secret: QUAY_USERNAME
   when:
     branch:
+      exclude:
        - main
     event:
        - push
@@ -216,6 +217,7 @@ steps:
     - export CYPRESS_CACHE_FOLDER="~/.cache/Cypress"
     - export AUTH_URL="$${PROTOCOL_HTTPS}$${DEV_KEYCLOAK_URL}"
     - export NAME="cerberus-functional-tests"
+    - export TEST_ENV="dev"
     - kd --insecure-skip-tls-verify -f kube/secret.yml
     - kd --insecure-skip-tls-verify -f kube/job.yml
   environment:
@@ -263,23 +265,23 @@ steps:
     CERBERUS_SERVICE_TEST_TAG: cron-${DRONE_COMMIT_SHA}
     CRON_SCHEDULE: "\"10 8-17/1 * * 1-5\""
     JOB_NAME: "\"cerberus-functional-tests\""
+    TEST_ENV: dev
   when:
     branch:
        - main
     event:
        - push
 
-- name: run_test_sit
+- name: create_testjob_sit
   pull: always
-  image: quay.io/ukhomeofficedigital/cop-cypress:6.3.0-node13
+  image: quay.io/ukhomeofficedigital/kd
   commands:
-    - export CYPRESS_CACHE_FOLDER=/home/node/.cache/Cypress
-    - export CYPRESS_AUTH_REALM="$${AUTH_REALM}"
-    - export CYPRESS_AUTH_CLIENT_ID="$${AUTH_CLIENT_ID}"
-    - export CYPRESS_AUTH_BASE_URL="$${AUTH_BASE_URL}"
-    - export JOB_NAME="drone-build"
-    - npm ci
-    - scripts/run-tests.sh
+    - export CYPRESS_CACHE_FOLDER="~/.cache/Cypress"
+    - export AUTH_URL="$${PROTOCOL_HTTPS}$${SIT_KEYCLOAK_URL}"
+    - export NAME="cerberus-functional-tests-sit"
+    - export TEST_ENV="sit"
+    - kd --insecure-skip-tls-verify -f kube/secret.yml
+    - kd --insecure-skip-tls-verify -f kube/job.yml
   environment:
     AUTH_REALM:
       from_secret: SIT_KEYCLOAK_REALM
@@ -297,6 +299,8 @@ steps:
       from_secret: DEV_FORMIO_INT_TEST_SECRET_AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY:
       from_secret: DEV_FORMIO_INT_TEST_SECRET_AWS_SECRET_ACCESS_KEY
+    PROTOCOL_HTTPS:
+      from_secret: PROTOCOL_HTTPS
     REPORT_BASE_URL:
       from_secret: TESTS_REPORT_BASE_URL
     S3_ACCESS_KEY:
@@ -305,7 +309,31 @@ steps:
       from_secret: TESTS_S3_BUCKET_NAME
     S3_SECRET_KEY:
       from_secret: TESTS_S3_SECRET_KEY
-    DEPLOY_ENV: sit
+    SLACK_WEB_HOOK:
+      from_secret: TESTS_SLACK_WEBHOOK
+    TEST_SECRET_NAME:
+      from_secret: DEV_FORMIO_INT_TEST_SECRET_NAME
+    CYPRESS_KEY:
+      from_secret: CYPRESS_KEY
+    CYPRESS_PROJECT_ID:
+      from_secret: CYPRESS_PROJECT_ID
+    KUBE_NAMESPACE:
+      from_secret: SIT_KUBE_NAMESPACE_COP_CERBERUS
+    KUBE_SERVER:
+      from_secret: SIT_KUBE_SERVER
+    KUBE_TOKEN:
+      from_secret: SIT_CERBERUS_KUBE_TOKEN
+    CERBERUS_UI_NAME: cerberus-ui-service
+    CERBERUS_SERVICE_TEST_TAG: cron-${DRONE_COMMIT_SHA}
+    CRON_SCHEDULE: "\"10 8-17/2 * * 1-5\""
+    JOB_NAME: "\"cerberus-functional-tests-sit\""
+    TEST_ENV: sit
+  when:
+    branch:
+      exclude:
+      - main
+    event:
+      - push
 
 - name: deploy_to_sit
   pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -160,7 +160,6 @@ steps:
       from_secret: QUAY_USERNAME
   when:
     branch:
-      exclude:
        - main
     event:
        - push
@@ -330,7 +329,6 @@ steps:
     TEST_ENV: sit
   when:
     branch:
-      exclude:
       - main
     event:
       - push

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ create a file called cypress.env.json on a root folder and include the following
    "auth_realm": "xxx",
    "auth_client_id": "xxx",
    "cerberusServiceUrl": "xxx",
+   "formApiUrl": "xxx"
 }
 ```
 
@@ -145,6 +146,8 @@ npm run cypress:test:report -- -b chrome -s cypress/integration/cerberus/login.s
 
 Running all tests and generating mochawesome html report with screenshots using script
 export CERBERUS_WORKFLOW_SERVICE_URL=xxxxx
+export FORM_API_URL=xxxx
+export TEST_ENV= dev / sit
 ```sh
 ./scripts/run_tests.sh
 ```

--- a/cypress/config/sit.json
+++ b/cypress/config/sit.json
@@ -1,0 +1,6 @@
+{
+  "baseUrl": "https://www.sit.cerberus.cop.homeoffice.gov.uk",
+  "env": {
+    "envname": "sit"
+  }
+}

--- a/cypress/integration/cerberus/formapi-404.spec.js
+++ b/cypress/integration/cerberus/formapi-404.spec.js
@@ -1,21 +1,32 @@
-describe('Login', () => {
+describe('Cerberus-UI handles the exception if Form API server is unresponsive', () => {
+  let taskName;
+  let formApiUrl = Cypress.env('formApiUrl');
   before(() => {
     cy.login(Cypress.env('userName'));
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'CERB-AUTOTEST');
+      cy.postTasks(task, 'CERB-AUTOTEST').then((response) => {
+        taskName = response.businessKey;
+      });
     });
   });
 
   it('should show an error when Form API does not respond', () => {
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
 
-    cy.intercept('GET', 'https://form-api-server.dev.cop.homeoffice.gov.uk/form/name/*', {
+    cy.intercept('GET', `https://${formApiUrl}/form/name/*`, {
       statusCode: 404,
     }).as('formAPI');
 
-    cy.get('.govuk-grid-row').eq(0).within(() => {
-      cy.get('a').invoke('text').as('taskName');
-      cy.get('a').click();
+    cy.wait(4000);
+
+    cy.getTasksByPartialBusinessKey(`${taskName}`).then((tasks) => {
+      const processInstanceId = tasks.map(((item) => item.processInstanceId));
+      expect(processInstanceId.length).to.not.equal(0);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.visit(`/tasks/${processInstanceId[0]}`);
+      cy.wait('@tasksDetails').then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
     });
 
     cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -1,11 +1,4 @@
 describe('Render tasks from Camunda and manage them on task details Page', () => {
-  before(() => {
-    cy.login(Cypress.env('userName'));
-    cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'CERB-AUTOTEST');
-    });
-  });
-
   beforeEach(() => {
     cy.login(Cypress.env('userName'));
   });
@@ -23,16 +16,24 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   it('Should add notes for the selected tasks', () => {
     const taskNotes = 'Add notes for testing & check it stored';
     cy.intercept('POST', '/camunda/process-definition/key/noteSubmissionWrapper/submit-form').as('notes');
-    cy.get('.govuk-grid-row').eq(0).within(() => {
-      cy.intercept('GET', '/camunda/task?processInstanceId=*').as('tasksDetails');
-      cy.get('a').invoke('text').as('taskName');
-      cy.get('a').click();
-      cy.wait('@tasksDetails').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
+
+    cy.fixture('tasks.json').then((task) => {
+      cy.postTasks(task, 'CERB-AUTOTEST').then((taskResponse) => {
+        cy.wait(4000);
+        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+          const processInstanceId = tasks.map(((item) => item.processInstanceId));
+          expect(processInstanceId.length).to.not.equal(0);
+          cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+          cy.visit(`/tasks/${processInstanceId[0]}`);
+          cy.wait('@tasksDetails').then(({ response }) => {
+            expect(response.statusCode).to.equal(200);
+          });
+        });
       });
     });
 
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+
     cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
@@ -103,10 +104,21 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
 
-    cy.get('.govuk-grid-row').eq(0).within(() => {
-      cy.get('a').invoke('text').as('taskName');
-      cy.get('a').click();
+    cy.fixture('tasks.json').then((task) => {
+      cy.postTasks(task, 'CERB-AUTOTEST').then((taskResponse) => {
+        cy.wait(4000);
+        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+          const processInstanceId = tasks.map(((item) => item.processInstanceId));
+          expect(processInstanceId.length).to.not.equal(0);
+          cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+          cy.visit(`/tasks/${processInstanceId[0]}`);
+          cy.wait('@tasksDetails').then(({ response }) => {
+            expect(response.statusCode).to.equal(200);
+          });
+        });
+      });
     });
+
     cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
@@ -116,6 +128,8 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
 
     cy.wait(2000);
+
+    cy.get('.govuk-caption-xl').invoke('text').as('taskName');
 
     cy.get('.task-actions--buttons button').each(($items, index) => {
       expect($items.text()).to.equal(actionItems[index]);
@@ -203,12 +217,18 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       'Other',
     ];
 
-    cy.get('.govuk-grid-row').eq(0).within(() => {
-      cy.intercept('GET', '/camunda/task?processInstanceId=*').as('tasksDetails');
-      cy.get('a').invoke('text').as('taskName');
-      cy.get('a').click();
-      cy.wait('@tasksDetails').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
+    cy.fixture('tasks.json').then((task) => {
+      cy.postTasks(task, 'CERB-AUTOTEST-ASSESSMENT').then((taskResponse) => {
+        cy.wait(4000);
+        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+          const processInstanceId = tasks.map(((item) => item.processInstanceId));
+          expect(processInstanceId.length).to.not.equal(0);
+          cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+          cy.visit(`/tasks/${processInstanceId[0]}`);
+          cy.wait('@tasksDetails').then(({ response }) => {
+            expect(response.statusCode).to.equal(200);
+          });
+        });
       });
     });
 
@@ -247,12 +267,18 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       'Other',
     ];
 
-    cy.get('.govuk-grid-row').eq(0).within(() => {
-      cy.intercept('GET', '/camunda/task?processInstanceId=*').as('tasksDetails');
-      cy.get('a').invoke('text').as('taskName');
-      cy.get('a').click();
-      cy.wait('@tasksDetails').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
+    cy.fixture('tasks.json').then((task) => {
+      cy.postTasks(task, 'CERB-AUTOTEST-DISMISS').then((taskResponse) => {
+        cy.wait(4000);
+        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+          const processInstanceId = tasks.map(((item) => item.processInstanceId));
+          expect(processInstanceId.length).to.not.equal(0);
+          cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+          cy.visit(`/tasks/${processInstanceId[0]}`);
+          cy.wait('@tasksDetails').then(({ response }) => {
+            expect(response.statusCode).to.equal(200);
+          });
+        });
       });
     });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -10,6 +10,7 @@ const displayDate24Format = 'DD-MM-YYYY HH:mm';
 
 Cypress.Commands.add('login', (userName) => {
   cy.kcLogout();
+  console.log(Cypress.env('auth_realm'));
   cy.kcLogin(userName).as('tokens');
   cy.intercept('POST', `/auth/realms/${realm}/protocol/openid-connect/token`).as('token');
   cy.visit('/');
@@ -309,5 +310,16 @@ Cypress.Commands.add('findTaskInSinglePage', (taskName, action) => {
     }
   }).then(() => {
     return found;
+  });
+});
+
+Cypress.Commands.add('getTasksByPartialBusinessKey', (businessKey) => {
+  cy.request({
+    method: 'GET',
+    url: `https://${cerberusServiceUrl}/camunda/engine-rest/task?processInstanceBusinessKey=${businessKey}`,
+    headers: { Authorization: `Bearer ${token}` },
+  }).then((response) => {
+    expect(response.status).to.eq(200);
+    return response.body.filter((item) => item.assignee === null && item.name === 'Develop the Target');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -10,7 +10,6 @@ const displayDate24Format = 'DD-MM-YYYY HH:mm';
 
 Cypress.Commands.add('login', (userName) => {
   cy.kcLogout();
-  console.log(Cypress.env('auth_realm'));
   cy.kcLogin(userName).as('tokens');
   cy.intercept('POST', `/auth/realms/${realm}/protocol/openid-connect/token`).as('token');
   cy.visit('/');

--- a/cypress_runner.js
+++ b/cypress_runner.js
@@ -27,6 +27,10 @@ const argv = yargs.options({
     describe: 'ExecutionEnvironment',
     default: 'local',
   },
+  formApiUrl: {
+    alias: 'f',
+    describe: 'Form API URL',
+  },
 
 }).help()
   .argv;
@@ -63,6 +67,7 @@ cypress.run({
   spec: argv.spec,
   env: {
     cerberusServiceUrl: argv.cerberusServiceUrl,
+    formApiUrl: argv.formApiUrl,
     configFile: argv.configFile,
   },
 }).then((results) => {

--- a/get_secrets.js
+++ b/get_secrets.js
@@ -25,8 +25,6 @@ if (!('AWS_REGION' in env)) {
 
 const environment = process.argv[2];
 
-console.log(environment);
-
 if (environment === 'dev') {
   env.TEST_SECRET_NAME = '/test/dev';
 } else if (environment === 'sit') {

--- a/get_secrets.js
+++ b/get_secrets.js
@@ -23,7 +23,15 @@ if (!('AWS_REGION' in env)) {
   env.AWS_REGION = 'eu-west-2';
 }
 
-if (!('TEST_SECRET_NAME' in env)) {
+const environment = process.argv[2];
+
+console.log(environment);
+
+if (environment === 'dev') {
+  env.TEST_SECRET_NAME = '/test/dev';
+} else if (environment === 'sit') {
+  env.TEST_SECRET_NAME = '/test/sit';
+} else {
   env.TEST_SECRET_NAME = '/test/local';
 }
 
@@ -76,9 +84,9 @@ getSecret().then((secret) => {
         console.log(err);
       } else {
         obj = JSON.parse(data);
-        obj.env.auth_base_url = auth.url;
         obj.env.auth_realm = auth.realm;
         obj.env.auth_client_id = auth.client;
+        obj.env.auth_base_url = auth.url;
         json = JSON.stringify(obj);
         fs.writeFileSync('cypress.json', json, { flag: 'w' });
       }

--- a/kube/job.yml
+++ b/kube/job.yml
@@ -24,6 +24,13 @@ spec:
                     secretKeyRef:
                       name: "{{ .NAME }}"
                       key: cerberus_workflow_service_url
+                - name: JOB_NAME
+                  value: {{.JOB_NAME}}
+                - name: FORM_API_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .NAME }}"
+                      key: form_api__url
                 - name: KUBE_NAMESPACE
                   valueFrom:
                     secretKeyRef:

--- a/kube/job.yml
+++ b/kube/job.yml
@@ -24,13 +24,11 @@ spec:
                     secretKeyRef:
                       name: "{{ .NAME }}"
                       key: cerberus_workflow_service_url
-                - name: JOB_NAME
-                  value: {{.JOB_NAME}}
                 - name: FORM_API_URL
                   valueFrom:
                     secretKeyRef:
                       name: "{{ .NAME }}"
-                      key: form_api__url
+                      key: form_api_url
                 - name: KUBE_NAMESPACE
                   valueFrom:
                     secretKeyRef:
@@ -86,6 +84,11 @@ spec:
                     secretKeyRef:
                       name: "{{ .NAME }}"
                       key: cypress_cache_folder
+                - name: TEST_ENV
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .NAME }}"
+                      key: test_env
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000

--- a/kube/secret.yml
+++ b/kube/secret.yml
@@ -18,3 +18,5 @@ data:
   aws_access_key_id: "{{.AWS_ACCESS_KEY_ID | b64enc}}"
   aws_secret_access_key: "{{.AWS_SECRET_ACCESS_KEY | b64enc}}"
   cerberus_workflow_service_url: "{{.CERBERUS_WORKFLOW_SERVICE_URL | b64enc}}"
+  form_api_url: "{{.FORM_API_URL | b64enc}}"
+  test_env: "{{.TEST_ENV | b64enc}}"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "webpack serve --mode=development",
     "test": "jest",
     "cypress:test:local": "cypress run",
-    "cypress:test:dev": "node get_secrets.js && cypress run --env configFile=dev",
+    "cypress:test:dev": "node get_secrets.js dev && cypress run --env configFile=dev",
     "cypress:test:sit": "node get_secrets.js sit && cypress run --env configFile=sit",
     "cypress:runner": "cypress open",
     "cypress:test:report": "node cypress_runner"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest",
     "cypress:test:local": "cypress run",
     "cypress:test:dev": "node get_secrets.js && cypress run --env configFile=dev",
+    "cypress:test:sit": "node get_secrets.js sit && cypress run --env configFile=sit",
     "cypress:runner": "cypress open",
     "cypress:test:report": "node cypress_runner"
   },

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,7 +3,7 @@
 runTestsAndGenerateReport()
 {
     echo "== Starting cypress tests =="
-    npm run cypress:test:report -- -b electron -c ${CERBERUS_WORKFLOW_SERVICE_URL} -e dev
+    npm run cypress:test:report -- -b electron -c ${CERBERUS_WORKFLOW_SERVICE_URL} -f ${FORM_API_URL} -e ${DEPLOY_ENV}
     TEST_RUN_STATUS=$?
      echo "######## TEST RUN STATUS : TEST_RUN_STATUS #######"
 }
@@ -11,7 +11,7 @@ runTestsAndGenerateReport()
 getSecrets()
 {
     mkdir -p cypress/fixtures/users
-    node get_secrets.js
+    node get_secrets.js ${DEPLOY_ENV}
 }
 
 setVariables()

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,7 +3,7 @@
 runTestsAndGenerateReport()
 {
     echo "== Starting cypress tests =="
-    npm run cypress:test:report -- -b electron -c ${CERBERUS_WORKFLOW_SERVICE_URL} -f ${FORM_API_URL} -e ${DEPLOY_ENV}
+    npm run cypress:test:report -- -b electron -c ${CERBERUS_WORKFLOW_SERVICE_URL} -f ${FORM_API_URL} -e ${TEST_ENV}
     TEST_RUN_STATUS=$?
      echo "######## TEST RUN STATUS : TEST_RUN_STATUS #######"
 }
@@ -11,7 +11,7 @@ runTestsAndGenerateReport()
 getSecrets()
 {
     mkdir -p cypress/fixtures/users
-    node get_secrets.js ${DEPLOY_ENV}
+    node get_secrets.js ${TEST_ENV}
 }
 
 setVariables()
@@ -40,10 +40,10 @@ createReportUrl()
 createSlackMessage()
 {
     if [[ ${TEST_RUN_STATUS} == 0 ]] && [[ ${REPORT_UPLOAD_STATUS} == 0 ]]; then
-        SLACK_TEST_STATUS=" Test Execution *Successful*"
+        SLACK_TEST_STATUS=" Test Execution *Successful* on ${TEST_ENV} environment"
         SLACK_COLOR="good"
     else
-        SLACK_TEST_STATUS=" Test Execution *Failed*"
+        SLACK_TEST_STATUS=" Test Execution *Failed* on ${TEST_ENV} environment"
         SLACK_COLOR="danger"
     fi
 
@@ -62,14 +62,14 @@ sendSlackMessage()
     curl -X POST --data-urlencode \
     "payload={
            \"channel\": \"#cop-test-report\",
-           \"username\": \"Cerberus Tests\",
+           \"username\": \"Cerberus Tests against ${TEST_ENV}\",
            \"attachments\":
                 [
 					{
 						\"fallback\": \"${SLACK_FALLBACK}\",
 						\"text\": \"${SLACK_TEXT}\",
 						\"color\": \"${SLACK_COLOR}\",
-						\"title\": \"Cerberus Test Report\",
+						\"title\": \"Cerberus Test Report for ${TEST_ENV} environment\",
 						\"title_link\": \"${REPORT_FULL_URL}\",
 						\"mrkdwn_in\": [\"text\", \"pretext\"]
 					}


### PR DESCRIPTION
## Description
CronJob added on kubernetes to run automation tests every 2 hour between 8am to 6pm. Results would be slacked to `cop-tests-report` channel.
Tests updated such that it would make sure there is a task before claiming / un-claiming a task. 

## To Test
ssh to `kubectl --context=acp-notprod_COP --namespace=cop-cerberus-sit`
run the following command
kubectl --context=acp-notprod_COP --namespace=cop-cerberus-sit get cronjobs
you should see the following job
`cerberus-functional-tests-sit`

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
