### PR TITLE
COP-8861 Restrict target task view to user with target group

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
     'react/prop-types': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/jsx-one-expression-per-line': 'off',
+    'jest/no-mocks-import': 'off',
   },
   overrides: [
     // Unit tests

--- a/jest.setup.jsx
+++ b/jest.setup.jsx
@@ -1,30 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 
-jest.mock('./src/utils/keycloak', () => ({
-  KeycloakProvider: ({ children }) => children,
-  useKeycloak: () => ({
-    token: 'token',
-    authServerUrl: 'test',
-    realm: 'test',
-    clientId: 'client',
-    refreshToken: 'refreshToken',
-    tokenParsed: {
-      given_name: 'test',
-      family_name: 'test',
-      email: 'test',
-      realm_access: {
-        roles: ['test'],
-      },
-      team_id: '21',
-    },
-    createLogoutUrl: jest.fn(() => 'http://example.com/logout'),
-    logout: jest.fn(() => ({
-      pathname: '/example',
-    })),
-  }),
-}));
-
 jest.mock('react-router-dom', () => ({
   useLocation: jest.fn(() => ({
     pathname: '/example',

--- a/src/__mocks__/keycloakMock.js
+++ b/src/__mocks__/keycloakMock.js
@@ -1,0 +1,24 @@
+jest.mock('../../src/utils/keycloak', () => ({
+  KeycloakProvider: ({ children }) => children,
+  useKeycloak: () => ({
+    token: 'token',
+    authServerUrl: 'test',
+    realm: 'test',
+    clientId: 'client',
+    refreshToken: 'refreshToken',
+    tokenParsed: {
+      given_name: 'test',
+      family_name: 'test',
+      email: 'test',
+      realm_access: {
+        roles: ['test'],
+      },
+      team_id: '21',
+      groups: ['bf-intel-targeters'],
+    },
+    createLogoutUrl: jest.fn(() => 'http://example.com/logout'),
+    logout: jest.fn(() => ({
+      pathname: '/example',
+    })),
+  }),
+}));

--- a/src/__mocks__/keycloakNonTargeterMock.js
+++ b/src/__mocks__/keycloakNonTargeterMock.js
@@ -1,0 +1,24 @@
+jest.mock('../../src/utils/keycloak', () => ({
+  KeycloakProvider: ({ children }) => children,
+  useKeycloak: () => ({
+    token: 'token',
+    authServerUrl: 'test',
+    realm: 'test',
+    clientId: 'client',
+    refreshToken: 'refreshToken',
+    tokenParsed: {
+      given_name: 'test',
+      family_name: 'test',
+      email: 'test',
+      realm_access: {
+        roles: ['test'],
+      },
+      team_id: '21',
+      groups: ['non-targeter-group'],
+    },
+    createLogoutUrl: jest.fn(() => 'http://example.com/logout'),
+    logout: jest.fn(() => ({
+      pathname: '/example',
+    })),
+  }),
+}));

--- a/src/components/__tests__/ClaimTaskButton.test.jsx
+++ b/src/components/__tests__/ClaimTaskButton.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
+import '../../__mocks__/keycloakMock';
 import ClaimButton from '../ClaimTaskButton';
 import TaskListPage from '../../routes/TaskLists/TaskListPage';
 

--- a/src/components/__tests__/Header.test.jsx
+++ b/src/components/__tests__/Header.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '../../__mocks__/keycloakMock';
 import Header from '../Header';
 
 describe('Header', () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,4 +5,4 @@ export const TASK_STATUS_NEW = 'new';
 export const TASK_STATUS_IN_PROGRESS = 'inProgress';
 export const TASK_STATUS_TARGET_ISSUED = 'issued';
 export const TASK_STATUS_COMPLETED = 'complete';
-export const TARGETER_GROUP = '/DS05B2';
+export const TARGETER_GROUP = 'bf-intel-targeters';

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,3 +6,4 @@ export const TASK_STATUS_IN_PROGRESS = 'inProgress';
 export const TASK_STATUS_TARGET_ISSUED = 'issued';
 export const TASK_STATUS_COMPLETED = 'complete';
 export const TARGETER_GROUP = 'bf-intel-targeters';
+// export const TARGETER_GROUP = '/DS05B2';

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,4 +6,3 @@ export const TASK_STATUS_IN_PROGRESS = 'inProgress';
 export const TASK_STATUS_TARGET_ISSUED = 'issued';
 export const TASK_STATUS_COMPLETED = 'complete';
 export const TARGETER_GROUP = 'bf-intel-targeters';
-// export const TARGETER_GROUP = '/DS05B2';

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,3 +5,4 @@ export const TASK_STATUS_NEW = 'new';
 export const TASK_STATUS_IN_PROGRESS = 'inProgress';
 export const TASK_STATUS_TARGET_ISSUED = 'issued';
 export const TASK_STATUS_COMPLETED = 'complete';
+export const TARGETER_GROUP = '/DS05B2';

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -161,7 +161,11 @@ const TasksTab = ({ taskStatus, setError }) => {
   }, [location.search]);
 
   useEffect(() => {
-    if (activePage > 0) {
+    const isTargeter = (keycloak.tokenParsed.groups).indexOf('/DS05B2no') > -1;
+    if (!isTargeter) {
+      console.log('no')
+    }
+    if (activePage > 0 && isTargeter) {
       loadTasks();
       return () => {
         source.cancel('Cancelling request');

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -177,11 +177,14 @@ const TasksTab = ({ taskStatus, setError }) => {
   }, [activePage]);
 
   useInterval(() => {
-    setLoading(true);
-    loadTasks();
-    return () => {
-      source.cancel('Cancelling request');
-    };
+    const isTargeter = (keycloak.tokenParsed.groups).indexOf(TARGETER_GROUP) > -1;
+    if (isTargeter) {
+      setLoading(true);
+      loadTasks();
+      return () => {
+        source.cancel('Cancelling request');
+      };
+    }
   }, 60000);
 
   return (

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '../../__mocks__/keycloakMock';
 import TaskDetailsPage from '../TaskDetails/TaskDetailsPage';
 import variableInstanceStatusNew from '../__fixtures__/variableInstanceStatusNew.fixture.json';
 import variableInstanceStatusComplete from '../__fixtures__/variableInstanceStatusComplete.fixture.json';

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '../../__mocks__/keycloakMock';
 import TaskListPage from '../TaskLists/TaskListPage';
 import variableInstanceTaskSummaryBasedOnTIS from '../__fixtures__/variableInstanceTaskSummaryBasedOnTIS.fixture.json';
 
@@ -15,7 +16,6 @@ describe('TaskListPage', () => {
 
   it('should render loading spinner on component load', () => {
     render(<TaskListPage taskStatus="new" setError={() => { }} />);
-
     expect(screen.getByText('Loading')).toBeInTheDocument();
   });
 
@@ -40,6 +40,7 @@ describe('TaskListPage', () => {
 
     await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
 
+    expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
     expect(screen.getByText('New')).toBeInTheDocument();
     expect(screen.getByText('Target issued')).toBeInTheDocument();
 

--- a/src/routes/__tests__/TaskListPageNonTargeter.test.jsx
+++ b/src/routes/__tests__/TaskListPageNonTargeter.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '../../__mocks__/keycloakNonTargeterMock';
+import TaskListPage from '../TaskLists/TaskListPage';
+
+describe('TaskListPage for non targeter', () => {
+  jest.mock('../../__mocks__/keycloakNonTargeterMock');
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => { });
+  });
+
+  it('Should not load tasks if user does not have the correct targeter group', async () => {
+    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    expect(screen.getByText('You are not authorised to view these tasks.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description
Only users with the group `bf-intel-targeters` should be able to see tasks in the task lists

## To Test

GIVEN I am a COP user
WHEN I included in the "bf-intel-targeters" group
THEN I am able to view the Targeters task list

GIVEN I am a COP user
WHEN I am NOT included in the "bf-intel-targeters" group
THEN I am NOT able to view the Targeters task list

**To test as a dev:**
- in `constants.js` file, set `TARGETER_GROUP` to `bf-intel-targeters`
- (check if devops have given you that group yet)
- > if you have that group, go to `/tasks` and you should see tasks
- > if you do not have that group, go to `/tasks` and you should NOT see tasks

**If you have bf-intel-targeters group**
- in `constants.js` file, set `TARGETER_GROUP` to `not-my-group`
- > go to `/tasks` you should NOT see tasks

**If you do not have bf-intel-targeters group**
- in `constants.js` file, set `TARGETER_GROUP` to `COP_ADMIN`
- > go to `/tasks` you SHOULD see tasks

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
