### PR TITLE
Wrap rather than overflow email addresses

### DIFF
--- a/src/components/ClaimTaskButton.jsx
+++ b/src/components/ClaimTaskButton.jsx
@@ -60,7 +60,7 @@ const ClaimTaskButton = ({ assignee, taskId, setError = () => {}, businessKey, .
     return <CommonButton onClick={handleClaim} {...props}>Claim</CommonButton>;
   }
   if (assignee !== currentUser) {
-    return <span className="govuk-body">{`Assigned to ${assignee}`}</span>;
+    return <span className="govuk-body task-list--email">{`Assigned to ${assignee}`}</span>;
   }
   return null;
 };

--- a/src/routes/__assets__/TaskListPage.scss
+++ b/src/routes/__assets__/TaskListPage.scss
@@ -42,6 +42,10 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 
 }
 
+.task-list--email {
+  overflow-wrap: break-word;
+}
+
 .govuk-tag.govuk-tag--positiveTarget {
   @include govuk-font($size: 14, $weight: bold, $line-height: 1);
   height: 19px;


### PR DESCRIPTION
## Description
Email addresses overflow the container

Updated - set a class to wrap task-list--email addresses so they break and wrap

## To Test

View InProgress tab, you should see email addresses wrapping
Shrink screen, they should wrap more

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
