### PR TITLE
COP-6433: Add test to verify Auto-expand current task version

### DIFF
--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -240,6 +240,12 @@ describe('Task Details of different tasks on task details Page', () => {
   it('Should verify single task created for the same target with different versions when payloads sent with delay', () => {
     let date = new Date();
     const businessKey = `AUTOTEST-${dateNowFormatted}-RoRo-Versions-with-Delay-30Sec/${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+    const expectedAutoExpandStatus = [
+      'false',
+      'false',
+      'false',
+    ];
+
     date.setDate(date.getDate() + 8);
     cy.fixture('RoRo-task-v1.json').then((task) => {
       task.businessKey = businessKey;
@@ -281,16 +287,19 @@ describe('Task Details of different tasks on task details Page', () => {
 
     // COP-6433 : Auto-expand latest task version
 
-    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'true');
+    cy.get('.govuk-accordion__section-button').first().invoke('attr', 'aria-expanded').should('equal', 'true');
 
-    cy.get('.govuk-accordion__section-button').eq(0).click();
+    cy.get('.govuk-accordion__section-button').first().click();
 
     cy.wait(2000);
 
-    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'false');
+    cy.get('.govuk-accordion__section-button').first().invoke('attr', 'aria-expanded').should('equal', 'false');
     cy.reload();
     cy.wait(2000);
-    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'false');
+
+    cy.get('.govuk-accordion__section-button').each((version, index) => {
+      cy.wrap(version).invoke('attr', 'aria-expanded').should('equal', expectedAutoExpandStatus[index]);
+    });
 
     cy.contains('Sign out').click();
 
@@ -300,7 +309,15 @@ describe('Task Details of different tasks on task details Page', () => {
 
     cy.wait(2000);
 
-    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'true');
+    const expectedDefaultExpandStatus = [
+      'true',
+      'false',
+      'false',
+    ];
+
+    cy.get('.govuk-accordion__section-button').each((version, index) => {
+      cy.wrap(version).invoke('attr', 'aria-expanded').should('equal', expectedDefaultExpandStatus[index]);
+    });
   });
 
   it.skip('Should verify single task created for the same target with different versions when payloads sent without delay', () => {

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -10,17 +10,20 @@ describe('Task Details of different tasks on task details Page', () => {
 
   it('Should verify task version details of unaccompanied task on task details page', () => {
     let date = new Date();
+    let targetURL;
     cy.fixture('RoRo-Unaccompanied-RBT-SBT.json').then((task) => {
       date.setDate(date.getDate() + 8);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-RoRo-UNACC-VERSION`).then((response) => {
         cy.wait(4000);
+        targetURL = response.businessKey;
         cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
 
     cy.wait(2000);
+    cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'true');
     cy.expandTaskDetails();
 
     cy.fixture('unaccompanied-task-details.json').then((expectedDetails) => {
@@ -77,6 +80,22 @@ describe('Task Details of different tasks on task details Page', () => {
           expect(details).to.deep.equal(expectedDetails.selector_matches);
         });
       });
+      // COP-6433 : Auto-expand current task version
+      cy.collapseTaskDetails();
+      cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'false');
+      cy.reload();
+      cy.wait(2000);
+      cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'false');
+
+      cy.contains('Sign out').click();
+
+      cy.login(Cypress.env('userName'));
+
+      cy.checkTaskDisplayed(targetURL);
+
+      cy.wait(2000);
+
+      cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'true');
     });
   });
 
@@ -94,6 +113,7 @@ describe('Task Details of different tasks on task details Page', () => {
 
     cy.wait(2000);
 
+    cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'true');
     cy.expandTaskDetails();
 
     cy.fixture('accompanied-task-details.json').then((expectedDetails) => {
@@ -161,6 +181,8 @@ describe('Task Details of different tasks on task details Page', () => {
     });
 
     cy.wait(2000);
+
+    cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'true');
 
     cy.expandTaskDetails();
 
@@ -383,7 +405,7 @@ describe('Task Details of different tasks on task details Page', () => {
       });
     });
     cy.get('.govuk-accordion__section-heading').should('have.length', 1);
-
+    cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'true');
     cy.expandTaskDetails();
 
     const expectedDetails = {

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -276,7 +276,31 @@ describe('Task Details of different tasks on task details Page', () => {
         });
       });
     });
+
     cy.get('.govuk-accordion__section-heading').should('have.length', 3);
+
+    // COP-6433 : Auto-expand latest task version
+
+    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'true');
+
+    cy.get('.govuk-accordion__section-button').eq(0).click();
+
+    cy.wait(2000);
+
+    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'false');
+    cy.reload();
+    cy.wait(2000);
+    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'false');
+
+    cy.contains('Sign out').click();
+
+    cy.login(Cypress.env('userName'));
+
+    cy.checkTaskDisplayed(businessKey);
+
+    cy.wait(2000);
+
+    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'true');
   });
 
   it.skip('Should verify single task created for the same target with different versions when payloads sent without delay', () => {
@@ -462,6 +486,8 @@ describe('Task Details of different tasks on task details Page', () => {
       });
     });
     cy.get('.govuk-accordion__section-heading').should('have.length', 2);
+
+    cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').should('equal', 'true');
 
     cy.get('.govuk-accordion__section-button').eq(0).invoke('attr', 'aria-expanded').then((value) => {
       if (value !== true) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -373,6 +373,14 @@ Cypress.Commands.add('expandTaskDetails', () => {
   });
 });
 
+Cypress.Commands.add('collapseTaskDetails', () => {
+  cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').then((value) => {
+    if (value === true) {
+      cy.get('.govuk-accordion__section-button').click();
+    }
+  });
+});
+
 Cypress.Commands.add('navigateToTaskDetailsPage', (task) => {
   const processInstanceId = task.map((item) => item.processInstanceId);
   expect(processInstanceId.length).to.not.equal(0);


### PR DESCRIPTION
## Description
Add tests to verify the following scenario,

- click on a target (remember this target url)
- the latest version should be open ​
- close the latest version
- refresh the page
- latest version should stay closed
​
- go back to target list
- click on a different target
- latest version should be open

- go to your first target again
- latest version should be closed (as you left it in a closed state earlier
log out
log in
go to your first target again
latest version should be open (as logging out clears all your states)

## To Test
npm run cypress:runner
run all the tests from test spec,  `task-version-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
