### PR TITLE
Cop 8798 display claim name

### DIFF
--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -60,7 +60,7 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, businessKey, .
     return <CommonButton onClick={handleClaim} {...props}>Claim</CommonButton>;
   }
   if (assignee !== currentUser) {
-    return <span>{`Already claimed by ${assignee}`}</span>;
+    return <span className="govuk-body">{`Assigned to ${assignee}`}</span>;
   }
   return null;
 };

--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -59,6 +59,9 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, businessKey, .
   if (!assignee) {
     return <CommonButton onClick={handleClaim} {...props}>Claim</CommonButton>;
   }
+  if (assignee !== currentUser) {
+    return <span>{`Already claimed by ${assignee}`}</span>;
+  }
   return null;
 };
 

--- a/src/components/__tests__/ClaimTaskButton.test.jsx
+++ b/src/components/__tests__/ClaimTaskButton.test.jsx
@@ -93,4 +93,22 @@ describe('Claim/Unclaim buttons', () => {
     expect(screen.queryByText('Target issued tasks')).not.toBeInTheDocument();
     expect(screen.queryByText('Completed tasks')).not.toBeInTheDocument();
   });
+
+  it('should render with text of username when the assignee does not match the current user', async () => {
+    const task = {
+      assignee: 'not-current-user',
+      id: '123',
+    };
+
+    render(<ClaimButton
+      className="govuk-!-font-weight-bold"
+      assignee={task.assignee}
+      taskId={task.id}
+      setError={setError}
+    />);
+
+    await waitFor(() => expect(screen.queryByText('Claim')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Unclaim')).not.toBeInTheDocument());
+    expect(screen.getByText(/Assigned to not-current-user/i)).toBeInTheDocument();
+  });
 });

--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -258,6 +258,14 @@ const TaskDetailsPage = () => {
     return <LoadingSpinner><br /><br /><br /></LoadingSpinner>;
   }
 
+  /*
+   * TaskListPage and TaskDetailsPage both use the
+   * ClaimButton logic to display claim/unclaim button
+   * And to display who the task is assigned to
+   * if it's already assigned (ie assignee !== currentUser)
+   * TaskDetaisPage needs extra text in the two scenarios
+   * listed below
+  */
   const getAssignee = () => {
     if (!assignee) {
       return 'Unassigned ';
@@ -265,7 +273,6 @@ const TaskDetailsPage = () => {
     if (assignee === currentUser) {
       return 'Assigned to you ';
     }
-    return `Assigned to ${assignee} `;
   };
 
   return (

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -217,7 +217,7 @@ const TasksTab = ({ taskStatus, setError }) => {
                 </h4>
               </div>
               <div className="govuk-grid-column-one-quarter govuk-!-font-size-19">
-                { (activeTab === TASK_STATUS_NEW || currentUser === target.assignee)
+                { (activeTab === TASK_STATUS_NEW || activeTab === TASK_STATUS_IN_PROGRESS || currentUser === target.assignee)
                   && (
                   <ClaimButton
                     className="govuk-!-font-weight-bold"

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -150,8 +150,8 @@ describe('TaskListPage', () => {
       .onGet('/task')
       .reply(200, [
         { processInstanceId: '123', assignee: 'test' },
-        { processInstanceId: '456', assignee: null },
-        { processInstanceId: '789', assignee: null },
+        { processInstanceId: '456', assignee: 'another-user' },
+        { processInstanceId: '789', assignee: 'another-user' },
       ])
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);


### PR DESCRIPTION
## Description
Display claimed by name on task list

- Added a check on the ClaimTaskButton component for when assignee !== currentUser, to now return Assigned to username.
- Included IN_PROGRESS tab to show all claim button types
- Added comment to TaskDetails page to explain why only two scenarios covered in that code now
- Updated tests

## To Test

- go to In progress tab
- > you should see `assigned to <email>` if someone else has claimed the task
- > you should see `unclaim` if you have claimed the task

- go to task details
- > you should see `assigned to <email>` if someone else has claimed the task
- > you should see `assigned to you unclaim` if you have claimed the task
- > you should see `claim` if no one has claimed the task

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
