### PR TITLE
COP-7676 Display passengers

### DIFF
--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -25,6 +25,28 @@ const formatField = (fieldType, content) => {
   }
 };
 
+
+const fieldContent = (fieldSet) => {
+  if (fieldSet.hasChildSet === false) {
+    return (
+      fieldSet.contents.map(({ fieldName, content, type }, i) => {
+        return (
+          <div className="govuk-summary-list__row" key={i}>
+            <dt className="govuk-summary-list__key">{fieldName}</dt>
+            <dd className="govuk-summary-list__value">{formatField(type, content)}</dd>
+          </div>
+        );
+      })
+    );
+  } if (fieldSet.hasChildSet === true) {
+    return (
+      fieldSet.childSets.map((obj) => {
+        return (fieldContent(obj));
+      })
+    );
+  }
+};
+
 const TaskVersions = ({ taskVersions }) => {
   /* There can be multiple versions of the data
   * We need to display each version
@@ -42,19 +64,12 @@ const TaskVersions = ({ taskVersions }) => {
           const booking = version.find((fieldset) => { return fieldset.fieldSetName === 'Booking'; }) || null;
           const bookingDate = booking?.contents.find((field) => { return field.fieldName === 'Date and time'; }) || null;
           const versionNumber = taskVersions.length - index;
-          const childrenSection = version.map((field) => {
+          const detailSection = version.map((field) => {
             return (
               <div key={field.fieldSetName}>
                 <h2 className="govuk-heading-m">{field.fieldSetName}</h2>
                 <dl className="govuk-summary-list govuk-!-margin-bottom-9">
-                  {field.contents.map(({ fieldName, content, type }, i) => {
-                    return (
-                      <div className="govuk-summary-list__row" key={i}>
-                        <dt className="govuk-summary-list__key">{fieldName}</dt>
-                        <dd className="govuk-summary-list__value">{formatField(type, content)}</dd>
-                      </div>
-                    );
-                  })}
+                  {fieldContent(field)}
                 </dl>
               </div>
             );
@@ -75,7 +90,7 @@ const TaskVersions = ({ taskVersions }) => {
                   </div>
                 </>
               ),
-              children: childrenSection,
+              children: detailSection,
             }
           );
         })

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -25,15 +25,26 @@ const formatField = (fieldType, content) => {
   }
 };
 
-
 const fieldContent = (fieldSet) => {
+  /*
+  * When there are multiple entries for a section
+  * e.g. 'Passengers' can have multiple passengers
+  * the 'hasChildSet' flag will be set to true
+  * which indicates we need to map out the childSet contents
+  * and not the parent contents
+  */
   if (fieldSet.hasChildSet === false) {
     return (
       fieldSet.contents.map(({ fieldName, content, type }, i) => {
         return (
           <div className="govuk-summary-list__row" key={i}>
-            <dt className="govuk-summary-list__key">{fieldName}</dt>
-            <dd className="govuk-summary-list__value">{formatField(type, content)}</dd>
+            { type !== 'HIDDEN'
+            && (
+            <>
+              <dt className="govuk-summary-list__key">{fieldName}</dt>
+              <dd className="govuk-summary-list__value">{formatField(type, content)}</dd>
+            </>
+            )}
           </div>
         );
       })
@@ -48,7 +59,8 @@ const fieldContent = (fieldSet) => {
 };
 
 const TaskVersions = ({ taskVersions }) => {
-  /* There can be multiple versions of the data
+  /*
+  * There can be multiple versions of the data
   * We need to display each version
   * We currently get the data as an array of unnamed objects
   * That contain an array of unnamed objects


### PR DESCRIPTION
## Description

The data structure for Passengers has been updated and now requires us to map out the childSets.
This code handles it for passengers, and also for matched selectors as it uses the same structure.

## To Test

**scenario 1**

- create an unaccompanied target
- view target in cerberus UI
- task details section should populate data as normal

**scenario 2**

- create an accompanied target with 0 passenger
- view target in cerberus UI
- task details section should populate data as normal, with a driver section and no passenger details

**scenario 3**

- create an accompanied target with 2 passengers
- view target in cerberus UI
- task details section should populate data as normal, with a driver section and a passenger section with two passengers populated

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
