### PR TITLE
COP-7632: Setup cronJob to run automation tests on Staging environment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -335,6 +335,70 @@ steps:
     target:
       - sit
 
+- name: create_testjob_staging
+  pull: always
+  image: quay.io/ukhomeofficedigital/kd
+  commands:
+    - export CYPRESS_CACHE_FOLDER="~/.cache/Cypress"
+    - export AUTH_URL="$${PROTOCOL_HTTPS}$${SIT_KEYCLOAK_URL}"
+    - export NAME="cerberus-functional-tests-staging"
+    - export TEST_ENV="staging"
+    - kd --insecure-skip-tls-verify -f kube/secret.yml
+    - kd --insecure-skip-tls-verify -f kube/job.yml
+  environment:
+    AUTH_REALM:
+      from_secret: STAGING_KEYCLOAK_REALM
+    AUTH_CLIENT_ID:
+      from_secret: STAGING_CERBERUS_UI_SERVICE_KEYCLOAK_CLIENT_ID
+    AUTH_BASE_URL:
+      from_secret: STAGING_KEYCLOAK_URL
+    FORM_API_URL:
+      from_secret: STAGING_API_FORM_URL
+    CERBERUS_WORKFLOW_SERVICE_URL:
+      from_secret: STAGING_CERBERUS_SERVICE_URL
+    CERBERUS_SERVICE_URL:
+      from_secret: STAGING_CERBERUS_UI_SERVICE_URL
+    AWS_ACCESS_KEY_ID:
+      from_secret: STAGING_FORMIO_INT_TEST_SECRET_AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: STAGING_FORMIO_INT_TEST_SECRET_AWS_SECRET_ACCESS_KEY
+    PROTOCOL_HTTPS:
+      from_secret: PROTOCOL_HTTPS
+    REPORT_BASE_URL:
+      from_secret: TESTS_REPORT_BASE_URL
+    S3_ACCESS_KEY:
+      from_secret: TESTS_S3_ACCESS_KEY
+    S3_BUCKET_NAME:
+      from_secret: TESTS_S3_BUCKET_NAME
+    S3_SECRET_KEY:
+      from_secret: TESTS_S3_SECRET_KEY
+    SLACK_WEB_HOOK:
+      from_secret: TESTS_SLACK_WEBHOOK
+    TEST_SECRET_NAME:
+      from_secret: STAGING_FORMIO_INT_TEST_SECRET_NAME
+    CYPRESS_KEY:
+      from_secret: CYPRESS_KEY
+    CYPRESS_PROJECT_ID:
+      from_secret: CYPRESS_PROJECT_ID
+    KUBE_NAMESPACE:
+      from_secret: STAGING_KUBE_NAMESPACE_COP_CERBERUS
+    KUBE_SERVER:
+      from_secret: STAGING_KUBE_SERVER
+    KUBE_TOKEN:
+      from_secret: STAGING_CERBERUS_KUBE_TOKEN
+    CERBERUS_UI_NAME: cerberus-ui-service
+    CERBERUS_SERVICE_TEST_TAG: cron-${DRONE_COMMIT_SHA}
+    CRON_SCHEDULE: "\"10 10 * * 1-5\""
+    JOB_NAME: "\"cerberus-functional-tests-staging\""
+    TEST_ENV: staging
+  when:
+    branch:
+      - main
+    event:
+      - promote
+    target:
+      - staging
+
 - name: deploy_to_sit
   pull: if-not-exists
   image: quay.io/ukhomeofficedigital/kd

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ create a file called cypress.env.json on a root folder and include the following
    "auth_realm": "xxx",
    "auth_client_id": "xxx",
    "cerberusServiceUrl": "xxx",
-   "formApiUrl": "xxx"
+   "formApiUrl": "xxx",
+   "baseUrl": "xxx"
 }
 ```
 
@@ -109,7 +110,7 @@ npm run cypress:runner
 
 Running all tests using environment settings from a configuration file
 ```sh
-npm run cypress:runner -- --env configFile=dev
+npm run cypress:runner
 ```
 Once TestRunner launched, click on the interested spec inside folder cypress/integration/cerberus
 
@@ -134,9 +135,14 @@ Running specific test with chrome browser
 ```sh
 npm run cypress:test:local -- --browser chrome --spec cypress/integration/cerberus/task-management.spec.js
 ```
+
 Running All tests and generating mochawesome html report with screenshots
+run the command for specific environment to get the required baseUrl & keycloak authentication 
 ```sh
