### PR TITLE
COP-8775 Add scenario for assignee !== currentUser

### DIFF
--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -59,6 +59,9 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, businessKey, .
   if (!assignee) {
     return <CommonButton onClick={handleClaim} {...props}>Claim</CommonButton>;
   }
+  if (assignee !== currentUser) {
+    return <span>{`Already claimed by ${assignee}`}</span>;
+  }
   return null;
 };
 


### PR DESCRIPTION
## Description
Handle edge case of two users clicking 'claim' on the same task within seconds of each other

Added a check on the ClaimTaskButton component for when assignee !== currentUser.
This exists on TaskListPage and TaskDetailsPage, but in the edge case, userA and userB are both on those pages and click 'claim' before any reload so the pages are still in a state of assuming the task is unclaimed.

## To Test

Scenario One

- userA is on task list new tab
- userB is also on task list new tab
- userA clicks 'claim' on task 123
- userB clicks 'claim' on task 123
- take userB to task but show that task already claimed
 

Scenario Two

- userA is on task details page for task 123
- userB is also on task details page for task 123
- userA clicks 'claim'
- userB clicks 'claim'
- userB should be shown that task is already claimed
- userB's view of task should be updated to show userA has claimed it

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
