### PR TITLE
COP-6433 auto open accordion

### DIFF
--- a/jest.setup.jsx
+++ b/jest.setup.jsx
@@ -19,6 +19,9 @@ jest.mock('./src/utils/keycloak', () => ({
       team_id: '21',
     },
     createLogoutUrl: jest.fn(() => 'http://example.com/logout'),
+    logout: jest.fn(() => ({
+      pathname: '/example',
+    })),
   }),
 }));
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,12 +5,21 @@ import { useKeycloak } from '../utils/keycloak';
 import NavigationItem from './NavigationItem';
 
 const Header = () => {
-  const { createLogoutUrl } = useKeycloak();
+  const keycloak = useKeycloak();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const toggleMenu = (e) => {
     e.preventDefault();
     setMobileMenuOpen(!mobileMenuOpen);
+  };
+
+  const logout = (e) => {
+    e.preventDefault();
+    localStorage.clear();
+    sessionStorage.clear();
+    keycloak.logout({
+      redirectUri: window.location.origin.toString(),
+    });
   };
 
   return (
@@ -49,7 +58,9 @@ const Header = () => {
               aria-label="Navigation menu"
             >
               <NavigationItem href="/tasks">Tasks</NavigationItem>
-              <NavigationItem href={createLogoutUrl()}>Sign out</NavigationItem>
+              <li className="govuk-header__navigation-item">
+                <Link to="/" onClick={(e) => logout(e)} className="govuk-header__link">Sign out</Link>
+              </li>
             </ul>
           </nav>
         </div>

--- a/src/components/__tests__/Header.test.jsx
+++ b/src/components/__tests__/Header.test.jsx
@@ -1,12 +1,25 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Header from '../Header';
 
-test('renders the header with nav links', () => {
-  render(<Header />);
-  const bannerText = screen.getByRole('banner').textContent;
-  expect(bannerText).toContain('Cerberus');
-  expect(bannerText).toContain('powered by the Central Operations Platform');
-  expect(screen.getByText('Sign out'))
-    .toHaveAttribute('href', 'http://example.com/logout');
+describe('Header', () => {
+  test('renders the header with nav links', () => {
+    render(<Header />);
+    const bannerText = screen.getByRole('banner').textContent;
+    expect(bannerText).toContain('Cerberus');
+    expect(bannerText).toContain('powered by the Central Operations Platform');
+    expect(bannerText).toContain('powered by the Central Operations Platform');
+  });
+
+  it('should clear secure local storage on logout', async () => {
+    localStorage.setItem('test-key-local', 'test-value-keep');
+    sessionStorage.setItem('test-key-session', 'test-value-keep');
+
+    render(<Header />);
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+    await waitFor(() => { fireEvent.click(screen.getByText('Sign out')); });
+
+    expect(localStorage.getItem('test-key-local')).toBeFalsy();
+    expect(sessionStorage.getItem('test-key-session')).toBeFalsy();
+  });
 });

--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -372,7 +372,7 @@ const TaskDetailsPage = () => {
                 </>
               )}
               {!isCompleteFormOpen && !isDismissFormOpen && !isIssueTargetFormOpen && (
-                <TaskVersions taskVersions={targetData[0].taskDetails} businessKey={targetData[0].targetInformationSheet.parentBusinessKey.businessKey} />
+                <TaskVersions taskVersions={targetData[0].taskDetails} businessKey={targetData[0].taskSummaryBasedOnTIS?.businessKey} />
               )}
             </div>
 
@@ -380,7 +380,7 @@ const TaskDetailsPage = () => {
               {assignee === currentUser && (
                 <TaskNotesForm
                   formName="noteCerberus"
-                  businessKey={targetData[0].taskSummary?.businessKey}
+                  businessKey={targetData[0].taskSummaryBasedOnTIS?.businessKey}
                   processInstanceId={processInstanceId}
                 />
               )}

--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -372,7 +372,7 @@ const TaskDetailsPage = () => {
                 </>
               )}
               {!isCompleteFormOpen && !isDismissFormOpen && !isIssueTargetFormOpen && (
-                <TaskVersions taskVersions={targetData[0].taskDetails} />
+                <TaskVersions taskVersions={targetData[0].taskDetails} businessKey={targetData[0].targetInformationSheet.parentBusinessKey.businessKey} />
               )}
             </div>
 

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -76,7 +76,7 @@ const renderFieldSets = (fieldSet) => {
   return renderFieldSetContents(fieldSet.contents);
 };
 
-const TaskVersions = ({ taskVersions }) => {
+const TaskVersions = ({ taskVersions, businessKey }) => {
   /*
   * There can be multiple versions of the data
   * We need to display each version
@@ -88,10 +88,10 @@ const TaskVersions = ({ taskVersions }) => {
   return (
     <Accordion
       className="task-versions"
-      id="task-versions"
+      id={`task-versions-${businessKey}`}
       items={
         /* the task data is provided in an array,
-         * there is only everone item in the array
+         * there is only ever one item in the array
         */
         taskVersions.reverse().map((version, index) => {
           const booking = version.find((fieldset) => { return fieldset.fieldSetName === 'Booking'; }) || null;
@@ -109,6 +109,7 @@ const TaskVersions = ({ taskVersions }) => {
           });
           return (
             {
+              expanded: index === 0,
               heading: `Version ${versionNumber}`,
               summary: (
                 <>


### PR DESCRIPTION
## Description

AC: latest version of target should be expanded by default

Notes:
- GDS accordion stores last selected state of accordion (open/closed) and persists

Updated:
- gave every accordion item a unique ID connected to it's task ID so when state is saved to session storage by the accordion it doesn't impact other targets accordions
- set latest version to be open by default
- updated sign out to include clearing session and local storage data

## To Test

- click on a target (remember this target url)
- > the latest version should be open
- close the latest version
- refresh the page
- > latest version should stay closed
- go back to target list
- click on a different target
- > latest version should be open
- go to your first target again
- > latest version should be closed (as you left it in a closed state earlier)
- log out
- log in
- go to your first target again
- > latest version should be open (as logging out clears all your states)

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
