### PR TITLE
COP-5748: Update tests to URL with businessKey instead processInstanceId

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ env        context               namespace                secretname            
 -------|--------------------|-----------------------|------------------------------------|
 Dev    | acp-notprod_COP    |  cop-cerberus-dev     |   cerberus-functional-tests        |
 Sit    | acp-notprod_COP    |  cop-cerberus-sit     |   cerberus-functional-tests-sit    |
-Staging| acp-notprod_COP    |  cop-cerberus-staging |   cerberus-functional-tests-staging|
+Staging| acp-prod_COP       |  cop-cerberus-staging |   cerberus-functional-tests-staging|
 ```
 
 #### Running cypress test runner

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -9,9 +9,7 @@ describe('Create task with different payload from Cerberus', () => {
     cy.fixture('tasks-hazardous-cargo.json').then((task) => {
       cy.postTasks(task, 'AUTOTEST-HAZARDOUS').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -22,9 +20,7 @@ describe('Create task with different payload from Cerberus', () => {
       console.log(task);
       cy.postTasks(task, 'AUTOTEST-ORG-NULL').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -37,9 +33,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, 'AUTOTEST-TOURIST').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
       cy.wait(2000);
       cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').then((value) => {
@@ -61,9 +55,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, 'AUTOTEST-TOURIST-RBT-SBT').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -76,9 +68,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, 'AUTOTEST-TOURIST-SBT').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -87,9 +77,7 @@ describe('Create task with different payload from Cerberus', () => {
     cy.fixture('RoRo-Accompanied-Freight.json').then((task) => {
       cy.postTasks(task, 'AUTOTEST-RoRo-ACC').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -102,9 +90,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, 'AUTOTEST-RoRo-ACC-RBT-SBT').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -117,9 +103,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, 'AUTOTEST-RoRo-ACC-SBT').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -132,9 +116,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, 'AUTOTEST-RoRo-UNACC-SBT').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });
@@ -147,9 +129,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, 'AUTOTEST-RoRo-UNACC-RBT-SBT').then((response) => {
         cy.wait(4000);
-        cy.getProcessInstanceId(`${response.businessKey}`).then((processInstanceId) => {
-          cy.checkTaskDisplayed(processInstanceId, `${response.businessKey}`);
-        });
+        cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
   });

--- a/cypress/integration/cerberus/formapi-404.spec.js
+++ b/cypress/integration/cerberus/formapi-404.spec.js
@@ -19,13 +19,15 @@ describe('Cerberus-UI handles the exception if Form API server is unresponsive',
 
     cy.wait(4000);
 
-    cy.getTasksByPartialBusinessKey(`${taskName}`).then((tasks) => {
+    cy.getTasksByBusinessKey(`${taskName}`).then((tasks) => {
       const processInstanceId = tasks.map(((item) => item.processInstanceId));
       expect(processInstanceId.length).to.not.equal(0);
       cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-      cy.visit(`/tasks/${processInstanceId[0]}`);
-      cy.wait('@tasksDetails').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
+      cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+        cy.visit(`/tasks/${businessKey}`);
+        cy.wait('@tasksDetails').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
       });
     });
 

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -20,11 +20,11 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.fixture('tasks.json').then((task) => {
       cy.postTasks(task, 'CERB-AUTOTEST').then((taskResponse) => {
         cy.wait(4000);
-        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+        cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           const processInstanceId = tasks.map(((item) => item.processInstanceId));
           expect(processInstanceId.length).to.not.equal(0);
           cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-          cy.visit(`/tasks/${processInstanceId[0]}`);
+          cy.visit(`/tasks/${taskResponse.businessKey}`);
           cy.wait('@tasksDetails').then(({ response }) => {
             expect(response.statusCode).to.equal(200);
           });
@@ -71,9 +71,11 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       const processInstanceId = tasks.map((item) => item.processInstanceId);
       expect(processInstanceId.length).to.not.equal(0);
       cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-      cy.visit(`/tasks/${processInstanceId[0]}`);
-      cy.wait('@tasksDetails').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
+      cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+        cy.visit(`/tasks/${businessKey}`);
+        cy.wait('@tasksDetails').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
       });
     });
 
@@ -88,8 +90,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.getTasksAssignedToOtherUsers().then((tasks) => {
       const processInstanceId = tasks.map((item) => item.processInstanceId);
       expect(processInstanceId.length).to.not.equal(0);
-      let index = 0;
-      cy.navigateToTaskDetails(processInstanceId, index);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+        cy.visit(`/tasks/${businessKey}`);
+        cy.wait('@tasksDetails').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+      });
     });
 
     cy.get('button.link-button').should('not.exist');
@@ -107,13 +114,15 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.fixture('tasks.json').then((task) => {
       cy.postTasks(task, 'CERB-AUTOTEST').then((taskResponse) => {
         cy.wait(4000);
-        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+        cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           const processInstanceId = tasks.map(((item) => item.processInstanceId));
           expect(processInstanceId.length).to.not.equal(0);
           cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-          cy.visit(`/tasks/${processInstanceId[0]}`);
-          cy.wait('@tasksDetails').then(({ response }) => {
-            expect(response.statusCode).to.equal(200);
+          cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+            cy.visit(`/tasks/${businessKey}`);
+            cy.wait('@tasksDetails').then(({ response }) => {
+              expect(response.statusCode).to.equal(200);
+            });
           });
         });
       });
@@ -166,8 +175,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       cy.getTasksAssignedToMe().then((tasks) => {
         const processInstanceId = tasks.map((item) => item.processInstanceId);
         expect(processInstanceId.length).to.not.equal(0);
-        let index = 0;
-        cy.navigateToTaskDetails(processInstanceId, index);
+        cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+        cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+          cy.visit(`/tasks/${businessKey}`);
+          cy.wait('@tasksDetails').then(({ response }) => {
+            expect(response.statusCode).to.equal(200);
+          });
+        });
       });
 
       cy.get('.task-actions--buttons button').each(($items, index) => {
@@ -181,9 +195,11 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       const processInstanceId = tasks.map(((item) => item.processInstanceId));
       expect(processInstanceId.length).to.not.equal(0);
       cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-      cy.visit(`/tasks/${processInstanceId[0]}`);
-      cy.wait('@tasksDetails').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
+      cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+        cy.visit(`/tasks/${businessKey}`);
+        cy.wait('@tasksDetails').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
       });
     });
 
@@ -196,8 +212,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.getTasksAssignedToMe().then((tasks) => {
       const processInstanceId = tasks.map((item) => item.processInstanceId);
       expect(processInstanceId.length).to.not.equal(0);
-      let index = 0;
-      cy.navigateToTaskDetails(processInstanceId, index);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+        cy.visit(`/tasks/${businessKey}`);
+        cy.wait('@tasksDetails').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+      });
     });
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim').click();
@@ -220,13 +241,15 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.fixture('tasks.json').then((task) => {
       cy.postTasks(task, 'CERB-AUTOTEST-ASSESSMENT').then((taskResponse) => {
         cy.wait(4000);
-        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+        cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           const processInstanceId = tasks.map(((item) => item.processInstanceId));
           expect(processInstanceId.length).to.not.equal(0);
           cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-          cy.visit(`/tasks/${processInstanceId[0]}`);
-          cy.wait('@tasksDetails').then(({ response }) => {
-            expect(response.statusCode).to.equal(200);
+          cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+            cy.visit(`/tasks/${businessKey}`);
+            cy.wait('@tasksDetails').then(({ response }) => {
+              expect(response.statusCode).to.equal(200);
+            });
           });
         });
       });
@@ -270,13 +293,15 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.fixture('tasks.json').then((task) => {
       cy.postTasks(task, 'CERB-AUTOTEST-DISMISS').then((taskResponse) => {
         cy.wait(4000);
-        cy.getTasksByPartialBusinessKey(taskResponse.businessKey).then((tasks) => {
+        cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           const processInstanceId = tasks.map(((item) => item.processInstanceId));
           expect(processInstanceId.length).to.not.equal(0);
           cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
-          cy.visit(`/tasks/${processInstanceId[0]}`);
-          cy.wait('@tasksDetails').then(({ response }) => {
-            expect(response.statusCode).to.equal(200);
+          cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+            cy.visit(`/tasks/${businessKey}`);
+            cy.wait('@tasksDetails').then(({ response }) => {
+              expect(response.statusCode).to.equal(200);
+            });
           });
         });
       });
@@ -340,8 +365,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.getTasksAssignedToMe().then((tasks) => {
       const processInstanceId = tasks.map((item) => item.processInstanceId);
       expect(processInstanceId.length).to.not.equal(0);
-      let index = processInstanceId.length - 1;
-      cy.navigateToTaskDetails(processInstanceId, index);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+        cy.visit(`/tasks/${businessKey}`);
+        cy.wait('@tasksDetails').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+      });
     });
 
     cy.get('.govuk-caption-xl').invoke('text').as('taskName');
@@ -378,8 +408,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.getTasksAssignedToMe().then((tasks) => {
       const processInstanceId = tasks.map((item) => item.processInstanceId);
       expect(processInstanceId.length).to.not.equal(0);
-      let index = 0;
-      cy.navigateToTaskDetails(processInstanceId, index);
+      cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+      cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
+        cy.visit(`/tasks/${businessKey}`);
+        cy.wait('@tasksDetails').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+      });
     });
 
     cy.get('.govuk-caption-xl').invoke('text').as('taskName');

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -3,16 +3,6 @@
 
 describe('Render tasks from Camunda and manage them on task management Page', () => {
   const MAX_TASK_PER_PAGE = 10;
-  let taskName;
-
-  before(() => {
-    cy.login(Cypress.env('userName'));
-    cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'CERB-AUTOTEST').then((response) => {
-        taskName = response.businessKey;
-      });
-    });
-  });
 
   beforeEach(() => {
     cy.login(Cypress.env('userName'));
@@ -98,24 +88,27 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
 
   it('Should Claim & Unclaim a task Successfully from task management page', () => {
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
-
     const nextPage = 'a[data-test="next"]';
 
-    if (Cypress.$(nextPage).length > 0) {
-      cy.findTaskInAllThePages(`${taskName}`, 'Claim').then((returnvalue) => {
-        expect(returnvalue).to.equal(true);
-        cy.wait('@claim').then(({ response }) => {
-          expect(response.statusCode).to.equal(204);
-        });
+    cy.fixture('tasks.json').then((task) => {
+      cy.postTasks(task, 'AUTOTEST-').then((taskResponse) => {
+        if (Cypress.$(nextPage).length > 0) {
+          cy.findTaskInAllThePages(`${taskResponse.businessKey}`, 'Claim').then((returnvalue) => {
+            expect(returnvalue).to.equal(true);
+            cy.wait('@claim').then(({ response }) => {
+              expect(response.statusCode).to.equal(204);
+            });
+          });
+        } else {
+          cy.findTaskInSinglePage(`${taskResponse.businessKey}`, 'Claim').then((returnvalue) => {
+            expect(returnvalue).to.equal(true);
+            cy.wait('@claim').then(({ response }) => {
+              expect(response.statusCode).to.equal(204);
+            });
+          });
+        }
       });
-    } else {
-      cy.findTaskInSinglePage(`${taskName}`, 'Claim').then((returnvalue) => {
-        expect(returnvalue).to.equal(true);
-        cy.wait('@claim').then(({ response }) => {
-          expect(response.statusCode).to.equal(204);
-        });
-      });
-    }
+    });
 
     cy.wait(2000);
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -79,18 +79,6 @@ Cypress.Commands.add('getTasksAssignedToMe', () => {
   });
 });
 
-Cypress.Commands.add('navigateToTaskDetails', (processInstanceId, index) => {
-  cy.get('a[href="#in-progress"]').click();
-
-  cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[index]}`).as('tasksDetails');
-  cy.visit(`/tasks/${processInstanceId[index]}`);
-  cy.wait('@tasksDetails').then(({ response }) => {
-    expect(response.statusCode).to.equal(200);
-  });
-
-  cy.wait(2000);
-});
-
 Cypress.Commands.add('claimTask', () => {
   cy.intercept('POST', '/camunda/task/*/claim').as('claim');
 
@@ -219,7 +207,6 @@ Cypress.Commands.add('postTasks', (task, name) => {
     headers: { Authorization: `Bearer ${token}` },
     body: task,
   }).then((response) => {
-    console.log('response', response);
     expect(response.status).to.eq(200);
     expect(response.body.businessKey).to.eq(task.businessKey);
     return response.body;
@@ -271,8 +258,8 @@ Cypress.Commands.add('getProcessInstanceId', (businessKey) => {
   });
 });
 
-Cypress.Commands.add('checkTaskDisplayed', (processInstanceId, businessKey) => {
-  cy.visit(`/tasks/${processInstanceId}`);
+Cypress.Commands.add('checkTaskDisplayed', (businessKey) => {
+  cy.visit(`/tasks/${businessKey}`);
   cy.get('.govuk-caption-xl').should('have.text', businessKey);
 });
 
@@ -312,7 +299,7 @@ Cypress.Commands.add('findTaskInSinglePage', (taskName, action) => {
   });
 });
 
-Cypress.Commands.add('getTasksByPartialBusinessKey', (businessKey) => {
+Cypress.Commands.add('getTasksByBusinessKey', (businessKey) => {
   cy.request({
     method: 'GET',
     url: `https://${cerberusServiceUrl}/camunda/engine-rest/task?processInstanceBusinessKey=${businessKey}`,
@@ -320,5 +307,16 @@ Cypress.Commands.add('getTasksByPartialBusinessKey', (businessKey) => {
   }).then((response) => {
     expect(response.status).to.eq(200);
     return response.body.filter((item) => item.assignee === null && item.name === 'Develop the Target');
+  });
+});
+
+Cypress.Commands.add('getBusinessKeyByProcessInstanceId', (processInstanceId) => {
+  cy.request({
+    method: 'GET',
+    url: `https://${cerberusServiceUrl}/camunda/engine-rest/process-instance/${processInstanceId}`,
+    headers: { Authorization: `Bearer ${token}` },
+  }).then((response) => {
+    expect(response.status).to.eq(200);
+    return response.body.businessKey;
   });
 });


### PR DESCRIPTION
## Description
Tests are updated to use the URL with businessKey to navigate to taskDetailsPage.
README updated with correct context name for staging. 

## To Test
Please refer the README for the context, namespace and secretName for different env
./scripts/env-setup.sh {context} {namespace} {secretName}
update cypress.env.json with respective url for
"cerberusServiceUrl": "xxx",
"formApiUrl": "xxx",

npm run cypress:test:report -- -b electron

check the report mochawesome-report/mochawesome.html for status. 

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
