### PR TITLE
COP-9050 Difference between the date of departure and the booking date

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,23 @@ const config = {
   refdataApiUrl: process.env.REFDATA_API_URL,
   formApiUrl: process.env.FORM_API_URL,
   camundaApiUrl: '/camunda',
+  dayjsConfig: {
+    relativeTime: {
+      future: '%s before travel',
+      past: '%s after travel',
+      s: 'a few seconds',
+      m: 'a minute',
+      mm: '%d minutes',
+      h: 'an hour',
+      hh: '%d hours',
+      d: 'a day',
+      dd: '%d days',
+      M: 'a month',
+      MM: '%d months',
+      y: 'a year',
+      yy: '%d years',
+    },
+  },
 };
 
 export default config;

--- a/src/routes/TaskDetails/TaskSummary.jsx
+++ b/src/routes/TaskDetails/TaskSummary.jsx
@@ -8,6 +8,7 @@ import '../__assets__/TaskDetailsPage.scss';
 const TaskSummary = ({ taskSummaryData }) => {
   dayjs.extend(utc);
   const roroData = taskSummaryData.roro.details;
+  const bookingDateTime = roroData.bookingDateTime ? dayjs.utc(roroData.bookingDateTime.split(',')[0]) : '';
 
   return (
     <section className="card">
@@ -41,7 +42,7 @@ const TaskSummary = ({ taskSummaryData }) => {
         <div className="govuk-grid-column-one-half">
           <dl className="mode-details">
             <dt>Account</dt>
-            <dd>{!roroData.account?.name ? 'unknown' : roroData.account.name}{dayjs.utc(roroData.bookingDateTime).isValid() && <span className="govuk-!-font-weight-regular">, booked on {dayjs.utc(roroData.bookingDateTime).format(LONG_DATE_FORMAT)}</span>}</dd>
+            <dd>{!roroData.account?.name ? 'unknown' : roroData.account.name}{dayjs.utc(bookingDateTime).isValid() && <span className="govuk-!-font-weight-regular">, booked on {dayjs.utc(bookingDateTime).format(LONG_DATE_FORMAT)}</span>}</dd>
             <dt>Haulier</dt>
             <dd>{!roroData.haulier?.name ? 'unknown' : roroData.haulier.name}</dd>
           </dl>

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -76,7 +76,7 @@ const TaskVersions = ({ taskVersions, businessKey, taskVersionDifferencesCounts 
         */
         taskVersions.map((version, index) => {
           const booking = version.find((fieldset) => fieldset.propName === 'booking') || null;
-          const bookingDate = booking?.contents.find((field) => field.propName === 'dateBooked') || null;
+          const bookingDate = booking?.contents.find((field) => field.propName === 'dateBooked').content || null;
           const versionNumber = taskVersions.length - index;
           const detailSection = version.map((field) => {
             return (
@@ -95,7 +95,7 @@ const TaskVersions = ({ taskVersions, businessKey, taskVersionDifferencesCounts 
               summary: (
                 <>
                   <div className="task-versions--left">
-                    <div className="govuk-caption-m">{dayjs.utc(bookingDate?.content || null).format(LONG_DATE_FORMAT)}</div>
+                    <div className="govuk-caption-m">{dayjs.utc(bookingDate ? bookingDate.split(',')[0] : null).format(LONG_DATE_FORMAT)}</div>
                   </div>
                   <div className="task-versions--right">
                     <ul className="govuk-list">

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -1,44 +1,11 @@
 import React, { Fragment } from 'react';
 import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 import * as pluralise from 'pluralise';
 import { v4 as uuidv4 } from 'uuid';
 
 import Accordion from '../../govuk/Accordion';
-import { LONG_DATE_FORMAT, SHORT_DATE_FORMAT } from '../../constants';
-
-const formatField = (fieldType, content) => {
-  dayjs.extend(utc);
-  if (!content) {
-    return '';
-  }
-  let result;
-
-  switch (true) {
-    case fieldType.includes('DISTANCE'):
-      result = `${content}m`;
-      break;
-    case fieldType.includes('WEIGHT'):
-      result = `${content}kg`;
-      break;
-    case fieldType.includes('CURRENCY'):
-      result = `£${content}`;
-      break;
-    case fieldType.includes('SHORT_DATE'):
-      result = dayjs(0).add(content, 'days').format(SHORT_DATE_FORMAT);
-      break;
-    case fieldType.includes('DATETIME'):
-      result = dayjs.utc(content).format(LONG_DATE_FORMAT);
-      break;
-    default:
-      result = content;
-  }
-
-  if (fieldType.includes('CHANGED')) {
-    result = <span className="task-versions--highlight">{result}</span>;
-  }
-  return result;
-};
+import { LONG_DATE_FORMAT } from '../../constants';
+import formatField from '../../utils/formatField';
 
 const renderFieldSetContents = (contents) => (
   contents.map(({ fieldName, content, type }) => {

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -352,7 +352,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
                   {target.roro.details.account ? (
                     <>
                       {target.roro.details.account.name && <li className="govuk-!-font-weight-bold">{target.roro.details.account.name}</li>}
-                      {target.roro.details.bookingDateTime && <li>Booked on {dayjs.utc(target.roro.details.bookingDateTime.split(",")[0]).format(SHORT_DATE_FORMAT)}</li>}
+                      {target.roro.details.bookingDateTime && <li>Booked on {dayjs.utc(target.roro.details.bookingDateTime.split(',')[0]).format(SHORT_DATE_FORMAT)}</li>}
                       {target.roro.details.bookingDateTime && <li>{targetDatetimeDifference(target.roro.details.bookingDateTime)}</li>}
                     </>
                   ) : (<li className="govuk-!-font-weight-bold">Unknown</li>)}

--- a/src/utils/__tests__/calculateDatetimeDifference.test.js
+++ b/src/utils/__tests__/calculateDatetimeDifference.test.js
@@ -1,19 +1,19 @@
 import targetDatetimeDifference from '../calculateDatetimeDifference';
 
 describe('should calculate and return relative time diff between booking time and departure time', () => {
-    it.each([
-        ["2020-10-24T01:15:00,2020-11-08T14:00:00", "Booked 16 days before travel"],
-        ["2020-10-24T01:15:00,2020-10-25T01:15:00", "Booked a day before travel"],
-        ["2019-10-24T01:15:00,2020-11-08T14:00:00", "Booked a year before travel"],
-        ["2017-10-24T01:15:00,2020-11-08T14:00:00", "Booked 3 years before travel"],
-        ["2020-10-24T01:15:00,2020-11-24T14:00:00", "Booked a month before travel"],
-        ["2020-09-24T01:15:00,2020-11-24T14:00:00", "Booked 2 months before travel"],
-        ["2020-09-24T01:15:00,2020-09-24T02:15:00", "Booked an hour before travel"],
-        ["2020-09-24T01:15:00,2020-09-24T03:15:00", "Booked 2 hours before travel"],
-        ["2020-10-24T15:15:00,", ""]
-    ])(
-        'should calculate the relative time difference', (bookingDatetime, expected) => {
-            expect(targetDatetimeDifference(bookingDatetime)).toEqual(expected);          
-        }  
-    )
+  it.each([
+    ['2020-10-24T01:15:00,2020-11-08T14:00:00', 'Booked 16 days before travel'],
+    ['2020-10-24T01:15:00,2020-10-25T01:15:00', 'Booked a day before travel'],
+    ['2019-10-24T01:15:00,2020-11-08T14:00:00', 'Booked a year before travel'],
+    ['2017-10-24T01:15:00,2020-11-08T14:00:00', 'Booked 3 years before travel'],
+    ['2020-10-24T01:15:00,2020-11-24T14:00:00', 'Booked a month before travel'],
+    ['2020-09-24T01:15:00,2020-11-24T14:00:00', 'Booked 2 months before travel'],
+    ['2020-09-24T01:15:00,2020-09-24T02:15:00', 'Booked an hour before travel'],
+    ['2020-09-24T01:15:00,2020-09-24T03:15:00', 'Booked 2 hours before travel'],
+    ['2020-10-24T15:15:00,', ''],
+  ])(
+    'should calculate the relative time difference', (bookingDatetime, expected) => {
+      expect(targetDatetimeDifference(bookingDatetime)).toEqual(expected);
+    },
+  );
 });

--- a/src/utils/__tests__/formatField.test.jsx
+++ b/src/utils/__tests__/formatField.test.jsx
@@ -1,0 +1,20 @@
+import formatField from '../formatField';
+
+describe('formatField', () => {
+  describe('BOOKING_DATETIME type', () => {
+    it.each([
+      ['2020-10-24T01:15:00,2020-11-08T14:00:00', '24 Oct 2020 at 01:15, 16 days before travel'],
+      ['2020-10-24T01:15:00,2020-10-25T01:15:00', '24 Oct 2020 at 01:15, a day before travel'],
+      ['2019-10-24T01:15:00,2020-11-08T14:00:00', '24 Oct 2019 at 01:15, a year before travel'],
+      ['2017-10-24T01:15:00,2020-11-08T14:00:00', '24 Oct 2017 at 01:15, 3 years before travel'],
+      ['2020-10-24T01:15:00,2020-11-24T14:00:00', '24 Oct 2020 at 01:15, a month before travel'],
+      ['2020-09-24T01:15:00,2020-11-24T14:00:00', '24 Sep 2020 at 01:15, 2 months before travel'],
+      ['2020-09-24T01:15:00,2020-09-24T02:15:00', '24 Sep 2020 at 01:15, an hour before travel'],
+      ['2020-09-24T01:15:00,2020-09-24T03:15:00', '24 Sep 2020 at 01:15, 2 hours before travel'],
+    ])(
+      'should format the booking datetime correctly', (bookingDatetime, expectedOutput) => {
+        expect(formatField('BOOKING_DATETIME', bookingDatetime)).toEqual(expectedOutput);
+      },
+    );
+  });
+});

--- a/src/utils/calculateDatetimeDifference.js
+++ b/src/utils/calculateDatetimeDifference.js
@@ -5,15 +5,15 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 dayjs.extend(relativeTime);
 
 /**
- * Calculate difference between booking date and departure date 
+ * Calculate difference between booking date and departure date
  */
 const targetDatetimeDifference = (bookingDatimeDifference) => {
-    const datetimeArray = bookingDatimeDifference.split(",").filter(x => x.length > 0);
-    // Date at index 0, is the booking date.
-    if (datetimeArray.length > 1) {
-        return "Booked " + dayjs(datetimeArray[1]).from(datetimeArray[0], true) + " before travel";
-    }
-    return "";
+  const datetimeArray = bookingDatimeDifference.split(',').filter((x) => x.length > 0);
+  // Date at index 0, is the booking date.
+  if (datetimeArray.length > 1) {
+    return `Booked ${dayjs(datetimeArray[1]).from(datetimeArray[0], true)} before travel`;
+  }
+  return '';
 };
 
 export default targetDatetimeDifference;

--- a/src/utils/formatField.jsx
+++ b/src/utils/formatField.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import updateLocale from 'dayjs/plugin/updateLocale';
+
+import config from '../config';
+import { LONG_DATE_FORMAT, SHORT_DATE_FORMAT } from '../constants';
+
+export default (fieldType, content) => {
+  dayjs.extend(utc);
+  dayjs.extend(relativeTime);
+  dayjs.extend(updateLocale);
+  dayjs.updateLocale('en', { relativeTime: config.dayjsConfig.relativeTime });
+  if (!content) {
+    return '';
+  }
+  let result;
+
+  switch (true) {
+    case fieldType.includes('DISTANCE'):
+      result = `${content}m`;
+      break;
+    case fieldType.includes('WEIGHT'):
+      result = `${content}kg`;
+      break;
+    case fieldType.includes('CURRENCY'):
+      result = `£${content}`;
+      break;
+    case fieldType.includes('SHORT_DATE'):
+      result = dayjs(0).add(content, 'days').format(SHORT_DATE_FORMAT);
+      break;
+    case fieldType.includes('BOOKING_DATETIME'): {
+      const splitBookingDateTime = content.split(',');
+      const bookingDateTime = dayjs.utc(splitBookingDateTime[0]);
+      if (splitBookingDateTime.length < 2) {
+        result = bookingDateTime.format(LONG_DATE_FORMAT);
+      } else {
+        const scheduledDepartureTime = dayjs.utc(splitBookingDateTime[1]);
+        const difference = scheduledDepartureTime.from(bookingDateTime);
+        result = `${bookingDateTime.format(LONG_DATE_FORMAT)}, ${difference}`;
+      }
+      break;
+    }
+    case fieldType.includes('DATETIME'):
+      result = dayjs.utc(content).format(LONG_DATE_FORMAT);
+      break;
+    default:
+      result = content;
+  }
+
+  if (fieldType.includes('CHANGED')) {
+    result = <span className="task-versions--highlight">{result}</span>;
+  }
+  return result;
+};


### PR DESCRIPTION
## Description
This PR formats the new type given to the booking date time. The booking datetime now consists of 2 parts, the `bookingDatetime` (BDT) and the `scheduledDepartureTime` (SDT) which is required for the task versions section.  
## To Test
- Pull and run against dev
- Navigate to a single task (do this for when there is a BDT present - and when there isn't)
- *The task version summary BDT should be displayed correctly*
- Open the task version and navigate to the BDT
- *It should be displayed correctly according to what information was provided i.e. with both BDT and  SDT it renders `2 Aug 2020 at 09:15, a day before travel` and for only BDT `2 Aug 2020 at 09:15`*
## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
