### PR TITLE
calculate relative time difference between the booking date and departure date

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -15,6 +15,7 @@ import config from '../../config';
 // Utils
 import useAxiosInstance from '../../utils/axiosInstance';
 import { useKeycloak } from '../../utils/keycloak';
+import targetDatetimeDifference from '../../utils/calculateDatetimeDifference';
 // Components/Pages
 import ClaimButton from '../../components/ClaimTaskButton';
 import ErrorSummary from '../../govuk/ErrorSummary';
@@ -351,7 +352,8 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
                   {target.roro.details.account ? (
                     <>
                       {target.roro.details.account.name && <li className="govuk-!-font-weight-bold">{target.roro.details.account.name}</li>}
-                      {target.roro.details.bookingDateTime && <li>Booked on {dayjs.utc(target.roro.details.bookingDateTime).format(SHORT_DATE_FORMAT)}</li>}
+                      {target.roro.details.bookingDateTime && <li>Booked on {dayjs.utc(target.roro.details.bookingDateTime.split(",")[0]).format(SHORT_DATE_FORMAT)}</li>}
+                      {target.roro.details.bookingDateTime && <li>{targetDatetimeDifference(target.roro.details.bookingDateTime)}</li>}
                     </>
                   ) : (<li className="govuk-!-font-weight-bold">Unknown</li>)}
                 </ul>

--- a/src/utils/__tests__/calculateDatetimeDifference.test.js
+++ b/src/utils/__tests__/calculateDatetimeDifference.test.js
@@ -1,0 +1,19 @@
+import targetDatetimeDifference from '../calculateDatetimeDifference';
+
+describe('should calculate and return relative time diff between booking time and departure time', () => {
+    it.each([
+        ["2020-10-24T01:15:00,2020-11-08T14:00:00", "Booked 16 days before travel"],
+        ["2020-10-24T01:15:00,2020-10-25T01:15:00", "Booked a day before travel"],
+        ["2019-10-24T01:15:00,2020-11-08T14:00:00", "Booked a year before travel"],
+        ["2017-10-24T01:15:00,2020-11-08T14:00:00", "Booked 3 years before travel"],
+        ["2020-10-24T01:15:00,2020-11-24T14:00:00", "Booked a month before travel"],
+        ["2020-09-24T01:15:00,2020-11-24T14:00:00", "Booked 2 months before travel"],
+        ["2020-09-24T01:15:00,2020-09-24T02:15:00", "Booked an hour before travel"],
+        ["2020-09-24T01:15:00,2020-09-24T03:15:00", "Booked 2 hours before travel"],
+        ["2020-10-24T15:15:00,", ""]
+    ])(
+        'should calculate the relative time difference', (bookingDatetime, expected) => {
+            expect(targetDatetimeDifference(bookingDatetime)).toEqual(expected);          
+        }  
+    )
+});

--- a/src/utils/calculateDatetimeDifference.js
+++ b/src/utils/calculateDatetimeDifference.js
@@ -1,0 +1,19 @@
+// Third party imports
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+
+/**
+ * Calculate difference between booking date and departure date 
+ */
+const targetDatetimeDifference = (bookingDatimeDifference) => {
+    const datetimeArray = bookingDatimeDifference.split(",").filter(x => x.length > 0);
+    // Date at index 0, is the booking date.
+    if (datetimeArray.length > 1) {
+        return "Booked " + dayjs(datetimeArray[1]).from(datetimeArray[0], true) + " before travel";
+    }
+    return "";
+};
+
+export default targetDatetimeDifference;


### PR DESCRIPTION
This PR adds an aditional field to the TaskListPage which contains the relative time difference between the departure time and booking time.

In addition, also addresses a minor issue where by the variable containing the merged departure time and booking time is used to display the booking time.