### PR TITLE
COP-7942: Add test to verify selector matches displayed as is from payload

### DIFF
--- a/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
+++ b/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
@@ -15,18 +15,18 @@
          "selectorReference": "2021-51",
          "startDate": "2021-07-09T13:42:48.381Z",
          "endDate": "2021-08-20T22:59:59Z",
-         "category": "B",
+         "category": "A",
          "agencyCode": "Counter Terrorism Police (CTP)",
          "intelligenceSource": "intel source",
          "pointOfContact": "Point Of Contact",
          "pocMessage": "Message for the POC",
-         "priority": "Tier 2",
+         "priority": "Tier 1",
          "inboundActionCode": "Advise originator",
          "outboundActionCode": "Full attention",
          "threatType": "National Security at the Border",
          "notes": "Supplemental notes",
-         "creator": "Joe Jones",
-         "approver": "Henry Hamlet",
+         "creator": "Jack Jones",
+         "approver": "Van Gough",
          "securityLabels": [
           "DATA_RISK_PREARRIVAL"
          ],
@@ -39,7 +39,7 @@
            "entity": "Organisation",
            "descriptor": "telephone",
            "operator": "equal",
-           "value": "01234 56723737"
+           "value": "01234 45654654"
           },
           {
            "entity": "Message",

--- a/cypress/fixtures/unaccompanied-task-details.json
+++ b/cypress/fixtures/unaccompanied-task-details.json
@@ -66,5 +66,28 @@
   "vessel": {
     "name": "NORMANDIE",
     "shippingCompany": "Brittany Ferries"
+  },
+  "selector_matches": {
+    "Group number": "2021-51",
+    "Requesting officer": "Peter Price",
+    "Source reference": "intel source",
+    "Group reference": "Local Reference",
+    "Category": "A",
+    "Threat type": "National Security at the Border",
+    "Point of contact message": "Message for the POC",
+    "Point of contact": "Point Of Contact",
+    "Inbound action": "Advise originator",
+    "Outbound action": "Full attention",
+    "Warnings": "Supplemental warnings",
+    "Notes": "Supplemental notes",
+    "Creator": "Jack Jones",
+    "Entity": "Organisation",
+    "Attribute": "telephone",
+    "Operator": "equal",
+    "Value": "01234 45654654",
+    "Entity": "Message",
+    "Attribute": "mode",
+    "Operator": "in",
+    "Value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
   }
 }

--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -71,16 +71,18 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
 
   it('Should verify tasks are sorted in arrival time on task management page', () => {
     let arrivalDate;
-    cy.get('.arrival-dates ').each((item, index) => {
+    cy.get('.task-list--item .content-line-two').each((item, index) => {
       let dates;
       cy.wrap(item).find('li').last().then((element) => {
-        dates = element.text().split('at');
-        const d = new Date(dates[0]);
-        if (index === 0) {
-          arrivalDate = d.getTime();
-        } else {
-          expect(arrivalDate).to.be.lte(d.getTime());
-          arrivalDate = d.getTime();
+        if (element.text() !== 'unknown') {
+          dates = element.text().split('at');
+          const d = new Date(dates[0]);
+          if (index === 0) {
+            arrivalDate = d.getTime();
+          } else {
+            expect(arrivalDate).to.be.lte(d.getTime());
+            arrivalDate = d.getTime();
+          }
         }
       });
     });

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -65,6 +65,12 @@ describe('Task Details of different tasks on task details Page', () => {
           expect(details).to.deep.equal(expectedDetails.booking);
         });
       });
+
+      cy.contains('h2', '1 selector matches').next().within(() => {
+        cy.getTaskDetails().then((details) => {
+          expect(details).to.deep.equal(expectedDetails.selector_matches);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Description
Test added to create a task with selector matches in the payload and verify it on the UI.
Updated arrival date time sorting order failing tests.

## To Test
npm run cypress:runner
run tests `Should verify task version details of unaccompanied task on task details page` from task-version-details.spec.js

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
