### PR TITLE
Escape business key in the URL

### DIFF
--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -119,11 +119,12 @@ const TaskDetailsPage = () => {
         * If this returns an empty array, there are no in flight processes, therefore it
         * is a finished process instance and requires a history/process-instance call
         */
+        const decodedBusinessKey = decodeURIComponent(businessKey);
         let processInstanceResponse = await camundaClient.get(
           '/process-instance',
           {
             params: {
-              businessKey,
+              businessKey: decodedBusinessKey,
               processDefinitionKeyNotIn: 'raiseMovement,noteSubmissionWrapper',
             },
           },
@@ -133,7 +134,7 @@ const TaskDetailsPage = () => {
             '/history/process-instance',
             {
               params: {
-                processInstanceBusinessKey: businessKey,
+                processInstanceBusinessKey: decodedBusinessKey,
                 processDefinitionKeyNotIn: 'raiseMovement,noteSubmissionWrapper',
               },
             },

--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -273,7 +273,7 @@ const TaskDetailsPage = () => {
         <>
           <div className="govuk-grid-row govuk-!-padding-bottom-9">
             <div className="govuk-grid-column-one-half">
-              <span className="govuk-caption-xl">{taskVersions[0].taskSummary?.businessKey}</span>
+              <span className="govuk-caption-xl">{businessKey}</span>
               <h1 className="govuk-heading-xl govuk-!-margin-bottom-0">Task details</h1>
               {targetStatus.toUpperCase() === TASK_STATUS_NEW.toUpperCase() && (
                 <p className="govuk-body">

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -188,8 +188,7 @@ const TasksTab = ({ taskStatus, setError }) => {
       {!isLoading && targetTasks.length > 0 && targetTasks.map((target) => {
         const formattedData = formatTaskData(target);
         const passengers = target.people?.filter(({ role }) => role === 'PASSENGER') || [];
-        const regex = /\//g;
-        const escapedBusinessKey = target.businessKey.replace(regex, '%2F');
+        const escapedBusinessKey = encodeURIComponent(target.businessKey);
 
         return (
           <section className="task-list--item" key={target.businessKey}>

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -199,7 +199,7 @@ const TasksTab = ({ taskStatus, setError }) => {
                   <Link
                     className="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold"
                     to={`/tasks/${escapedBusinessKey}`}
-                  >{target.businessKey}
+                  >{escapedBusinessKey}
                   </Link>
                 </h3>
                 <h4 className="govuk-heading-m task-sub-heading govuk-!-font-weight-regular">

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -188,6 +188,8 @@ const TasksTab = ({ taskStatus, setError }) => {
       {!isLoading && targetTasks.length > 0 && targetTasks.map((target) => {
         const formattedData = formatTaskData(target);
         const passengers = target.people?.filter(({ role }) => role === 'PASSENGER') || [];
+        const regex = /\//g;
+        const escapedBusinessKey = target.businessKey.replace(regex, '%2F');
 
         return (
           <section className="task-list--item" key={target.businessKey}>
@@ -196,7 +198,7 @@ const TasksTab = ({ taskStatus, setError }) => {
                 <h3 className="govuk-heading-m task-heading">
                   <Link
                     className="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold"
-                    to={`/tasks/${target.businessKey}`}
+                    to={`/tasks/${escapedBusinessKey}`}
                   >{target.businessKey}
                   </Link>
                 </h3>
@@ -212,7 +214,7 @@ const TasksTab = ({ taskStatus, setError }) => {
                     assignee={target.assignee}
                     taskId={target.id}
                     setError={setError}
-                    businessKey={target.businessKey}
+                    businessKey={escapedBusinessKey}
                   />
                   )}
               </div>

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -143,9 +143,9 @@ describe('TaskListPage', () => {
       ])
       .onGet('/variable-instance')
       .reply(200, [
-        { processInstanceId: '123', type: 'Json', value: '{"mode":"TestValue"}' },
-        { processInstanceId: '456', type: 'Json', value: '{"mode":"TestValue"}' },
-        { processInstanceId: '789', type: 'Json', value: '{"mode":"TestValue"}' },
+        { processInstanceId: '123', type: 'Json', value: '{"mode":"TestValue","businessKey":"abc"}' },
+        { processInstanceId: '456', type: 'Json', value: '{"mode":"TestValue","businessKey":"def"}' },
+        { processInstanceId: '789', type: 'Json', value: '{"mode":"TestValue","businessKey":"ghi"}' },
       ]);
 
     await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
@@ -165,9 +165,9 @@ describe('TaskListPage', () => {
       ])
       .onGet('/variable-instance')
       .reply(200, [
-        { processInstanceId: '123', type: 'Json', value: '{"mode":"TestValue"}' },
-        { processInstanceId: '456', type: 'Json', value: '{"mode":"TestValue"}' },
-        { processInstanceId: '789', type: 'Json', value: '{"mode":"TestValue"}' },
+        { processInstanceId: '123', type: 'Json', value: '{"mode":"TestValue","businessKey":"abc"}' },
+        { processInstanceId: '456', type: 'Json', value: '{"mode":"TestValue","businessKey":"def"}' },
+        { processInstanceId: '789', type: 'Json', value: '{"mode":"TestValue","businessKey":"ghi"}' },
       ]);
 
     await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -78,25 +78,25 @@ describe('TaskListPage', () => {
       ])
       .onGet('/variable-instance')
       .reply(200, [
-        { processInstanceId: '123', type: 'Json', value: '{"businessKey":"abc"}' },
-        { processInstanceId: '456', type: 'Json', value: '{"businessKey":"def"}' },
+        { processInstanceId: '123', type: 'Json', value: '{"businessKey":"business:key=a/b/c"}' },
+        { processInstanceId: '456', type: 'Json', value: '{"businessKey":"business:key=d/e/f"}' },
         { processInstanceId: '789', type: 'Json', value: '{"businessKey":"ghi"}' },
       ]);
 
     await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
 
-    await waitFor(() => expect(screen.getByRole('link', { name: /abc/i }).href).toBe(`${envUrl}/tasks/abc`));
-    await waitFor(() => expect(screen.getByRole('link', { name: /def/i }).href).toBe(`${envUrl}/tasks/def`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Da%2Fb%2Fc/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Da%2Fb%2Fc`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Dd%2Fe%2Ff/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Dd%2Fe%2Ff`));
     await waitFor(() => expect(screen.getByRole('link', { name: /ghi/i }).href).toBe(`${envUrl}/tasks/ghi`));
 
     fireEvent.click(screen.getByRole('link', { name: /Target issued/i }));
-    await waitFor(() => expect(screen.getByRole('link', { name: /abc/i }).href).toBe(`${envUrl}/tasks/abc`));
-    await waitFor(() => expect(screen.getByRole('link', { name: /def/i }).href).toBe(`${envUrl}/tasks/def`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Da%2Fb%2Fc/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Da%2Fb%2Fc`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Dd%2Fe%2Ff/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Dd%2Fe%2Ff`));
     await waitFor(() => expect(screen.getByRole('link', { name: /ghi/i }).href).toBe(`${envUrl}/tasks/ghi`));
 
     fireEvent.click(screen.getByRole('link', { name: /In progress/i }));
-    await waitFor(() => expect(screen.getByRole('link', { name: /abc/i }).href).toBe(`${envUrl}/tasks/abc`));
-    await waitFor(() => expect(screen.getByRole('link', { name: /def/i }).href).toBe(`${envUrl}/tasks/def`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Da%2Fb%2Fc/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Da%2Fb%2Fc`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Dd%2Fe%2Ff/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Dd%2Fe%2Ff`));
     await waitFor(() => expect(screen.getByRole('link', { name: /ghi/i }).href).toBe(`${envUrl}/tasks/ghi`));
   });
 
@@ -118,16 +118,16 @@ describe('TaskListPage', () => {
       ])
       .onGet('/history/variable-instance')
       .reply(200, [
-        { processInstanceId: '123', type: 'Json', value: '{"businessKey":"abc"}' },
-        { processInstanceId: '456', type: 'Json', value: '{"businessKey":"def"}' },
+        { processInstanceId: '123', type: 'Json', value: '{"businessKey":"business:key=a/b/c"}' },
+        { processInstanceId: '456', type: 'Json', value: '{"businessKey":"business:key=d/e/f"}' },
         { processInstanceId: '789', type: 'Json', value: '{"businessKey":"ghi"}' },
       ]);
 
     await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
 
     fireEvent.click(screen.getByRole('link', { name: /Complete/i }));
-    await waitFor(() => expect(screen.getByRole('link', { name: /abc/i }).href).toBe(`${envUrl}/tasks/abc`));
-    await waitFor(() => expect(screen.getByRole('link', { name: /def/i }).href).toBe(`${envUrl}/tasks/def`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Da%2Fb%2Fc/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Da%2Fb%2Fc`));
+    await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Dd%2Fe%2Ff/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Dd%2Fe%2Ff`));
     await waitFor(() => expect(screen.getByRole('link', { name: /ghi/i }).href).toBe(`${envUrl}/tasks/ghi`));
   });
 


### PR DESCRIPTION
## Description
The business key contains forward slashes causing the single target page to not render anything. This PR encodes the business key to UTF-8 by replacing forward slashes with `%2F` allowing the user to use the business key (escaped) in the url. As well as this, by using encodeURIComponent (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) it escapes the whole business key
## To Test
- Pull and run natively
- Post a target with a business and movement id containing forward slashes
- Search task list for target
- *The target should have an escaped business key rendered*
- Click on target
- *It should render as normal*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
