### PR TITLE
Delete only one day older tasks & improve environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,24 +86,9 @@ By default, tests run against local environment.
 
 **NOTE:** You will need, the [cerberus-service](https://github.com/UKHomeOffice/cerberus-service) application, to be running before triggering Cypress.
 
-create a file called cypress.env.json on a root folder and include the following key-value pair when running the tests locally,
-(These values would be automatically fetched from secret manager and would be set when tests running inside drone server / kube)
-
-```json5
-{
-   "cerberusServiceUrl": "xxx",
-   "formApiUrl": "xxx",
-}
-```
-#### Setup Environment to run the tests on local
+#### Setup Environment to run the tests against different environment from local machine
 ```sh
-./scripts/env-setup.sh {context} {namespace} {secretName}
-
-env        context               namespace                secretname                     |
--------|--------------------|-----------------------|------------------------------------|
-Dev    | acp-notprod_COP    |  cop-cerberus-dev     |   cerberus-functional-tests        |
-Sit    | acp-notprod_COP    |  cop-cerberus-sit     |   cerberus-functional-tests-sit    |
-Staging| acp-prod_COP       |  cop-cerberus-staging |   cerberus-functional-tests-staging|
+./scripts/env-setup.sh {dev, sit , staging}
 ```
 
 #### Running cypress test runner
@@ -122,6 +107,7 @@ Once TestRunner launched, click on the interested spec inside folder cypress/int
 
 Running all tests on local Environment, (It executes tests headless mode on Electron Browser)
 ```sh
+source .env
 npm run cypress:test:local
 ```
 
@@ -143,7 +129,7 @@ npm run cypress:test:local -- --browser chrome --spec cypress/integration/cerber
 Running All tests and generating mochawesome html report with screenshots
 run the command for specific environment to get the required baseUrl & keycloak authentication 
 ```sh
-node get_secrets.js {dev, sit , staging}
+./scripts/env-setup.sh {dev, sit , staging}
 ```
 ```sh
 npm run cypress:test:report -- -b chrome -c ${CERBERUS_WORKFLOW_SERVICE_URL} -f ${FORM_API_URL}

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -1,8 +1,10 @@
 describe('Create task with different payload from Cerberus', () => {
   let date;
+  let dateNowFormatted;
   before(() => {
     cy.login(Cypress.env('userName'));
     date = new Date();
+    dateNowFormatted = Cypress.moment(date).format('DD-MM-YYYY');
   });
 
   it('Should create a task with a payload contains hazardous cargo without description and passport number as null', () => {
@@ -10,7 +12,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.parse(task.variables.rbtPayload.value);
       let registrationNumber = task.variables.rbtPayload.value.data.movement.vehicles[0].vehicle.registrationNumber;
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-HAZARDOUS').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-HAZARDOUS`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -22,7 +24,7 @@ describe('Create task with different payload from Cerberus', () => {
     cy.fixture('tasks-org-null.json').then((task) => {
       let registrationNumber = task.variables.rbtPayload.value.data.movement.vehicles[0].vehicle.registrationNumber;
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-ORG-NULL').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-ORG-NULL`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -37,7 +39,7 @@ describe('Create task with different payload from Cerberus', () => {
       date.setDate(date.getDate() + 2);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-TOURIST-WITH-PASSENGERS').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-TOURIST-WITH-PASSENGERS`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -58,7 +60,7 @@ describe('Create task with different payload from Cerberus', () => {
       date.setDate(date.getDate() + 5);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-TOURIST-RBT-SBT').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-TOURIST-RBT-SBT`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -74,7 +76,7 @@ describe('Create task with different payload from Cerberus', () => {
       date.setDate(date.getDate() + 4);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-TOURIST-SBT').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-TOURIST-SBT`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -88,7 +90,7 @@ describe('Create task with different payload from Cerberus', () => {
       console.log(task.variables.rbtPayload.value);
       let registrationNumber = task.variables.rbtPayload.value.data.movement.vehicles[0].vehicle.registrationNumber;
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-ACC').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-ACC`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -103,7 +105,7 @@ describe('Create task with different payload from Cerberus', () => {
       date.setDate(date.getDate() + 6);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-ACC-RBT-SBT').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-ACC-RBT-SBT`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -118,7 +120,7 @@ describe('Create task with different payload from Cerberus', () => {
       date.setDate(date.getDate() + 10);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-ACC-SBT').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-ACC-SBT`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -133,7 +135,7 @@ describe('Create task with different payload from Cerberus', () => {
       date.setDate(date.getDate() + 8);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-UNACC-SBT').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-UNACC-SBT`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -148,7 +150,7 @@ describe('Create task with different payload from Cerberus', () => {
       date.setDate(date.getDate() + 1);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-UNACC-RBT-SBT').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-UNACC-RBT-SBT`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);
@@ -164,7 +166,7 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       console.log(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-ACC-NO-PASSENGERS').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-ACC-NO-PASSENGERS`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber);

--- a/cypress/integration/cerberus/formapi-404.spec.js
+++ b/cypress/integration/cerberus/formapi-404.spec.js
@@ -2,9 +2,10 @@ describe('Cerberus-UI handles the exception if Form API server is unresponsive',
   let taskName;
   let formApiUrl = Cypress.env('formApiUrl');
   before(() => {
+    let dateNowFormatted = Cypress.moment(new Date()).format('DD-MM-YYYY');
     cy.login(Cypress.env('userName'));
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'CERB-AUTOTEST').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-FORMAPI-DOWN`).then((response) => {
         taskName = response.businessKey;
       });
     });

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -9,11 +9,12 @@ describe('Issue target from cerberus UI using target sheet information form', ()
     cy.fixture('RoRo-Accompanied-RBT-SBT.json').then((task) => {
       let date;
       date = new Date();
+      let dateNowFormatted = Cypress.moment(date).format('DD-MM-YYYY');
       task.variables.rbtPayload.value = JSON.parse(task.variables.rbtPayload.value);
       date.setDate(date.getDate() + 6);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-Accompanied').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-Accompanied`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.navigateToTaskDetailsPage(tasks);

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -1,6 +1,11 @@
 describe('Render tasks from Camunda and manage them on task details Page', () => {
+  let dateNowFormatted;
   beforeEach(() => {
     cy.login(Cypress.env('userName'));
+  });
+
+  before(() => {
+    dateNowFormatted = Cypress.moment(new Date()).format('DD-MM-YYYY');
   });
 
   it('Should navigate to task details page', () => {
@@ -18,7 +23,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     cy.intercept('POST', '/camunda/process-definition/key/noteSubmissionWrapper/submit-form').as('notes');
 
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'CERB-AUTOTEST').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-ADD-NOTES`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.navigateToTaskDetailsPage(tasks);
@@ -62,7 +67,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   it('Should hide Notes Textarea for the tasks assigned to others', () => {
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'AUTOTEST-ASSIGN-TO-OTHER').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-ASSIGN-TO-OTHER`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.assignToOtherUser(tasks);
@@ -81,7 +86,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   it('Should hide Claim/UnClaim button for the tasks assigned to others', () => {
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'AUTOTEST-ASSIGN-TO-OTHER').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-ASSIGN-TO-OTHER-USER`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.assignToOtherUser(tasks);
@@ -106,9 +111,8 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     ];
 
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
-
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'CERB-AUTOTEST').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-CLAIM`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.navigateToTaskDetailsPage(tasks);
@@ -172,7 +176,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   it('Should verify all the action buttons not available for non-task owner', () => {
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'AUTOTEST-ASSIGN-TO-OTHER').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-ASSIGN-TO-OTHER`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.assignToOtherUser(tasks);
@@ -212,7 +216,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     ];
 
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'AUTOTEST-ASSESSMENT').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-ASSESSMENT`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.navigateToTaskDetailsPage(tasks);
@@ -256,7 +260,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     ];
 
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'AUTOTEST-DISMISS').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-DISMISS`).then((taskResponse) => {
         cy.wait(4000);
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.navigateToTaskDetailsPage(tasks);

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -89,9 +89,10 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
   it('Should Claim and Unclaim a task Successfully from task management page', () => {
     cy.intercept('POST', '/camunda/task/*/claim').as('claim');
     const nextPage = 'a[data-test="next"]';
+    let dateNowFormatted = Cypress.moment(new Date()).format('DD-MM-YYYY');
 
     cy.fixture('tasks.json').then((task) => {
-      cy.postTasks(task, 'AUTOTEST-').then((taskResponse) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-CLAIM-TASK-MANAGEMENT`).then((taskResponse) => {
         let businessKey = encodeURIComponent(taskResponse.businessKey);
         if (Cypress.$(nextPage).length > 0) {
           cy.findTaskInAllThePages(`${businessKey}`, 'Claim').then((returnValue) => {

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -1,6 +1,11 @@
 describe('Task Details of different tasks on task details Page', () => {
+  let dateNowFormatted;
   beforeEach(() => {
     cy.login(Cypress.env('userName'));
+  });
+
+  before(() => {
+    dateNowFormatted = Cypress.moment(new Date()).format('DD-MM-YYYY');
   });
 
   it('Should verify task version details of unaccompanied task on task details page', () => {
@@ -10,7 +15,7 @@ describe('Task Details of different tasks on task details Page', () => {
       date.setDate(date.getDate() + 8);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-UNACC-SBT').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-UNACC-SBT`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
       });
@@ -71,7 +76,7 @@ describe('Task Details of different tasks on task details Page', () => {
       date.setDate(date.getDate() + 8);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-ACC').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-ACC`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
       });
@@ -133,7 +138,7 @@ describe('Task Details of different tasks on task details Page', () => {
       date.setDate(date.getDate() + 8);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, 'AUTOTEST-RoRo-ACC-2-Passengers').then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-ACC-2-Passengers`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
       });
@@ -196,7 +201,7 @@ describe('Task Details of different tasks on task details Page', () => {
 
   it('Should verify single task created for the same target with different versions when payloads sent with delay', () => {
     let date = new Date();
-    const businessKey = `AUTOTEST-RoRo-Versions-with-Delay-30Sec/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+    const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-with-Delay-30Sec/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
     date.setDate(date.getDate() + 8);
     cy.fixture('RoRo-task-v1.json').then((task) => {
       task.businessKey = businessKey;
@@ -239,7 +244,7 @@ describe('Task Details of different tasks on task details Page', () => {
   it('Should verify single task created for the same target with different versions when payloads sent without delay', () => {
     let date = new Date();
     date.setDate(date.getDate() + 8);
-    const businessKey = `AUTOTEST-RoRo-Versions-No-Delay/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+    const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-No-Delay/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
 
     let tasks = [];
 
@@ -282,7 +287,7 @@ describe('Task Details of different tasks on task details Page', () => {
   it('Should verify single task created for the same target with different versions of failure when payloads sent without delay', () => {
     let date = new Date();
     date.setDate(date.getDate() + 8);
-    const businessKey = `AUTOTEST-RoRo-Versions-No-Delay-Failure/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+    const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-No-Delay-Failure/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
 
     let tasks = [];
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -415,12 +415,13 @@ Cypress.Commands.add('checkTaskSummary', (registrationNumber) => {
 });
 
 Cypress.Commands.add('deleteAutomationTestData', () => {
+  let dateNowFormatted = Cypress.moment().subtract('1', 'd').format('DD-MM-YYYY');
   cy.request({
     method: 'POST',
-    url: `https://${cerberusServiceUrl}/camunda/engine-rest/process-instance?businessKeyLike='%AUTO-TEST%'`,
+    url: `https://${cerberusServiceUrl}/camunda/engine-rest/process-instance`,
     headers: { Authorization: `Bearer ${token}` },
     body: {
-      'processDefinitionKeyIn': ['assignTarget', 'raiseMovement'],
+      'businessKeyLike': `%AUTOTEST-${dateNowFormatted}-%`,
     },
   }).then((response) => {
     const processInstanceId = response.body.map((item) => item.id);
@@ -437,10 +438,10 @@ Cypress.Commands.add('deleteAutomationTestData', () => {
   });
   cy.request({
     method: 'POST',
-    url: `https://${cerberusServiceUrl}/camunda/engine-rest/history/process-instance?processInstanceBusinessKeyLike='%AUTO-TEST%'`,
+    url: `https://${cerberusServiceUrl}/camunda/engine-rest/history/process-instance`,
     headers: { Authorization: `Bearer ${token}` },
     body: {
-      'processDefinitionKeyIn': ['assignTarget', 'raiseMovement'],
+      'processInstanceBusinessKeyLike': `%AUTOTEST-${dateNowFormatted}-%`,
     },
   }).then((response) => {
     const processInstanceId = response.body.map((item) => item.id);

--- a/get_secrets.js
+++ b/get_secrets.js
@@ -92,6 +92,8 @@ getSecret().then((secret) => {
         obj.env.auth_realm = auth.realm;
         obj.env.auth_client_id = auth.client;
         obj.env.auth_base_url = auth.url;
+        obj.env.cerberusServiceUrl = secret.services.cerberus.service_url;
+        obj.env.formApiUrl = secret.services.form.api_server;
         json = JSON.stringify(obj);
         fs.writeFileSync('cypress.json', json, { flag: 'w' });
       }

--- a/scripts/env-setup.sh
+++ b/scripts/env-setup.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
-context=$1
-namespace=$2
-secretName=$3
+environment=$1
+
+if [[ $environment == "dev" ]]; then
+   context="acp-notprod_COP"
+   namespace="cop-cerberus-dev"
+   secretName="cerberus-functional-tests"
+fi
+
+if [[ $environment == "sit" ]]; then
+   context="acp-notprod_COP"
+   namespace="cop-cerberus-sit"
+   secretName="cerberus-functional-tests-sit"
+fi
+
+if [[ $environment == "staging" ]]; then
+   context="acp-prod_COP"
+   namespace="cop-cerberus-staging"
+   secretName="cerberus-functional-tests-staging"
+fi
 
 rm .env
 


### PR DESCRIPTION
## Description
Delete all the automation test data one day older and keep the latest test data.
Simplify environment setup to run the tests against different env from local machine.  

## To Test
./script/env-setup.sh dev
npm run cypress:test:report -- -b electron

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
