### PR TITLE
fixed bug where relative time difference differed from most recent ve…

### DIFF
--- a/src/utils/calculateDatetimeDifference.js
+++ b/src/utils/calculateDatetimeDifference.js
@@ -1,8 +1,15 @@
 // Third party imports
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import updateLocale from 'dayjs/plugin/updateLocale';
 
+import config from '../config';
+
+dayjs.extend(utc);
 dayjs.extend(relativeTime);
+dayjs.extend(updateLocale);
+dayjs.updateLocale('en', { relativeTime: config.dayjsConfig.relativeTime });
 
 /**
  * Calculate difference between booking date and departure date
@@ -11,7 +18,9 @@ const targetDatetimeDifference = (bookingDatimeDifference) => {
   const datetimeArray = bookingDatimeDifference.split(',').filter((x) => x.length > 0);
   // Date at index 0, is the booking date.
   if (datetimeArray.length > 1) {
-    return `Booked ${dayjs(datetimeArray[1]).from(datetimeArray[0], true)} before travel`;
+    const bookingDateTime = dayjs.utc(datetimeArray[0]);
+    const scheduledDepartureTime = dayjs.utc(datetimeArray[1]);
+    return `Booked ${scheduledDepartureTime.from(bookingDateTime)}`;
   }
   return '';
 };


### PR DESCRIPTION
## Description
This PR fixes a bug that appeared during testing of COP-9050. Relative time difference shown
in task list was opposite of what was in the most recent version of a task.
Task List would show 'Booked 2 hours before travel', most recent version of a task would show
'Booked 2 hours after travel'.

## To Test
- Pull and run against dev
- On the task list, if task has a scheduled departure time, the relative time difference between the booking time and departure time shown in the task list should correlate with that found in that particular task when viewing the most recent version of it.
- Check against Task: **AUTOTEST-18-11-2021-RORO-Accompanied-Freight-different-versions-task_846387%3ACMID%3DTEST** as this was one that was highlighted during the testing of COP-9050.


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
