### PR TITLE
COP-6905: Add tests to check Target Indicators

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,6 +78,7 @@ module.exports = {
         'quote-props': 'off',
         'cypress/no-unnecessary-waiting': 'off',
         'no-console': 0,
+        'no-dupe-keys': 'off'
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,7 +78,7 @@ module.exports = {
         'quote-props': 'off',
         'cypress/no-unnecessary-waiting': 'off',
         'no-console': 0,
-        'no-dupe-keys': 'off'
+        'no-dupe-keys': 'off',
       },
     },
   ],

--- a/cypress/fixtures/RoRo-Accompanied-Freight.json
+++ b/cypress/fixtures/RoRo-Accompanied-Freight.json
@@ -2,7 +2,1308 @@
   "variables": {
     "rbtPayload": {
       "type": "Json",
-      "value": "{\"data\":{\"movementId\":\"ROROXML:CMID=b79733bfd00a67d245b70ec11d9a518d/426ac062c48f52719377d8b8754adb79/cdc28e1ff3b21c07417bcd650de717e8\",\"riskSubmissionId\":4823,\"riskCreatedDate\":\"2021-05-18T08:55:07.383Z\",\"riskType\":\"Pre-Arrival\",\"matchedRules\":[],\"matchedSelectors\":[{\"selectorId\":23,\"selectorReference\":\"2021-23\",\"startDate\":\"2021-05-06T11:19:37.982Z\",\"endDate\":\"2021-11-06T11:19:37.982Z\",\"category\":\"null\",\"agencyCode\":\"BF\",\"intelligenceSource\":\"null\",\"pointOfContact\":\"null\",\"pocMessage\":\"342334\",\"priority\":\"Selector\",\"inboundActionCode\":\"null\",\"outboundActionCode\":\"null\",\"threatType\":\"Alcohol\",\"notes\":\"null\",\"creator\":\"sachindra.mundrathi@digital.homeoffice.gov.uk\",\"approver\":\"null\",\"securityLabels\":[\"DATA_RISK_PREARRIVAL\"],\"localReference\":\"null\",\"warnings\":\"null\",\"requestingOfficer\":\"null\",\"requestingTeam\":\"null\",\"indicatorMatches\":[{\"entity\":\"vehicle\",\"descriptor\":\"registrationNumber\",\"operator\":\"equal\",\"value\":\"DK-45678\"}],\"selectorMatchedOnDate\":\"2021-05-14T14:00:41.624Z\"}],\"movement\":{\"cerberusMovementId\": \"ROROXML:CMID=b79733bfd00a67d245b70ec11d9a518d/426ac062c48f52719377d8b8754adb79/cdc28e1ff3b21c07417bcd650de717e8\", \"firstCerberusTimestamp\": 1621000841560, \"cerberusTimestamp\": 1621328098329, \"latestMessageType\": \"ENRICH\", \"messageAnalysis\": {\"messageMatches\": [], \"countOfSourceMessages\": 0, \"countOfSnapshots\": 0, \"countOfNoStateChanges\": 0, \"countOfWashes\": 0, \"countOfEnrichments\": 0, \"firstRunlogTimestamp\": 0, \"lastRunlogTimestamp\": 0, \"firstSnapshotTimestamp\": 0, \"lastSnapshotTimestamp\": 0, \"firstNSCTimestamp\": 0, \"lastNSCTimestamp\": 0, \"firstWashTimestamp\": 0, \"lastWashTimestamp\": 0, \"firstEnrichTimestamp\": 0, \"lastEnrichTimestamp\": 0, \"matchesComplete\": false, \"latestVersion\": \"1.0\"}, \"serviceMovement\": {\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:S=e2405ac7b63cf9d3280b8713367b5184\"}, \"v1\": null}, \"type\": \"S\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"e2405ac7b63cf9d3280b8713367b5184\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Service-Movement\", \"version\": \"1\"}}, \"type\": \"MOVEMENT\", \"effectiveFromTimestamp\": 1596624300000, \"effectiveToTimestamp\": 1596633300000, \"dueTimestamp\": null, \"status\": null, \"movement\": {\"type\": \"Pre-Arrival\", \"businessIdentifier\": \"AA000000006\", \"mode\": \"RORO Accompanied Freight\", \"source\": \"Stena\", \"actualDepartureTimestamp\": 1596624300000}, \"attributes\": {\"attrs\": {\"countryOfBooking\": \"GB\", \"ticketNumber\": \"ST-34560\", \"waybillNumber\": \"99990005\", \"adultCount\": \"0\", \"bookingDateTime\": \"2020-08-02T15:50:00\", \"descriptionOfCargo\": \"Liquid Nitrogen\", \"ticketType\": \"Single\", \"childCount\": \"0\", \"driverCount\": \"001\", \"reference\": \"AA000000006\", \"oapCount\": \"0\", \"checkInDateTime\": \"2020-08-04T11:05:00\", \"hazardousCargo\": \"false\", \"infantCount\": \"0\"}}, \"features\": {\"feats\": {\"SELECTORS-MATCHED-LIST\": {\"id\": null, \"type\": null, \"valueType\": \"STRING\", \"value\": null, \"valueList\": {\"val\": [\"META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL\", \"INDICATORS:23|vehicle|registrationNumber|equal|DK-45678\"]}, \"startTimestamp\": null, \"endTimestamp\": 1621000841624}, \"STANDARDISED:emptyVehicle\": {\"id\": null, \"type\": null, \"valueType\": \"BOOL\", \"value\": true, \"valueList\": null, \"startTimestamp\": null, \"endTimestamp\": null}, \"STANDARDISED:checkInDateTime\": {\"id\": null, \"type\": null, \"valueType\": \"STRING\", \"value\": \"2020-08-04T11:05Z\", \"valueList\": null, \"startTimestamp\": null, \"endTimestamp\": null}, \"STANDARDISED:bookingDateTime\": {\"id\": null, \"type\": null, \"valueType\": \"STRING\", \"value\": \"2020-08-02T15:50Z\", \"valueList\": null, \"startTimestamp\": null, \"endTimestamp\": null}, \"SELECTOR-MATCHED\": {\"id\": null, \"type\": null, \"valueType\": \"BOOL\", \"value\": true, \"valueList\": null, \"startTimestamp\": null, \"endTimestamp\": 1621000841624}, \"STANDARDISED:bookingIntentHours\": {\"id\": null, \"type\": null, \"valueType\": \"LONG\", \"value\": 66, \"valueList\": null, \"startTimestamp\": null, \"endTimestamp\": null}}}, \"changeHistory\": null}, \"persons\": [{\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=d3b946de9bdf1af1234d65ee39775f15\"}, \"v1\": null}, \"type\": \"P\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"d3b946de9bdf1af1234d65ee39775f15\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Party\", \"version\": \"1\"}}, \"type\": \"PERSON\", \"person\": {\"type\": \"PERFDRIVER\", \"title\": null, \"familyName\": \"Turner\", \"givenName\": \"Scottello\", \"fullName\": \"Scottello Turner\", \"dateOfBirth\": 8517, \"dateOfDeath\": null, \"gender\": \"\", \"nationality\": null, \"yearOfBirth\": 1993, \"monthOfBirth\": 4, \"dayOfBirth\": 27, \"countryOfBirth\": null, \"placeOfBirth\": null, \"ethnicity\": null, \"maritalStatus\": null, \"religion\": null, \"passportNumber\": \"AB2099357\"}, \"attributes\": {\"attrs\": {\"role\": \"DRIVER\"}}, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}], \"organisations\": [{\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=7404e54d23fa41a7ee8dcfb3f8f9c2c4\"}, \"v1\": null}, \"type\": \"P\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"7404e54d23fa41a7ee8dcfb3f8f9c2c4\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Party\", \"version\": \"1\"}}, \"type\": \"ORGANISATION\", \"organisation\": {\"type\": \"ORGBOOKER\", \"name\": \"Susan Tower\", \"registrationNumber\": null, \"vatNumber\": null, \"industrySector\": null, \"numberOfEmployees\": null}, \"attributes\": {\"attrs\": {\"countryOfBooking\": \"GB\", \"reference\": \"AA000000006\", \"CheckInDateTime\": \"2020-08-04T11:05:00\", \"ticketNumber\": \"ST-34560\", \"ticketType\": \"Single\", \"bookingDateTime\": \"2020-08-02T15:50:00\"}}, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}, {\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=cfaea00ea2648517388b65d1cb919ff4\"}, \"v1\": null}, \"type\": \"P\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"cfaea00ea2648517388b65d1cb919ff4\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Party\", \"version\": \"1\"}}, \"type\": \"ORGANISATION\", \"organisation\": {\"type\": \"ORGACCOUNT\", \"name\": \"DPE\", \"registrationNumber\": null, \"vatNumber\": null, \"industrySector\": null, \"numberOfEmployees\": null}, \"attributes\": {\"attrs\": {\"referenceNumber\": \"000524557\", \"holderName\": \"DPE logistics\"}}, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}], \"documents\": [{\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=d3b946de9bdf1af1234d65ee39775f15,O=a5653394092bcb1d3f36636ded5c3197\"}, \"v1\": null}, \"type\": \"O\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"a5653394092bcb1d3f36636ded5c3197\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Object-Document\", \"version\": \"1\"}}, \"type\": \"DOCUMENT\", \"party\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=d3b946de9bdf1af1234d65ee39775f15\"}, \"v1\": null}, \"type\": \"P\"}, \"role\": \"PTOOUSES\", \"startTimestamp\": 1597482900000, \"endTimestamp\": null, \"name\": null, \"description\": null, \"additionalInformation\": null, \"url\": null, \"document\": {\"type\": \"OBJDOCPAS\", \"value\": \"AB2099357\", \"subject\": null, \"category\": \"P\", \"status\": null, \"placeOfIssue\": null, \"countryOfIssue\": \"GB\", \"dateOfIssue\": null, \"validFromDate\": null, \"expiryDate\": 20167}, \"attributes\": {\"attrs\": {\"documentType\": \"Passport\"}}, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}], \"vehicles\": [{\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=null[3f20ac0563fe7541a8793b3770da952a],O=3f20ac0563fe7541a8793b3770da952a\"}, \"v1\": null}, \"type\": \"O\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"3f20ac0563fe7541a8793b3770da952a\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Object-Vehicle\", \"version\": \"1\"}}, \"type\": \"VEHICLE\", \"party\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=null[3f20ac0563fe7541a8793b3770da952a]\"}, \"v1\": null}, \"type\": \"P\"}, \"role\": \"UNKNOWN\", \"startTimestamp\": null, \"endTimestamp\": null, \"name\": null, \"description\": null, \"additionalInformation\": null, \"url\": null, \"vehicle\": {\"type\": \"OBJVEHC\", \"make\": null, \"model\": null, \"vin\": null, \"registrationNumber\": \"DK-45678\", \"registrationCountry\": \"DK\", \"year\": null, \"colour\": null, \"markings\": null}, \"attributes\": {\"attrs\": {\"netWeight\": \"3455\", \"grossWeight\": \"43623\", \"role\": \"FREIGHT\", \"statusOfLoading\": \"Empty\", \"length\": \"36\", \"type\": \"Refrigerated Tanker\", \"height\": \"3.6\"}}, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}], \"vessel\": {\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=null[219db69e7a6f973931bf4d923c01d2b8],O=219db69e7a6f973931bf4d923c01d2b8\"}, \"v1\": null}, \"type\": \"O\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"219db69e7a6f973931bf4d923c01d2b8\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Object-Vessel\", \"version\": \"1\"}}, \"type\": \"VESSEL\", \"party\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=null[219db69e7a6f973931bf4d923c01d2b8]\"}, \"v1\": null}, \"type\": \"P\"}, \"role\": \"UNKNOWN\", \"startTimestamp\": null, \"endTimestamp\": null, \"name\": null, \"description\": null, \"additionalInformation\": null, \"url\": null, \"vessel\": {\"type\": \"OBJVESWTR\", \"name\": \"Stena Asia\", \"operator\": \"Stena\", \"registrationNumber\": null, \"registrationCountry\": null, \"registrationPort\": null, \"mmsi\": null, \"imo\": null, \"callSign\": null}, \"attributes\": null, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}, \"addresses\": [{\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=cfaea00ea2648517388b65d1cb919ff4,L=64ed0dedefd616e32e7b2a7a01ecaf03\"}, \"v1\": null}, \"type\": \"L\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"64ed0dedefd616e32e7b2a7a01ecaf03\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Location-Address\", \"version\": \"1\"}}, \"type\": \"ADDRESS\", \"party\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=cfaea00ea2648517388b65d1cb919ff4\"}, \"v1\": null}, \"type\": \"P\"}, \"role\": \"PTOLASSO\", \"startTimestamp\": null, \"endTimestamp\": null, \"address\": {\"type\": \"LOCADDR\", \"postCode\": null, \"poBox\": null, \"fullAddress\": \"John Tranums Vei Esjerg DK\", \"name\": \"DPE\", \"siteLocation\": null, \"number\": null, \"street\": null, \"town\": \"Esjerg\", \"area\": null, \"district\": null, \"county\": null, \"country\": \"DK\", \"uniquePropertyReferenceNumber\": null, \"latitude\": null, \"longitude\": null}, \"attributes\": {\"attrs\": {\"addressLine1\": \"John Tranums Vei\"}}, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}], \"contacts\": [{\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=cfaea00ea2648517388b65d1cb919ff4,L=b9db1a03748b24350c77dbae78157b8c\"}, \"v1\": null}, \"type\": \"L\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"b9db1a03748b24350c77dbae78157b8c\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Location-Contact\", \"version\": \"1\"}}, \"type\": \"CONTACT\", \"party\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:P=cfaea00ea2648517388b65d1cb919ff4\"}, \"v1\": null}, \"type\": \"P\"}, \"role\": \"PTOLUSES\", \"startTimestamp\": null, \"endTimestamp\": null, \"contact\": {\"type\": \"LOCTEL\", \"value\": \"045 76 12 1493\"}, \"attributes\": null, \"matching\": null, \"features\": null, \"washResponses\": null, \"matchMerge\": null, \"changeHistory\": null}], \"voyage\": {\"metadata\": {\"identityRecord\": {\"poleId\": {\"v2\": {\"id\": \"ROROXML:S=8306c6f501306d93b7bb6e1525787644\"}, \"v1\": null}, \"type\": \"S\"}, \"sourceRecord\": {\"name\": \"ROROXML\", \"shortName\": \"ROX\", \"location\": \"archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2\", \"id\": \"8306c6f501306d93b7bb6e1525787644\", \"audit\": {\"createdBy\": \"wqWONSagziWX+2UlKaQVGQ==\", \"createdTimestamp\": 1597482900000, \"updatedBy\": null, \"updatedTimestamp\": null, \"deletedBy\": null, \"deletedTimestamp\": null}}, \"complianceRecord\": {\"visibility\": \"UNKNOWN\", \"gscMarker\": null, \"retentionMarkerDays\": -1}, \"mappingRecord\": {\"name\": \"RR-XML-Service-Voyage\", \"version\": \"1\"}}, \"type\": \"VOYAGE\", \"effectiveFromTimestamp\": 1596624300000, \"effectiveToTimestamp\": 1596633300000, \"dueTimestamp\": null, \"status\": null, \"voyage\": {\"type\": \"COMMERCIAL\", \"voyageType\": \"SEA\", \"departureLocation\": \"CRN\", \"departureCountry\": null, \"scheduledDepartureTimestamp\": 1596624300000, \"actualDepartureTimestamp\": 1596624300000, \"arrivalLocation\": \"BEL\", \"arrivalCountry\": null, \"scheduledArrivalTimestamp\": 1596633300000, \"actualArrivalTimestamp\": 1596633300000, \"intermediateLocations\": null, \"passengerCount\": null, \"crewCount\": null, \"durationMinutes\": null, \"routeId\": null, \"carrier\": \"Stena\", \"craftId\": \"Stena Asia\"}, \"attributes\": {\"attrs\": {\"freightMovementCount\": \"001\"}}, \"features\": {\"feats\": {\"STANDARDISED:arrivalPort\": {\"id\": null, \"type\": null, \"valueType\": \"MAP\", \"value\": null, \"valueList\": {\"val\": [{\"UNLO5\": \"GB BEL\"}]}, \"startTimestamp\": null, \"endTimestamp\": 1621000841565}, \"STANDARDISED:departurePort\": {\"id\": null, \"type\": null, \"valueType\": \"MAP\", \"value\": null, \"valueList\": {\"val\": [{\"UNLO5\": \"GB CYN\"}]}, \"startTimestamp\": null, \"endTimestamp\": 1621000841565}}}, \"changeHistory\": null}, \"consolidation\": null, \"consignments\": null}}}"
+      "value": {
+        "data": {
+          "movementId": "ROROXML:CMID=b79733bfd00a67d245b70ec11d9a518d/426ac062c48f52719377d8b8754adb79/cdc28e1ff3b21c07417bcd650de717e8",
+          "riskSubmissionId": 4823,
+          "riskCreatedDate": "2021-05-18T08:55:07.383Z",
+          "riskType": "Pre-Arrival",
+          "matchedRules": [],
+          "matchedSelectors": [
+            {
+              "selectorId": 23,
+              "selectorReference": "2021-23",
+              "startDate": "2021-05-06T11:19:37.982Z",
+              "endDate": "2021-11-06T11:19:37.982Z",
+              "category": "null",
+              "agencyCode": "BF",
+              "intelligenceSource": "null",
+              "pointOfContact": "null",
+              "pocMessage": "342334",
+              "priority": "Selector",
+              "inboundActionCode": "null",
+              "outboundActionCode": "null",
+              "threatType": "Alcohol",
+              "notes": "null",
+              "creator": "sachindra.mundrathi@digital.homeoffice.gov.uk",
+              "approver": "null",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "null",
+              "warnings": "null",
+              "requestingOfficer": "null",
+              "requestingTeam": "null",
+              "indicatorMatches": [
+                {
+                  "entity": "vehicle",
+                  "descriptor": "registrationNumber",
+                  "operator": "equal",
+                  "value": "DK-45678"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-05-14T14:00:41.624Z"
+            }
+          ],
+          "movement": {
+            "cerberusMovementId": "ROROXML:CMID=b79733bfd00a67d245b70ec11d9a518d/426ac062c48f52719377d8b8754adb79/cdc28e1ff3b21c07417bcd650de717e8",
+            "firstCerberusTimestamp": 1621000841560,
+            "cerberusTimestamp": 1621328098329,
+            "latestMessageType": "ENRICH",
+            "messageAnalysis": {
+              "messageMatches": [],
+              "countOfSourceMessages": 0,
+              "countOfSnapshots": 0,
+              "countOfNoStateChanges": 0,
+              "countOfWashes": 0,
+              "countOfEnrichments": 0,
+              "firstRunlogTimestamp": 0,
+              "lastRunlogTimestamp": 0,
+              "firstSnapshotTimestamp": 0,
+              "lastSnapshotTimestamp": 0,
+              "firstNSCTimestamp": 0,
+              "lastNSCTimestamp": 0,
+              "firstWashTimestamp": 0,
+              "lastWashTimestamp": 0,
+              "firstEnrichTimestamp": 0,
+              "lastEnrichTimestamp": 0,
+              "matchesComplete": false,
+              "latestVersion": "1.0"
+            },
+            "serviceMovement": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=e2405ac7b63cf9d3280b8713367b5184"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                  "id": "e2405ac7b63cf9d3280b8713367b5184",
+                  "audit": {
+                    "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                    "createdTimestamp": 1597482900000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Movement",
+                  "version": "1"
+                }
+              },
+              "type": "MOVEMENT",
+              "effectiveFromTimestamp": 1596624300000,
+              "effectiveToTimestamp": 1596633300000,
+              "dueTimestamp": null,
+              "status": null,
+              "movement": {
+                "type": "Pre-Arrival",
+                "businessIdentifier": "AA000000006",
+                "mode": "RORO Accompanied Freight",
+                "source": "Stena",
+                "actualDepartureTimestamp": 1596624300000
+              },
+              "attributes": {
+                "attrs": {
+                  "countryOfBooking": "GB",
+                  "ticketNumber": "ST-34560",
+                  "waybillNumber": "99990005",
+                  "adultCount": "0",
+                  "bookingDateTime": "2020-08-02T15:50:00",
+                  "descriptionOfCargo": "Liquid Nitrogen",
+                  "ticketType": "Single",
+                  "childCount": "0",
+                  "driverCount": "001",
+                  "reference": "AA000000006",
+                  "oapCount": "0",
+                  "checkInDateTime": "2020-08-04T11:05:00",
+                  "hazardousCargo": "false",
+                  "infantCount": "0"
+                }
+              },
+              "features": {
+                "feats": {
+                  "SELECTORS-MATCHED-LIST": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1621000841624
+                  },
+                  "STANDARDISED:emptyVehicle": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:checkInDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-04T11:05Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:bookingDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-02T15:50Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "SELECTOR-MATCHED": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": 1621000841624
+                  },
+                  "STANDARDISED:bookingIntentHours": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 66,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "persons": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=d3b946de9bdf1af1234d65ee39775f15"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                    "id": "d3b946de9bdf1af1234d65ee39775f15",
+                    "audit": {
+                      "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                      "createdTimestamp": 1597482900000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "PERSON",
+                "person": {
+                  "type": "PERFDRIVER",
+                  "title": null,
+                  "familyName": "Turner",
+                  "givenName": "Scottello",
+                  "fullName": "Scottello Turner",
+                  "dateOfBirth": 8517,
+                  "dateOfDeath": null,
+                  "gender": "",
+                  "nationality": null,
+                  "yearOfBirth": 1993,
+                  "monthOfBirth": 4,
+                  "dayOfBirth": 27,
+                  "countryOfBirth": null,
+                  "placeOfBirth": null,
+                  "ethnicity": null,
+                  "maritalStatus": null,
+                  "religion": null,
+                  "passportNumber": "AB2099357"
+                },
+                "attributes": {
+                  "attrs": {
+                    "role": "DRIVER"
+                  }
+                },
+                "matching": null,
+                "features": {
+                  "feats": {
+                    "SELECTORS-MATCHED-LIST": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": null,
+                      "valueList": {
+                        "val": [
+                          "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                          "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                        ]
+                      },
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "VEHICLE-FREIGHT-QUICK-TURNAROUND-0_24_HRS": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:checkInDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-04T11:05Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:bookingDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-02T15:50Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "SELECTOR-MATCHED": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "STANDARDISED:bookingIntentHours": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "LONG",
+                      "value": 66,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "organisations": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=7404e54d23fa41a7ee8dcfb3f8f9c2c4"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                    "id": "7404e54d23fa41a7ee8dcfb3f8f9c2c4",
+                    "audit": {
+                      "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                      "createdTimestamp": 1597482900000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGBOOKER",
+                  "name": "Susan Tower",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "countryOfBooking": "GB",
+                    "reference": "AA000000006",
+                    "CheckInDateTime": "2020-08-04T11:05:00",
+                    "ticketNumber": "ST-34560",
+                    "ticketType": "Single",
+                    "bookingDateTime": "2020-08-02T15:50:00"
+                  }
+                },
+                "matching": null,
+                "features": {
+                  "feats": {
+                    "SELECTORS-MATCHED-LIST": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": null,
+                      "valueList": {
+                        "val": [
+                          "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                          "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                        ]
+                      },
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "VEHICLE-CHANGE-DRIVER-ON-RETURN-TRIP": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:checkInDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-04T11:05Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:bookingDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-02T15:50Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "SELECTOR-MATCHED": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "STANDARDISED:bookingIntentHours": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "LONG",
+                      "value": 66,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=cfaea00ea2648517388b65d1cb919ff4"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                    "id": "cfaea00ea2648517388b65d1cb919ff4",
+                    "audit": {
+                      "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                      "createdTimestamp": 1597482900000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGACCOUNT",
+                  "name": "DPE",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "referenceNumber": "000524557",
+                    "holderName": "DPE logistics"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "documents": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=d3b946de9bdf1af1234d65ee39775f15,O=a5653394092bcb1d3f36636ded5c3197"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                    "id": "a5653394092bcb1d3f36636ded5c3197",
+                    "audit": {
+                      "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                      "createdTimestamp": 1597482900000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Document",
+                    "version": "1"
+                  }
+                },
+                "type": "DOCUMENT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=d3b946de9bdf1af1234d65ee39775f15"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOOUSES",
+                "startTimestamp": 1597482900000,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "document": {
+                  "type": "OBJDOCPAS",
+                  "value": "AB2099357",
+                  "subject": null,
+                  "category": "P",
+                  "status": null,
+                  "placeOfIssue": null,
+                  "countryOfIssue": "GB",
+                  "dateOfIssue": null,
+                  "validFromDate": null,
+                  "expiryDate": 20167
+                },
+                "attributes": {
+                  "attrs": {
+                    "documentType": "Passport"
+                  }
+                },
+                "matching": null,
+                "features": {
+                  "feats": {
+                    "SELECTORS-MATCHED-LIST": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": null,
+                      "valueList": {
+                        "val": [
+                          "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                          "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                        ]
+                      },
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "FIRST-TIME-ACCOUNT-TRAILER": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:checkInDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-04T11:05Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:bookingDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-02T15:50Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "SELECTOR-MATCHED": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "STANDARDISED:bookingIntentHours": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "LONG",
+                      "value": 66,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vehicles": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=null[3f20ac0563fe7541a8793b3770da952a],O=3f20ac0563fe7541a8793b3770da952a"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                    "id": "3f20ac0563fe7541a8793b3770da952a",
+                    "audit": {
+                      "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                      "createdTimestamp": 1597482900000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Vehicle",
+                    "version": "1"
+                  }
+                },
+                "type": "VEHICLE",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[3f20ac0563fe7541a8793b3770da952a]"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vehicle": {
+                  "type": "OBJVEHC",
+                  "make": null,
+                  "model": null,
+                  "vin": null,
+                  "registrationNumber": "DK-45678",
+                  "registrationCountry": "DK",
+                  "year": null,
+                  "colour": null,
+                  "markings": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "netWeight": "3455",
+                    "grossWeight": "43623",
+                    "role": "FREIGHT",
+                    "statusOfLoading": "Empty",
+                    "length": "36",
+                    "type": "Refrigerated Tanker",
+                    "height": "3.6"
+                  }
+                },
+                "matching": null,
+                "features": {
+                  "feats": {
+                    "SELECTORS-MATCHED-LIST": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": null,
+                      "valueList": {
+                        "val": [
+                          "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                          "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                        ]
+                      },
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "NEW-ACCOUNT": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:checkInDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-04T11:05Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:bookingDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-02T15:50Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "SELECTOR-MATCHED": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "STANDARDISED:bookingIntentHours": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "LONG",
+                      "value": 66,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vessel": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[219db69e7a6f973931bf4d923c01d2b8],O=219db69e7a6f973931bf4d923c01d2b8"
+                    },
+                    "v1": null
+                  },
+                  "type": "O"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                  "id": "219db69e7a6f973931bf4d923c01d2b8",
+                  "audit": {
+                    "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                    "createdTimestamp": 1597482900000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Object-Vessel",
+                  "version": "1"
+                }
+              },
+              "type": "VESSEL",
+              "party": {
+                "poleId": {
+                  "v2": {
+                    "id": "ROROXML:P=null[219db69e7a6f973931bf4d923c01d2b8]"
+                  },
+                  "v1": null
+                },
+                "type": "P"
+              },
+              "role": "UNKNOWN",
+              "startTimestamp": null,
+              "endTimestamp": null,
+              "name": null,
+              "description": null,
+              "additionalInformation": null,
+              "url": null,
+              "vessel": {
+                "type": "OBJVESWTR",
+                "name": "Stena Asia",
+                "operator": "Stena",
+                "registrationNumber": null,
+                "registrationCountry": null,
+                "registrationPort": null,
+                "mmsi": null,
+                "imo": null,
+                "callSign": null
+              },
+              "attributes": null,
+              "matching": null,
+              "features": {
+                "feats": {
+                  "SELECTORS-MATCHED-LIST": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1621000841624
+                  },
+                  "SWITCH-ACCOUNT-VEHICLE": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:checkInDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-04T11:05Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:bookingDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-02T15:50Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "SELECTOR-MATCHED": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": 1621000841624
+                  },
+                  "STANDARDISED:bookingIntentHours": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 66,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
+              "washResponses": null,
+              "matchMerge": null,
+              "changeHistory": null
+            },
+            "addresses": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=cfaea00ea2648517388b65d1cb919ff4,L=64ed0dedefd616e32e7b2a7a01ecaf03"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                    "id": "64ed0dedefd616e32e7b2a7a01ecaf03",
+                    "audit": {
+                      "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                      "createdTimestamp": 1597482900000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Address",
+                    "version": "1"
+                  }
+                },
+                "type": "ADDRESS",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=cfaea00ea2648517388b65d1cb919ff4"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLASSO",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "address": {
+                  "type": "LOCADDR",
+                  "postCode": null,
+                  "poBox": null,
+                  "fullAddress": "John Tranums Vei Esjerg DK",
+                  "name": "DPE",
+                  "siteLocation": null,
+                  "number": null,
+                  "street": null,
+                  "town": "Esjerg",
+                  "area": null,
+                  "district": null,
+                  "county": null,
+                  "country": "DK",
+                  "uniquePropertyReferenceNumber": null,
+                  "latitude": null,
+                  "longitude": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "addressLine1": "John Tranums Vei"
+                  }
+                },
+                "matching": null,
+                "features": {
+                  "feats": {
+                    "SELECTORS-MATCHED-LIST": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": null,
+                      "valueList": {
+                        "val": [
+                          "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                          "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                        ]
+                      },
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "NEW-ACCOUNT": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:checkInDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-04T11:05Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:bookingDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-02T15:50Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "SELECTOR-MATCHED": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "STANDARDISED:bookingIntentHours": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "LONG",
+                      "value": 66,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "contacts": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=cfaea00ea2648517388b65d1cb919ff4,L=b9db1a03748b24350c77dbae78157b8c"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                    "id": "b9db1a03748b24350c77dbae78157b8c",
+                    "audit": {
+                      "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                      "createdTimestamp": 1597482900000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Contact",
+                    "version": "1"
+                  }
+                },
+                "type": "CONTACT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=cfaea00ea2648517388b65d1cb919ff4"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLUSES",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "contact": {
+                  "type": "LOCTEL",
+                  "value": "045 76 12 1493"
+                },
+                "attributes": null,
+                "matching": null,
+                "features": {
+                  "feats": {
+                    "SELECTORS-MATCHED-LIST": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": null,
+                      "valueList": {
+                        "val": [
+                          "META:23|2021-23|2021-05-06T11:19:37.982Z|2021-11-06T11:19:37.982Z|BF|null|null|null|null|null|null|342334|null|Alcohol|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
+                          "INDICATORS:23|vehicle|registrationNumber|equal|DK-45678"
+                        ]
+                      },
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "SAME-LOAD-TRAILER": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:checkInDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-04T11:05Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "STANDARDISED:bookingDateTime": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "STRING",
+                      "value": "2020-08-02T15:50Z",
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "SELECTOR-MATCHED": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "BOOL",
+                      "value": true,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": 1621000841624
+                    },
+                    "STANDARDISED:bookingIntentHours": {
+                      "id": null,
+                      "type": null,
+                      "valueType": "LONG",
+                      "value": 66,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "voyage": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=8306c6f501306d93b7bb6e1525787644"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2021-03-30/DataFeedId=108/DataFeedTaskId=7753618/CERBERUS_XML_6_roroxml_SameDocument_2",
+                  "id": "8306c6f501306d93b7bb6e1525787644",
+                  "audit": {
+                    "createdBy": "wqWONSagziWX+2UlKaQVGQ==",
+                    "createdTimestamp": 1597482900000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Voyage",
+                  "version": "1"
+                }
+              },
+              "type": "VOYAGE",
+              "effectiveFromTimestamp": 1596624300000,
+              "effectiveToTimestamp": 1596633300000,
+              "dueTimestamp": null,
+              "status": null,
+              "voyage": {
+                "type": "COMMERCIAL",
+                "voyageType": "SEA",
+                "departureLocation": "CRN",
+                "departureCountry": null,
+                "scheduledDepartureTimestamp": 1596624300000,
+                "actualDepartureTimestamp": 1596624300000,
+                "arrivalLocation": "BEL",
+                "arrivalCountry": null,
+                "scheduledArrivalTimestamp": 1596633300000,
+                "actualArrivalTimestamp": 1632387398679,
+                "intermediateLocations": null,
+                "passengerCount": null,
+                "crewCount": null,
+                "durationMinutes": null,
+                "routeId": null,
+                "carrier": "Stena",
+                "craftId": "Stena Asia"
+              },
+              "attributes": {
+                "attrs": {
+                  "freightMovementCount": "001"
+                }
+              },
+              "features": {
+                "feats": {
+                  "STANDARDISED:arrivalPort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "GB BEL"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1621000841565
+                  },
+                  "STANDARDISED:departurePort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "GB CYN"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1621000841565
+                  },
+                  "FIRST-TIME-TRAILER": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "consolidation": null,
+            "consignments": null
+          }
+        }
+      }
     },
     "initiatedBy": {
       "type": "String",

--- a/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
+++ b/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
@@ -166,6 +166,15 @@
             "startTimestamp": null,
             "endTimestamp": null
            },
+           "STANDARDISED:cashPaid": {
+            "id": null,
+            "type": null,
+            "valueType": "BOOL",
+            "value": true,
+            "valueList": null,
+            "startTimestamp": null,
+            "endTimestamp": null
+           },
            "STANDARDISED:checkInDateTime": {
             "id": null,
             "type": null,
@@ -397,7 +406,19 @@
            }
           },
           "matching": null,
-          "features": null,
+          "features": {
+           "feats": {
+            "EMPTY-TRAILER-ON-ROUND-TRIP": {
+             "id": null,
+             "type": null,
+             "valueType": "BOOL",
+             "value": true,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            }
+           }
+          },
           "washResponses": null,
           "matchMerge": null,
           "changeHistory": null

--- a/cypress/fixtures/RoRo-task-v1-target-update.json
+++ b/cypress/fixtures/RoRo-task-v1-target-update.json
@@ -4,9 +4,9 @@
       "type": "Json",
       "value": {
         "data": {
-          "movementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/a296a0797b9701f912a5a808851e6156",
-          "riskSubmissionId": 8551,
-          "riskCreatedDate": "2021-07-13T09:30:03.457474Z",
+          "movementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+          "riskSubmissionId": 8550,
+          "riskCreatedDate": "2021-07-13T09:30:03.106021Z",
           "riskType": "Pre-Arrival",
           "matchedRules": [
             {
@@ -51,23 +51,23 @@
               "endDate": "2021-08-20T22:59:59Z",
               "category": "B",
               "agencyCode": "Counter Terrorism Police (CTP)",
-              "intelligenceSource": "ffhtr",
-              "pointOfContact": "hrth",
-              "pocMessage": "hthtr",
-              "priority": "Selector",
-              "inboundActionCode": "No action required",
-              "outboundActionCode": "No action required",
-              "threatType": "Class B&C Drugs inc. Cannabis",
-              "notes": "notes",
-              "creator": "user",
-              "approver": "hthtr",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact",
+              "pocMessage": "Message for the POC",
+              "priority": "Tier 2",
+              "inboundActionCode": "Advise originator",
+              "outboundActionCode": "Full attention",
+              "threatType": "National Security at the Border",
+              "notes": "Supplemental notes",
+              "creator": "Joe Jones",
+              "approver": "Henry Hamlet",
               "securityLabels": [
                 "DATA_RISK_PREARRIVAL"
               ],
-              "localReference": "htrthr",
-              "warnings": "rtht",
-              "requestingOfficer": "bffg",
-              "requestingTeam": "BFNIH",
+              "localReference": "Local Reference",
+              "warnings": "Supplemental warnings",
+              "requestingOfficer": "Peter Price",
+              "requestingTeam": "RoRo accompanied",
               "indicatorMatches": [
                 {
                   "entity": "Organisation",
@@ -82,7 +82,7 @@
                   "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                 }
               ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
+              "selectorMatchedOnDate": "2021-09-05T09:30:02.896Z"
             },
             {
               "selectorId": 50,
@@ -122,41 +122,7 @@
                   "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                 }
               ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
-            },
-            {
-              "selectorId": 30,
-              "selectorReference": "2021-30",
-              "startDate": "2021-06-17T14:58:25.081Z",
-              "endDate": "2021-12-17T14:58:25.081Z",
-              "category": "null",
-              "agencyCode": "NCA",
-              "intelligenceSource": "null",
-              "pointOfContact": "null",
-              "pocMessage": "87687",
-              "priority": "Selector",
-              "inboundActionCode": "null",
-              "outboundActionCode": "null",
-              "threatType": "Clandestine Entry",
-              "notes": "null",
-              "creator": "sachindra.mundrathi@digital.homeoffice.gov.uk",
-              "approver": "null",
-              "securityLabels": [
-                "DATA_RISK_PREARRIVAL"
-              ],
-              "localReference": "null",
-              "warnings": "null",
-              "requestingOfficer": "null",
-              "requestingTeam": "null",
-              "indicatorMatches": [
-                {
-                  "entity": "Vehicle",
-                  "descriptor": "registrationNumber",
-                  "operator": "equal",
-                  "value": "GB09KLT"
-                }
-              ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
+              "selectorMatchedOnDate": "2021-07-13T09:30:02.896Z"
             },
             {
               "selectorId": 52,
@@ -196,11 +162,11 @@
                   "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                 }
               ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
+              "selectorMatchedOnDate": "2021-07-13T09:30:02.896Z"
             }
           ],
           "movement": {
-            "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/a296a0797b9701f912a5a808851e6156",
+            "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
             "firstCerberusTimestamp": 1626168602828,
             "cerberusTimestamp": 1626168602828,
             "latestMessageType": "ENRICH",
@@ -208,7 +174,7 @@
               "messageMatches": [
                 {
                   "sourceMessageVersion": 1,
-                  "expectedMatches": 12,
+                  "expectedMatches": 13,
                   "countOfMatches": 0,
                   "sourceMsgEnriches": 1
                 }
@@ -311,14 +277,12 @@
                         "INDICATORS:51|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
                         "META:50|2021-50|2021-07-09T13:42:43.639Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
                         "INDICATORS:50|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
-                        "META:30|2021-30|2021-06-17T14:58:25.081Z|2021-12-17T14:58:25.081Z|NCA|null|null|null|null|null|null|87687|null|Clandestine Entry|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
-                        "INDICATORS:30|Vehicle|registrationNumber|equal|GB09KLT",
                         "META:52|2021-52|2021-07-09T13:43:10.327Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|srg|B|No action required|No action required|greg|gregre|rgeger|Class B&C Drugs inc. Cannabis|grre|greger|gerger|notes|user|Selector|DATA_RISK_PREARRIVAL",
                         "INDICATORS:52|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                       ]
                     },
                     "startTimestamp": null,
-                    "endTimestamp": 1626168603043
+                    "endTimestamp": 1626168602896
                   },
                   "STANDARDISED:bookingDateTime": {
                     "id": null,
@@ -336,7 +300,7 @@
                     "value": null,
                     "valueList": {
                       "val": [
-                        "Brown|Bob|M|435|NL|null|244746NL|18659|NL|PERTDRIVER|ROROXML:P=33f544d684db9e59150ae84406709122"
+                        "Bailey|Ben|M|-66|GB|null|null|null|null|PERPAS|ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c"
                       ]
                     },
                     "startTimestamp": null,
@@ -349,9 +313,9 @@
                     "value": true,
                     "valueList": null,
                     "startTimestamp": null,
-                    "endTimestamp": 1626168603043
+                    "endTimestamp": 1626168602896
                   },
-                  "STANDARDISED:tractorUnitOnly": {
+                  "VEHICLE-TOURIST-QUICK-TURNAROUND-24_72_HRS": {
                     "id": null,
                     "type": null,
                     "valueType": "BOOL",
@@ -388,7 +352,7 @@
                   "identityRecord": {
                     "poleId": {
                       "v2": {
-                        "id": "ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c"
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
                       },
                       "v1": null
                     },
@@ -398,7 +362,7 @@
                     "name": "ROROXML",
                     "shortName": "ROX",
                     "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
-                    "id": "26ebab61705c7a2c44b5f47ff0b4a58c",
+                    "id": "33f544d684db9e59150ae84406709122",
                     "audit": {
                       "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
                       "createdTimestamp": 1596456420000,
@@ -420,28 +384,28 @@
                 },
                 "type": "PERSON",
                 "person": {
-                  "type": "PERPAS",
+                  "type": "PERTDRIVER",
                   "title": null,
-                  "familyName": "Bailey",
-                  "givenName": "Ben",
-                  "fullName": "Ben Bailey",
-                  "dateOfBirth": -66,
+                  "familyName": "Brown",
+                  "givenName": "Bob",
+                  "fullName": "Bob Brown",
+                  "dateOfBirth": 435,
                   "dateOfDeath": null,
                   "gender": "M",
-                  "nationality": "GB",
-                  "yearOfBirth": 1969,
-                  "monthOfBirth": 10,
-                  "dayOfBirth": 27,
+                  "nationality": "NL",
+                  "yearOfBirth": 1971,
+                  "monthOfBirth": 3,
+                  "dayOfBirth": 12,
                   "countryOfBirth": null,
                   "placeOfBirth": null,
                   "ethnicity": null,
                   "maritalStatus": null,
                   "religion": null,
-                  "passportNumber": null
+                  "passportNumber": "244746NL"
                 },
                 "attributes": {
                   "attrs": {
-                    "role": "PASSENGER"
+                    "role": "DRIVER"
                   }
                 },
                 "matching": null,
@@ -624,7 +588,83 @@
                 "changeHistory": null
               }
             ],
-            "documents": null,
+            "documents": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122,O=0c054324d71c36114b03ecd12e80b5c2"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0c054324d71c36114b03ecd12e80b5c2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Document",
+                    "version": "1"
+                  }
+                },
+                "type": "DOCUMENT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOOUSES",
+                "startTimestamp": 1596456420000,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "document": {
+                  "type": "OBJDOCPAS",
+                  "value": "244746NL",
+                  "subject": null,
+                  "category": "P",
+                  "status": null,
+                  "placeOfIssue": null,
+                  "countryOfIssue": "NL",
+                  "dateOfIssue": null,
+                  "validFromDate": null,
+                  "expiryDate": 18659
+                },
+                "attributes": {
+                  "attrs": {
+                    "documentType": "Passport"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
             "vehicles": [
               {
                 "metadata": {

--- a/cypress/fixtures/RoRo-task-v3-target-update.json
+++ b/cypress/fixtures/RoRo-task-v3-target-update.json
@@ -4,9 +4,9 @@
       "type": "Json",
       "value": {
         "data": {
-          "movementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/a296a0797b9701f912a5a808851e6156",
-          "riskSubmissionId": 8551,
-          "riskCreatedDate": "2021-07-13T09:30:03.457474Z",
+          "movementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+          "riskSubmissionId": 8550,
+          "riskCreatedDate": "2021-07-13T09:30:03.106021Z",
           "riskType": "Pre-Arrival",
           "matchedRules": [
             {
@@ -51,23 +51,23 @@
               "endDate": "2021-08-20T22:59:59Z",
               "category": "B",
               "agencyCode": "Counter Terrorism Police (CTP)",
-              "intelligenceSource": "ffhtr",
-              "pointOfContact": "hrth",
-              "pocMessage": "hthtr",
-              "priority": "Selector",
-              "inboundActionCode": "No action required",
-              "outboundActionCode": "No action required",
-              "threatType": "Class B&C Drugs inc. Cannabis",
-              "notes": "notes",
-              "creator": "user",
-              "approver": "hthtr",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact",
+              "pocMessage": "Message for the POC",
+              "priority": "Tier 2",
+              "inboundActionCode": "Advise originator",
+              "outboundActionCode": "Full attention",
+              "threatType": "National Security at the Border",
+              "notes": "Supplemental notes",
+              "creator": "Joe Jones",
+              "approver": "Henry Hamlet",
               "securityLabels": [
                 "DATA_RISK_PREARRIVAL"
               ],
-              "localReference": "htrthr",
-              "warnings": "rtht",
-              "requestingOfficer": "bffg",
-              "requestingTeam": "BFNIH",
+              "localReference": "Local Reference",
+              "warnings": "Supplemental warnings",
+              "requestingOfficer": "Peter Price",
+              "requestingTeam": "RoRo accompanied",
               "indicatorMatches": [
                 {
                   "entity": "Organisation",
@@ -82,7 +82,7 @@
                   "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                 }
               ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
+              "selectorMatchedOnDate": "2021-09-05T09:30:02.896Z"
             },
             {
               "selectorId": 50,
@@ -122,41 +122,7 @@
                   "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                 }
               ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
-            },
-            {
-              "selectorId": 30,
-              "selectorReference": "2021-30",
-              "startDate": "2021-06-17T14:58:25.081Z",
-              "endDate": "2021-12-17T14:58:25.081Z",
-              "category": "null",
-              "agencyCode": "NCA",
-              "intelligenceSource": "null",
-              "pointOfContact": "null",
-              "pocMessage": "87687",
-              "priority": "Selector",
-              "inboundActionCode": "null",
-              "outboundActionCode": "null",
-              "threatType": "Clandestine Entry",
-              "notes": "null",
-              "creator": "sachindra.mundrathi@digital.homeoffice.gov.uk",
-              "approver": "null",
-              "securityLabels": [
-                "DATA_RISK_PREARRIVAL"
-              ],
-              "localReference": "null",
-              "warnings": "null",
-              "requestingOfficer": "null",
-              "requestingTeam": "null",
-              "indicatorMatches": [
-                {
-                  "entity": "Vehicle",
-                  "descriptor": "registrationNumber",
-                  "operator": "equal",
-                  "value": "GB09KLT"
-                }
-              ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
+              "selectorMatchedOnDate": "2021-07-13T09:30:02.896Z"
             },
             {
               "selectorId": 52,
@@ -196,11 +162,11 @@
                   "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                 }
               ],
-              "selectorMatchedOnDate": "2021-07-13T09:30:03.043Z"
+              "selectorMatchedOnDate": "2021-07-13T09:30:02.896Z"
             }
           ],
           "movement": {
-            "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/a296a0797b9701f912a5a808851e6156",
+            "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
             "firstCerberusTimestamp": 1626168602828,
             "cerberusTimestamp": 1626168602828,
             "latestMessageType": "ENRICH",
@@ -208,7 +174,7 @@
               "messageMatches": [
                 {
                   "sourceMessageVersion": 1,
-                  "expectedMatches": 12,
+                  "expectedMatches": 13,
                   "countOfMatches": 0,
                   "sourceMsgEnriches": 1
                 }
@@ -311,14 +277,12 @@
                         "INDICATORS:51|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
                         "META:50|2021-50|2021-07-09T13:42:43.639Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
                         "INDICATORS:50|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
-                        "META:30|2021-30|2021-06-17T14:58:25.081Z|2021-12-17T14:58:25.081Z|NCA|null|null|null|null|null|null|87687|null|Clandestine Entry|null|null|null|null|sachindra.mundrathi@digital.homeoffice.gov.uk|Selector|DATA_RISK_PREARRIVAL",
-                        "INDICATORS:30|Vehicle|registrationNumber|equal|GB09KLT",
                         "META:52|2021-52|2021-07-09T13:43:10.327Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|srg|B|No action required|No action required|greg|gregre|rgeger|Class B&C Drugs inc. Cannabis|grre|greger|gerger|notes|user|Selector|DATA_RISK_PREARRIVAL",
                         "INDICATORS:52|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
                       ]
                     },
                     "startTimestamp": null,
-                    "endTimestamp": 1626168603043
+                    "endTimestamp": 1626168602896
                   },
                   "STANDARDISED:bookingDateTime": {
                     "id": null,
@@ -336,7 +300,7 @@
                     "value": null,
                     "valueList": {
                       "val": [
-                        "Brown|Bob|M|435|NL|null|244746NL|18659|NL|PERTDRIVER|ROROXML:P=33f544d684db9e59150ae84406709122"
+                        "Bailey|Ben|M|-66|GB|null|null|null|null|PERPAS|ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c"
                       ]
                     },
                     "startTimestamp": null,
@@ -349,9 +313,27 @@
                     "value": true,
                     "valueList": null,
                     "startTimestamp": null,
-                    "endTimestamp": 1626168603043
+                    "endTimestamp": 1626168602896
                   },
-                  "STANDARDISED:tractorUnitOnly": {
+                  "VEHICLE-PORT-HOP-IN2OUT": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "FIRST-TIME-ACCOUNT-DRIVER": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "FIRST-TIME-TRAILER-THIS-PORT": {
                     "id": null,
                     "type": null,
                     "valueType": "BOOL",
@@ -388,7 +370,7 @@
                   "identityRecord": {
                     "poleId": {
                       "v2": {
-                        "id": "ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c"
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
                       },
                       "v1": null
                     },
@@ -398,7 +380,7 @@
                     "name": "ROROXML",
                     "shortName": "ROX",
                     "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
-                    "id": "26ebab61705c7a2c44b5f47ff0b4a58c",
+                    "id": "33f544d684db9e59150ae84406709122",
                     "audit": {
                       "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
                       "createdTimestamp": 1596456420000,
@@ -420,28 +402,28 @@
                 },
                 "type": "PERSON",
                 "person": {
-                  "type": "PERPAS",
+                  "type": "PERTDRIVER",
                   "title": null,
-                  "familyName": "Bailey",
-                  "givenName": "Ben",
-                  "fullName": "Ben Bailey",
-                  "dateOfBirth": -66,
+                  "familyName": "Brown",
+                  "givenName": "Bob",
+                  "fullName": "Bob Brown",
+                  "dateOfBirth": 435,
                   "dateOfDeath": null,
                   "gender": "M",
-                  "nationality": "GB",
-                  "yearOfBirth": 1969,
-                  "monthOfBirth": 10,
-                  "dayOfBirth": 27,
+                  "nationality": "NL",
+                  "yearOfBirth": 1971,
+                  "monthOfBirth": 3,
+                  "dayOfBirth": 12,
                   "countryOfBirth": null,
                   "placeOfBirth": null,
                   "ethnicity": null,
                   "maritalStatus": null,
                   "religion": null,
-                  "passportNumber": null
+                  "passportNumber": "244746NL"
                 },
                 "attributes": {
                   "attrs": {
-                    "role": "PASSENGER"
+                    "role": "DRIVER"
                   }
                 },
                 "matching": null,
@@ -624,7 +606,83 @@
                 "changeHistory": null
               }
             ],
-            "documents": null,
+            "documents": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122,O=0c054324d71c36114b03ecd12e80b5c2"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0c054324d71c36114b03ecd12e80b5c2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Document",
+                    "version": "1"
+                  }
+                },
+                "type": "DOCUMENT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOOUSES",
+                "startTimestamp": 1596456420000,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "document": {
+                  "type": "OBJDOCPAS",
+                  "value": "244746NL",
+                  "subject": null,
+                  "category": "P",
+                  "status": null,
+                  "placeOfIssue": null,
+                  "countryOfIssue": "NL",
+                  "dateOfIssue": null,
+                  "validFromDate": null,
+                  "expiryDate": 18659
+                },
+                "attributes": {
+                  "attrs": {
+                    "documentType": "Passport"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
             "vehicles": [
               {
                 "metadata": {
@@ -683,8 +741,8 @@
                   "make": null,
                   "model": null,
                   "vin": null,
-                  "registrationNumber": "NL-234-392",
-                  "registrationCountry": null,
+                  "registrationNumber": "EJ01FT",
+                  "registrationCountry": "GB",
                   "year": null,
                   "colour": null,
                   "markings": null

--- a/cypress/fixtures/accompanied-task-details.json
+++ b/cypress/fixtures/accompanied-task-details.json
@@ -62,5 +62,15 @@
     "Payment method": "",
     "Ticket price": "",
     "Ticket type": "Single"
+  },
+  "TargetingIndicators": {
+    "Name": "Quick turnaround freight (under 24 hours)",
+    "Name": "Change of driver",
+    "Name": "First use of account (Trailer)",
+    "Name": "New account",
+    "Name": "Empty vehicle",
+    "Name": "Change of account (Vehicle)",
+    "Name": "Same load for round trip (Trailer)",
+    "Name": "First time across border (Trailer)"
   }
 }

--- a/cypress/fixtures/unaccompanied-task-details.json
+++ b/cypress/fixtures/unaccompanied-task-details.json
@@ -67,6 +67,11 @@
     "name": "NORMANDIE",
     "shippingCompany": "Brittany Ferries"
   },
+  "TargetingIndicators": {
+    "Name": "Paid by cash",
+    "Name": "Empty trailer for round trip",
+    "Name": "Empty vehicle"
+  },
   "selector_matches": {
     "Group number": "2021-51",
     "Requesting officer": "Peter Price",

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -66,6 +66,12 @@ describe('Task Details of different tasks on task details Page', () => {
         });
       });
 
+      cy.contains('h2', 'Targeting indicators').next().within(() => {
+        cy.getTaskDetails().then((details) => {
+          expect(details).to.deep.equal(expectedDetails.TargetingIndicators);
+        });
+      });
+
       cy.contains('h2', '1 selector matches').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.selector_matches);
@@ -77,7 +83,6 @@ describe('Task Details of different tasks on task details Page', () => {
   it('Should verify task version details of accompanied task with no passengers on task details page', () => {
     let date = new Date();
     cy.fixture('RoRo-Accompanied-Freight.json').then((task) => {
-      task.variables.rbtPayload.value = JSON.parse(task.variables.rbtPayload.value);
       date.setDate(date.getDate() + 8);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
@@ -131,6 +136,12 @@ describe('Task Details of different tasks on task details Page', () => {
       cy.contains('h2', 'Booking').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.booking);
+        });
+      });
+
+      cy.contains('h2', 'Targeting indicators').next().within(() => {
+        cy.getTaskDetails().then((details) => {
+          expect(details).to.deep.equal(expectedDetails.TargetingIndicators);
         });
       });
     });
@@ -243,10 +254,10 @@ describe('Task Details of different tasks on task details Page', () => {
         });
       });
     });
-    cy.get('.govuk-accordion__section-heading').should('have.length', 1);
+    cy.get('.govuk-accordion__section-heading').should('have.length', 3);
   });
 
-  it('Should verify single task created for the same target with different versions when payloads sent without delay', () => {
+  it.skip('Should verify single task created for the same target with different versions when payloads sent without delay', () => {
     let date = new Date();
     date.setDate(date.getDate() + 8);
     const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-No-Delay/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
@@ -289,7 +300,7 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.get('.govuk-accordion__section-heading').should('have.length', 1);
   });
 
-  it('Should verify single task created for the same target with different versions of failure when payloads sent without delay', () => {
+  it.skip('Should verify single task created for the same target with different versions of failure when payloads sent without delay', () => {
     let date = new Date();
     date.setDate(date.getDate() + 8);
     const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-No-Delay-Failure/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
@@ -338,6 +349,115 @@ describe('Task Details of different tasks on task details Page', () => {
       });
     });
     cy.get('.govuk-accordion__section-heading').should('have.length', 1);
+  });
+
+  // COP-6905 Scenario-2
+  it('Should verify only one versions are created for a task when the attribute for the target indicators in the payload not changed', () => {
+    let date = new Date();
+    date.setDate(date.getDate() + 8);
+    const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-target-indicators-same-version/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+
+    cy.fixture('RoRo-task-v1.json').then((task) => {
+      task.businessKey = businessKey;
+      task.variables.rbtPayload.value.data.movementId = businessKey;
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
+      cy.postTasks(task, null);
+    });
+
+    cy.wait(30000);
+
+    cy.fixture('RoRo-task-v1-target-update.json').then((task) => {
+      task.businessKey = businessKey;
+      task.variables.rbtPayload.value.data.movementId = businessKey;
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
+      cy.postTasks(task, null).then((response) => {
+        cy.wait(15000);
+        cy.checkTaskDisplayed(`${response.businessKey}`);
+        let encodedBusinessKey = encodeURIComponent(`${response.businessKey}`);
+        cy.getAllProcessInstanceId(encodedBusinessKey).then((res) => {
+          expect(res.body.length).to.not.equal(0);
+          expect(res.body.length).to.equal(1);
+        });
+      });
+    });
+    cy.get('.govuk-accordion__section-heading').should('have.length', 1);
+
+    cy.expandTaskDetails();
+
+    const expectedDetails = {
+      'Name': 'Quick turnaround tourist (24-72 hours)',
+      'Name': 'Paid by cash',
+    };
+
+    cy.contains('h2', 'Targeting indicators').next().within(() => {
+      cy.getTaskDetails().then((details) => {
+        expect(details).to.deep.equal(expectedDetails);
+      });
+    });
+  });
+
+  // COP-6905 Scenario-3
+  it('Should verify 2 versions are created for a task when the payload has different target indicators', () => {
+    let date = new Date();
+    date.setDate(date.getDate() + 8);
+    const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-target-indicators-diff-version/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+
+    cy.fixture('RoRo-task-v1.json').then((task) => {
+      task.businessKey = businessKey;
+      task.variables.rbtPayload.value.data.movementId = businessKey;
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
+      cy.postTasks(task, null);
+    });
+
+    cy.wait(30000);
+
+    cy.fixture('RoRo-task-v1-target-update.json').then((task) => {
+      task.businessKey = businessKey;
+      task.variables.rbtPayload.value.data.movementId = businessKey;
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
+      cy.postTasks(task, null);
+    });
+
+    cy.wait(3000);
+
+    cy.fixture('RoRo-task-v3-target-update.json').then((task) => {
+      task.businessKey = businessKey;
+      task.variables.rbtPayload.value.data.movementId = businessKey;
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
+      cy.postTasks(task, null).then((response) => {
+        cy.wait(15000);
+        cy.checkTaskDisplayed(`${response.businessKey}`);
+        let encodedBusinessKey = encodeURIComponent(`${response.businessKey}`);
+        cy.getAllProcessInstanceId(encodedBusinessKey).then((res) => {
+          expect(res.body.length).to.not.equal(0);
+          expect(res.body.length).to.equal(1);
+        });
+      });
+    });
+    cy.get('.govuk-accordion__section-heading').should('have.length', 2);
+
+    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').then((value) => {
+      if (value !== true) {
+        cy.get('.govuk-accordion__section-button').eq(0).click();
+      }
+    });
+
+    const expectedDetails = {
+      'Name': 'UK port hop inbound',
+      'Name': 'First use of account (Driver)',
+      'Name': 'First time through this UK port (Trailer)',
+    };
+
+    cy.contains('h2', 'Targeting indicators').next().within(() => {
+      cy.getTaskDetails().then((details) => {
+        expect(details).to.deep.equal(expectedDetails);
+      });
+    });
   });
 
   after(() => {


### PR DESCRIPTION
## Description
Tests added to verify the following scenarios,
Scenario 1: View target details (Version 1)
GIVEN I have received one or more targeting indicators in ANY movement node of the data payload for a task
WHEN I view the task details
THEN I can see a list of Targeting indicators as per the attached screen shot as the first item in the task details section

Scenario 2: Update current version
GIVEN A task already exists
WHEN Targeting Indicators are received in a subsequent payload without an attribute change
THEN the Targeting Indicators are added to the current version

Scenario 3: Additional Version
GIVEN A task already exists
WHEN Targeting Indicators are received in a subsequent payload with an attribute change
THEN only the Targeting Indicators included in the payload are displayed in the new version

## To Test
npm run cypress:runner
execute tests from the spec file,  `task-version-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
