### PR TITLE
fixed minor bug as part of COP-9192 where relative time calculation would appear on the same line as the booking time 

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -353,6 +353,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
                     <>
                       {target.roro.details.account.name && <li className="govuk-!-font-weight-bold">{target.roro.details.account.name}</li>}
                       {target.roro.details.bookingDateTime && <li>Booked on {dayjs.utc(target.roro.details.bookingDateTime.split(',')[0]).format(SHORT_DATE_FORMAT)}</li>}
+                      {target.roro.details.bookingDateTime && <br />}
                       {target.roro.details.bookingDateTime && <li>{targetDatetimeDifference(target.roro.details.bookingDateTime)}</li>}
                     </>
                   ) : (<li className="govuk-!-font-weight-bold">Unknown</li>)}


### PR DESCRIPTION

## Description
This PR fixes a minor bug where relative time calculation would appear on the same line as the booking time when viewed on a wide display.

## To Test

- Pull and run against dev
- On the task list, if scheduled departure time is available, the relative time difference calculation e.g. `Booked 2 days before travel` should appear below the line containing the booking date.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