-npm run cypress:test:report -- -b chrome -c ${CERBERUS_WORKFLOW_SERVICE_URL} -e dev
+node get_secrets.js {dev, sit , staging}
+```
+```sh
+npm run cypress:test:report -- -b chrome -c ${CERBERUS_WORKFLOW_SERVICE_URL} -f ${FORM_API_URL}
 ```
 
 Running specific test and generating mochawesome html report with screenshots
@@ -147,7 +153,7 @@ npm run cypress:test:report -- -b chrome -s cypress/integration/cerberus/login.s
 Running all tests and generating mochawesome html report with screenshots using script
 export CERBERUS_WORKFLOW_SERVICE_URL=xxxxx
 export FORM_API_URL=xxxx
-export TEST_ENV= dev / sit
+export TEST_ENV= dev / sit / staging
 ```sh
 ./scripts/run_tests.sh
 ```

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "baseUrl": "http://localhost:8080",
   "env": {
     "userName": "cypressuser-cerberus@lodev.xyz"
   },

--- a/cypress/config/dev.json
+++ b/cypress/config/dev.json
@@ -1,6 +1,0 @@
-{
-  "baseUrl": "https://www.dev.cerberus.cop.homeoffice.gov.uk",
-  "env": {
-    "envname": "development"
-  }
-}

--- a/cypress/config/sit.json
+++ b/cypress/config/sit.json
@@ -1,6 +1,0 @@
-{
-  "baseUrl": "https://www.sit.cerberus.cop.homeoffice.gov.uk",
-  "env": {
-    "envname": "sit"
-  }
-}

--- a/cypress/config/staging.json
+++ b/cypress/config/staging.json
@@ -1,0 +1,6 @@
+{
+  "baseUrl": "https://www.staging.cerberus.cop.homeoffice.gov.uk",
+  "env": {
+    "envname": "staging"
+  }
+}

--- a/cypress/config/staging.json
+++ b/cypress/config/staging.json
@@ -1,6 +1,0 @@
-{
-  "baseUrl": "https://www.staging.cerberus.cop.homeoffice.gov.uk",
-  "env": {
-    "envname": "staging"
-  }
-}

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -123,4 +123,9 @@ describe('Create task with different payload from Cerberus', () => {
       });
     });
   });
+
+  after(() => {
+    cy.contains('Sign out').click();
+    cy.get('#kc-page-title').should('contain.text', 'Log In');
+  });
 });

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -126,6 +126,6 @@ describe('Create task with different payload from Cerberus', () => {
 
   after(() => {
     cy.contains('Sign out').click();
-    cy.get('#kc-page-title').should('contain.text', 'Log In');
+    cy.url().should('include', Cypress.env('auth_realm'));
   });
 });

--- a/cypress/integration/cerberus/formapi-404.spec.js
+++ b/cypress/integration/cerberus/formapi-404.spec.js
@@ -48,6 +48,6 @@ describe('Cerberus-UI handles the exception if Form API server is unresponsive',
 
   after(() => {
     cy.contains('Sign out').click();
-    cy.get('#kc-page-title').should('contain.text', 'Log In');
+    cy.url().should('include', Cypress.env('auth_realm'));
   });
 });

--- a/cypress/integration/cerberus/formapi-404.spec.js
+++ b/cypress/integration/cerberus/formapi-404.spec.js
@@ -45,4 +45,9 @@ describe('Cerberus-UI handles the exception if Form API server is unresponsive',
 
     cy.get('.govuk-error-summary a').eq(0).should('contain.text', 'Request failed with status code 404');
   });
+
+  after(() => {
+    cy.contains('Sign out').click();
+    cy.get('#kc-page-title').should('contain.text', 'Log In');
+  });
 });

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -111,4 +111,9 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.get('.formio-component-note textarea').should('not.exist');
   });
+
+  after(() => {
+    cy.contains('Sign out').click();
+    cy.get('#kc-page-title').should('contain.text', 'Log In');
+  });
 });

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -114,6 +114,6 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
   after(() => {
     cy.contains('Sign out').click();
-    cy.get('#kc-page-title').should('contain.text', 'Log In');
+    cy.url().should('include', Cypress.env('auth_realm'));
   });
 });

--- a/cypress/integration/cerberus/login.spec.js
+++ b/cypress/integration/cerberus/login.spec.js
@@ -17,6 +17,6 @@ describe('Log-in to cerberus UI', () => {
 
   after(() => {
     cy.contains('Sign out').click();
-    cy.get('#kc-page-title').should('contain.text', 'Log In');
+    cy.url().should('include', Cypress.env('auth_realm'));
   });
 });

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -410,6 +410,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   after(() => {
     cy.contains('Sign out').click();
-    cy.get('#kc-page-title').should('contain.text', 'Log In');
+    cy.url().should('include', Cypress.env('auth_realm'));
   });
 });

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -132,6 +132,6 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
 
   after(() => {
     cy.contains('Sign out').click();
-    cy.get('#kc-page-title').should('contain.text', 'Log In');
+    cy.url().should('include', Cypress.env('auth_realm'));
   });
 });

--- a/cypress_runner.js
+++ b/cypress_runner.js
@@ -22,11 +22,6 @@ const argv = yargs.options({
     alias: 'c',
     describe: 'Cerberus Service URL',
   },
-  configFile: {
-    alias: 'e',
-    describe: 'ExecutionEnvironment',
-    default: 'local',
-  },
   formApiUrl: {
     alias: 'f',
     describe: 'Form API URL',
@@ -68,7 +63,6 @@ cypress.run({
   env: {
     cerberusServiceUrl: argv.cerberusServiceUrl,
     formApiUrl: argv.formApiUrl,
-    configFile: argv.configFile,
   },
 }).then((results) => {
   const reporterOptions = {

--- a/get_secrets.js
+++ b/get_secrets.js
@@ -29,6 +29,8 @@ if (environment === 'dev') {
   env.TEST_SECRET_NAME = '/test/dev';
 } else if (environment === 'sit') {
   env.TEST_SECRET_NAME = '/test/sit';
+} else if (environment === 'staging') {
+  env.TEST_SECRET_NAME = '/test/staging';
 } else {
   env.TEST_SECRET_NAME = '/test/local';
 }

--- a/get_secrets.js
+++ b/get_secrets.js
@@ -32,7 +32,7 @@ if (environment === 'dev') {
 } else if (environment === 'staging') {
   env.TEST_SECRET_NAME = '/test/staging';
 } else {
-  env.TEST_SECRET_NAME = '/test/local';
+  env.TEST_SECRET_NAME = '/test/dev';
 }
 
 async function getSecret() {
@@ -84,6 +84,11 @@ getSecret().then((secret) => {
         console.log(err);
       } else {
         obj = JSON.parse(data);
+        if(environment !== 'local') {
+          obj.baseUrl = secret.services.cerberus.base_url;
+        } else {
+          obj.baseUrl = 'http://localhost:8080';
+        }
         obj.env.auth_realm = auth.realm;
         obj.env.auth_client_id = auth.client;
         obj.env.auth_base_url = auth.url;

--- a/get_secrets.js
+++ b/get_secrets.js
@@ -84,7 +84,7 @@ getSecret().then((secret) => {
         console.log(err);
       } else {
         obj = JSON.parse(data);
-        if(environment !== 'local') {
+        if (environment !== 'local') {
           obj.baseUrl = secret.services.cerberus.base_url;
         } else {
           obj.baseUrl = 'http://localhost:8080';

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "lint": "eslint -f table --ext=js,jsx",
     "start": "webpack serve --mode=development",
     "test": "jest",
-    "cypress:test:local": "cypress run",
-    "cypress:test:dev": "node get_secrets.js dev && cypress run --env configFile=dev",
-    "cypress:test:sit": "node get_secrets.js sit && cypress run --env configFile=sit",
+    "cypress:test:local": "node get_secrets.js local && cypress run",
+    "cypress:test:dev": "node get_secrets.js dev && cypress run",
+    "cypress:test:sit": "node get_secrets.js sit && cypress run",
+    "cypress:test:staging": "node get_secrets.js staging && cypress run",
     "cypress:runner": "cypress open",
     "cypress:test:report": "node cypress_runner"
   },


### PR DESCRIPTION
## Description
Setup CronJob to run Automation functional tests on Staging environment once in a day. 
Results would be slacked to `cop-tests-report` channel.
Tests updated with `after` step to log out  after every spec completed.

## To Test
It needs access to cop-cerberus-staging namespace
ssh to kubectl --context=acp-prod_COP --namespace=cop-cerberus-staging
run the following command
kubectl --context=acp-prod_COP --namespace=cop-cerberus-staging get cronjobs
you should see the following job
cerberus-functional-tests-staging

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
