### PR TITLE
COP-9152 Move count shown in tabs to after label

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -535,7 +535,7 @@ const TaskListPage = () => {
               items={[
                 {
                   id: TASK_STATUS_NEW,
-                  label: `${taskCountsByStatus?.TASK_STATUS_NEW || ''} New`,
+                  label: `New (${taskCountsByStatus?.TASK_STATUS_NEW || '0'})`,
                   panel: (
                     <>
                       <h2 className="govuk-heading-l">New tasks</h2>
@@ -545,7 +545,7 @@ const TaskListPage = () => {
                 },
                 {
                   id: TASK_STATUS_IN_PROGRESS,
-                  label: `${taskCountsByStatus?.TASK_STATUS_IN_PROGRESS || ''} In progress`,
+                  label: `In progress (${taskCountsByStatus?.TASK_STATUS_IN_PROGRESS || '0'})`,
                   panel: (
                     <>
                       <h2 className="govuk-heading-l">In progress tasks</h2>
@@ -555,7 +555,7 @@ const TaskListPage = () => {
                 },
                 {
                   id: TASK_STATUS_TARGET_ISSUED,
-                  label: `${taskCountsByStatus?.TASK_STATUS_TARGET_ISSUED || ''} Issued`,
+                  label: `Issued (${taskCountsByStatus?.TASK_STATUS_TARGET_ISSUED || '0'})`,
                   panel: (
                     <>
                       <h2 className="govuk-heading-l">Target issued tasks</h2>
@@ -565,7 +565,7 @@ const TaskListPage = () => {
                 },
                 {
                   id: TASK_STATUS_COMPLETED,
-                  label: `${taskCountsByStatus?.TASK_STATUS_COMPLETED || ''} Complete`,
+                  label: `Complete (${taskCountsByStatus?.TASK_STATUS_COMPLETED || '0'})`,
                   panel: (
                     <>
                       <h2 className="govuk-heading-l">Completed tasks</h2>

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -41,8 +41,8 @@ describe('TaskListPage', () => {
     await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
 
     expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
-    expect(screen.getByText('7 New')).toBeInTheDocument();
-    expect(screen.getByText('5 Issued')).toBeInTheDocument();
+    expect(screen.getByText('New (7)')).toBeInTheDocument();
+    expect(screen.getByText('Issued (5)')).toBeInTheDocument();
   });
 
   it('should render no tasks available message when New, In Progress, Target Issued and Complete tabs are clicked and there are no tasks', async () => {
@@ -67,8 +67,8 @@ describe('TaskListPage', () => {
     await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
 
     expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
-    expect(screen.getByText('0 New')).toBeInTheDocument();
-    expect(screen.getByText('0 Issued')).toBeInTheDocument();
+    expect(screen.getByText('New (0)')).toBeInTheDocument();
+    expect(screen.getByText('Issued (0)')).toBeInTheDocument();
 
     expect(screen.getByText('No tasks available')).toBeInTheDocument();
     expect(screen.queryByText('Request failed with status code 404')).not.toBeInTheDocument();


### PR DESCRIPTION
## Description
Design change to move the count to be shown in brackets after the label in the tab

## To Test

Tabs should read
`New (123)` not `123 New`

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
