### PR TITLE
ItemsPerPage increased from 10 to 100

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -38,7 +38,7 @@ const TasksTab = ({ taskStatus, setError }) => {
 
   // PAGINATION SETTINGS
   const index = activePage - 1;
-  const itemsPerPage = 10;
+  const itemsPerPage = 100;
   const offset = index * itemsPerPage;
   const totalPages = Math.ceil(targetTaskCount / itemsPerPage);
 


### PR DESCRIPTION
Signed-off-by: Andrew Scrivener <andrew.scrivener@digital.homeoffice.gov.uk>

## Description
https://support.cop.homeoffice.gov.uk/browse/COP-6072
The business have requested that we display 100 tasks per page rather than 10 and pagination be shown thereafter.   

## To Test
Does pagination display when more than 100 tasks are available for the task list page.

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
