### PR TITLE
COP-7637 Update date formatting position so it formats date correctly

### DIFF
--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -95,7 +95,7 @@ const TaskVersions = ({ taskVersions }) => {
               summary: (
                 <>
                   <div className="task-versions--left">
-                    <div className="govuk-caption-m">{dayjs(bookingDate?.bookingDateTime || null).format(LONG_DATE_FORMAT)}</div>
+                    <div className="govuk-caption-m">{dayjs(bookingDate?.bookingDateTime).format(LONG_DATE_FORMAT) || null}</div>
                   </div>
                   <div className="task-versions--right">
                     <ul className="govuk-list">


### PR DESCRIPTION
## Description
The date under the version title on the /tasks/id page was always showing as `invalid date`, the position of the `.format()` was incorrect and causing this

## To Test

- Open a Cerberus task
- Under the version number you should see a date format of `DD MMM YYYY at HH:mm`


## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
