### PR TITLE
COP-9192: Add tests to verify Booking Date time on taskList Page and taskSummary

### DIFF
--- a/cypress/fixtures/taskInfo-known/RoRo-Acc-TaskDetails-expected.json
+++ b/cypress/fixtures/taskInfo-known/RoRo-Acc-TaskDetails-expected.json
@@ -1,89 +1,98 @@
 {
-  "taskListDetail": ["Pre-ArrivalClaim",
-    "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
-    "Brittany Ferries voyage of BARFLEURarrival a year ago",
-    "DOV4 Aug 2020 at 13:05CAL4 Aug 2020 at 13:35",
-    "Driver detailsBenBaileyDOB: 27/10/1969? trips",
-    "Passenger details1 passenger",
-    "Vehicle detailsCOP1Colour-WhiteModel-xyzMake-1230 trips",
-    "Trailer detailsNL-234-3920 trips",
-    "Haulier detailsMatthesons",
-    "Account detailsUniveral Printers LtdBooked on 02/08/2020",
-    "Goods detailsPrinted Paper",
-    "Unknown",
-    "3 indicators",
-    "UK port hop inbound",
-    "First use of account (Driver)",
-    "First time through this UK port (Trailer)"
-  ],
-  "taskSummary": [
-    "Vehicle with Trailer",
-    "COP1 with NL-234-392 driven by Ben Bailey",
-    "FerryBrittany Ferries voyage of BARFLEUR",
-    "DepartureDOV, 4 Aug 2020 at 13:05",
-    "ArrivalCAL, 4 Aug 2020 at 13:35",
-    "AccountUniveral Printers Ltd, booked on 2 Aug 2020 at 09:15",
-    "HaulierMatthesons"
-  ],
-  "vehicle": {
-    "Vehicle registration": "COP1",
-    "Type": "HGV",
-    "Make": "Model-xyz",
-    "Model": "Make-123",
-    "Country of registration": "GB",
-    "Colour": "Colour-White",
-    "Net weight": "3455kg",
-    "Gross weight": "43623kg",
-    "Trailer registration number": "NL-234-392",
-    "Trailer type": "TR",
-    "Trailer country of registration": "",
-    "Empty or loaded": "Loaded",
-    "Trailer length": "36m",
-    "Trailer height": "3.6m",
-    "Gross weight": "43623kg",
-    "Net weight": "3455kg"
+  "taskListDetails": {
+    "mode": "Pre-Arrival",
+    "rules": "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
+    "voyage": "Brittany Ferries voyage of BARFLEUR",
+    "arrival": "arrival a year after travel",
+    "departurePort": "DOV",
+    "departureDateTime": "4 Aug 2020 at 13:05",
+    "arrivalPort": "CAL",
+    "arrivalDateTime": "4 Aug 2020 at 13:35",
+    "driverFirstName": "Ben",
+    "driverLastName": "Bailey",
+    "driverNumberOfTrips": "? trips",
+    "vehicleRegistration": "COP1",
+    "vehicleMake": "Colour-White",
+    "vehicleModel": "Model-xyz",
+    "vehicleNumberOfTrips": "0 trips",
+    "bookedDateTime": "Univeral Printers Ltd",
+    "bookedDetails": "Booked 2 days before travel",
+    "haulier": "Matthesons",
+    "goods": "Printed Paper",
+    "passengerDetails": "1 passenger",
+    "trailerRegitration": "NL-234-392",
+    "trailerTrips": "0 trips"
   },
-  "account": {
-    "Full name": "Univeral Printers Ltd",
-    "Short name": "",
-    "Reference number": "PO000359675",
-    "Address": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
-    "Telephone": "01243785239",
-    "Mobile": "",
-    "Email": ""
+  "taskSummary": {
+    "Ferry": "Brittany Ferries voyage of BARFLEUR",
+    "Departure": "DOV, 4 Aug 2020 at 13:05",
+    "Arrival": "CAL, 4 Aug 2020 at 13:35",
+    "Account": "Univeral Printers Ltd, booked on 2 Aug 2020 at 09:15",
+    "Haulier": "Matthesons"
   },
-  "haulier": {
-    "Name": "Matthesons",
-    "Address": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
-    "Telephone": "01243785239",
-    "Mobile": ""
-  },
-  "driver": {
-    "Name": "Ben Bailey",
-    "Date of birth": "27/10/1969",
-    "Gender": "M",
-    "Nationality": "GB",
-    "Travel document type": "",
-    "Travel document number": "",
-    "Travel document expiry": ""
-  },
-  "goods": {
-    "Description of goods": "Printed Paper",
-    "Is cargo hazardous?": "No",
-    "Weight of goods": ""
-  },
-  "booking": {
-    "Reference": "357485636",
-    "Ticket number": "DFDS-1000974",
-    "Type": "Test",
-    "Name": "test",
-    "Address": "",
-    "Date and time": "2 Aug 2020 at 09:15",
-    "Country": "GB",
-    "Payment method": "Account",
-    "Ticket price": "£30 quid",
-    "Ticket type": "Return",
-    "Check-in": "4 Aug 2020 at 12:05"
-  }
+  "versions": [
+    {
+      "vehicle": {
+        "Vehicle registration": "COP1",
+        "Type": "HGV",
+        "Make": "Model-xyz",
+        "Model": "Make-123",
+        "Country of registration": "GB",
+        "Colour": "Colour-White",
+        "Net weight": "3455kg",
+        "Gross weight": "43623kg",
+        "Trailer registration number": "NL-234-392",
+        "Trailer type": "TR",
+        "Trailer country of registration": "",
+        "Empty or loaded": "Loaded",
+        "Trailer length": "36m",
+        "Trailer height": "3.6m",
+        "Gross weight": "43623kg",
+        "Net weight": "3455kg"
+      },
+      "account": {
+        "Full name": "Univeral Printers Ltd",
+        "Short name": "",
+        "Reference number": "PO000359675",
+        "Address": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+        "Telephone": "01243785239",
+        "Mobile": "",
+        "Email": ""
+      },
+      "haulier": {
+        "Name": "Matthesons",
+        "Address": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+        "Telephone": "01243785239",
+        "Mobile": ""
+      },
+      "driver": {
+        "Name": "Ben Bailey",
+        "Date of birth": "27/10/1969",
+        "Gender": "M",
+        "Nationality": "GB",
+        "Travel document type": "",
+        "Travel document number": "",
+        "Travel document expiry": ""
+      },
+      "goods": {
+        "Description of goods": "Printed Paper",
+        "Is cargo hazardous?": "No",
+        "Weight of goods": ""
+      },
+      "booking": {
+        "Reference": "357485636",
+        "Ticket number": "DFDS-1000974",
+        "Type": "Test",
+        "Name": "test",
+        "Address": "",
+        "Date and time": "2 Aug 2020 at 09:15, 2 days before travel",
+        "Country": "GB",
+        "Payment method": "Account",
+        "Ticket price": "£30 quid",
+        "Ticket type": "Return",
+        "Check-in": "4 Aug 2020 at 12:05"
+      }
+    }
+  ]
 }
 

--- a/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehOnly-expected.json
+++ b/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehOnly-expected.json
@@ -1,24 +1,28 @@
 {
-  "taskListDetail": ["Pre-ArrivalClaim",
-    "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
-    "Brittany Ferries voyage of BARFLEURarrival a year ago",
-    "unknown4 Aug 2020 at 13:05unknown4 Aug 2020 at 13:35",
-    "Driver detailsUnknown",
-    "Passenger detailsUnknown",
-    "Vehicle details0 trips",
-    "Trailer details0 trips",
-    "Haulier detailsUnknown",
-    "Account detailsBooked on 02/08/2020",
-    "Goods detailsUnknownUnknown"
-  ],
-  "taskSummary":[
-    "Vehicle",
-    "FerryBrittany Ferries voyage of BARFLEUR",
-    "Departure4 Aug 2020 at 13:05",
-    "Arrival4 Aug 2020 at 13:35",
-    "Accountunknown, booked on 2 Aug 2020 at 09:15",
-    "Haulierunknown"
-  ]
-
+  "taskListDetails": {
+    "mode": "Pre-Arrival",
+    "rules": "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
+    "voyage": "Brittany Ferries voyage of BARFLEUR",
+    "arrival": "arrival a year after travel",
+    "departurePort": "unknown",
+    "departureDateTime": "4 Aug 2020 at 13:05",
+    "arrivalPort": "unknown",
+    "arrivalDateTime": "4 Aug 2020 at 13:35",
+    "driverFirstName": "Unknown",
+    "vehicleRegistration": "0 trips",
+    "bookedDateTime": "Booked on 02/08/2020",
+    "bookedDetails": "Booked 2 days before travel",
+    "haulier": "Unknown",
+    "goods": "Unknown",
+    "passengerDetails": "Unknown",
+    "trailerRegitration": "0 trips"
+  },
+  "taskSummary": {
+    "Ferry": "Brittany Ferries voyage of BARFLEUR",
+    "Departure": "4 Aug 2020 at 13:05",
+    "Arrival": "4 Aug 2020 at 13:35",
+    "Account": "unknown, booked on 2 Aug 2020 at 09:15",
+    "Haulier": "unknown"
+  }
 }
 

--- a/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehWithTrail-expected.json
+++ b/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehWithTrail-expected.json
@@ -1,23 +1,28 @@
 {
-  "taskListDetail": ["Pre-ArrivalClaim",
-    "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
-    "Brittany Ferries voyage of BARFLEURarrival a year ago",
-    "unknown4 Aug 2020 at 13:05unknown4 Aug 2020 at 13:35",
-    "Driver detailsUnknown",
-    "Passenger detailsUnknown",
-    "Vehicle details0 trips",
-    "Trailer detailsNL-234-3920 trips",
-    "Haulier detailsUnknown",
-    "Account detailsBooked on 01/08/2020",
-    "Goods detailsUnknownUnknown"
-  ],
-  "taskSummary":[
-    "Vehicle with TrailerNL-234-392",
-    "FerryBrittany Ferries voyage of BARFLEUR",
-    "Departure4 Aug 2020 at 13:05",
-    "Arrival4 Aug 2020 at 13:35",
-    "Accountunknown, booked on 1 Aug 2020 at 09:15",
-    "Haulierunknown"
-  ]
-
+  "taskListDetails": {
+    "mode": "Pre-Arrival",
+    "rules": "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
+    "voyage": "Brittany Ferries voyage of BARFLEUR",
+    "arrival": "arrival a year after travel",
+    "departurePort": "unknown",
+    "departureDateTime": "4 Aug 2020 at 13:05",
+    "arrivalPort": "unknown",
+    "arrivalDateTime": "4 Aug 2020 at 13:35",
+    "driverFirstName": "Unknown",
+    "vehicleRegistration": "0 trips",
+    "bookedDateTime": "Booked on 02/08/2020",
+    "bookedDetails": "Booked 2 days before travel",
+    "haulier": "Unknown",
+    "goods": "Unknown",
+    "passengerDetails": "Unknown",
+    "trailerRegitration": "NL-234-392",
+    "trailerTrips": "0 trips"
+  },
+  "taskSummary": {
+    "Ferry": "Brittany Ferries voyage of BARFLEUR",
+    "Departure": "4 Aug 2020 at 13:05",
+    "Arrival": "4 Aug 2020 at 13:35",
+    "Account": "unknown, booked on 2 Aug 2020 at 09:15",
+    "Haulier": "unknown"
+  }
 }

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -420,15 +420,24 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
         cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-${mode}`)
           .then((response) => {
             cy.wait(4000);
-            cy.get('@expTestData').then((expectedData) => {
-              let exptaskListInfo = encodeURIComponent(response.businessKey) + expectedData.taskListDetail.join('');
-              cy.verifyTaskListInfo(exptaskListInfo, response.businessKey);
+            cy.get('@expTestData').then((expTestData) => {
+              cy.verifyTaskListInfo(`${response.businessKey}`).then((taskListDetails) => {
+                expect(expTestData.taskListDetails).to.deep.equal(taskListDetails);
+              });
             });
             cy.checkTaskDisplayed(`${response.businessKey}`);
           });
       });
+
+    cy.get('.card .govuk-caption-m').should('contain.text', 'Vehicle with Trailer');
+    cy.get('.card .govuk-heading-m').should('contain.text', 'NL-234-392');
+
     cy.get('@expTestData').then((expTestData) => {
-      cy.verifyTaskSummary(expTestData.taskSummary.join(''));
+      cy.checkTaskSummaryDetails().then((taskSummary) => {
+        console.log('expected data', expTestData.taskSummary);
+        console.log('actual data', taskSummary);
+        expect(taskSummary).to.deep.equal(expTestData.taskSummary);
+      });
     });
   });
 
@@ -453,15 +462,24 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
         cy.postTasks(task, businessKey)
           .then((response) => {
             cy.wait(4000);
-            cy.get('@expTestData').then((expectedData) => {
-              let exptaskListInfo = encodeURIComponent(response.businessKey) + expectedData.taskListDetail.join('');
-              cy.verifyTaskListInfo(exptaskListInfo, response.businessKey);
+            cy.get('@expTestData').then((expTestData) => {
+              cy.verifyTaskListInfo(`${response.businessKey}`).then((taskListDetails) => {
+                console.log('task Details', taskListDetails);
+                expect(expTestData.taskListDetails).to.deep.equal(taskListDetails);
+              });
             });
             cy.checkTaskDisplayed(`${response.businessKey}`);
           });
       });
+
+    cy.get('.card .govuk-caption-m').should('contain.text', 'Vehicle');
+
     cy.get('@expTestData').then((expTestData) => {
-      cy.verifyTaskSummary(expTestData.taskSummary.join(''));
+      cy.checkTaskSummaryDetails().then((taskSummary) => {
+        console.log('expected data', expTestData.taskSummary);
+        console.log('actual data', taskSummary);
+        expect(taskSummary).to.deep.equal(expTestData.taskSummary);
+      });
     });
   });
 
@@ -475,18 +493,28 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
         cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-${mode}`)
           .then((response) => {
             cy.wait(4000);
-            cy.get('@expTestData').then((expectedData) => {
-              let exptaskListInfo = encodeURIComponent(response.businessKey) + expectedData.taskListDetail.join('');
-              cy.verifyTaskListInfo(exptaskListInfo, response.businessKey);
+            cy.get('@expTestData').then((expTestData) => {
+              cy.verifyTaskListInfo(`${response.businessKey}`).then((taskListDetails) => {
+                console.log('task Details', taskListDetails);
+                expect(expTestData.taskListDetails).to.deep.equal(taskListDetails);
+              });
             });
             cy.checkTaskDisplayed(`${response.businessKey}`);
             cy.get('@expTestData').then((expectedData) => {
-              cy.verifyTaskDetailAllSections(expectedData, 1);
+              cy.verifyTaskDetailAllSections(expectedData.versions[0], 1);
             });
           });
       });
+
+    cy.get('.card .govuk-caption-m').should('contain.text', 'Vehicle with Trailer');
+    cy.get('.card .govuk-heading-m').should('contain.text', 'NL-234-392');
+
     cy.get('@expTestData').then((expTestData) => {
-      cy.verifyTaskSummary(expTestData.taskSummary.join(''));
+      cy.checkTaskSummaryDetails().then((taskSummary) => {
+        console.log('expected data', expTestData.taskSummary);
+        console.log('actual data', taskSummary);
+        expect(taskSummary).to.deep.equal(expTestData.taskSummary);
+      });
     });
   });
 

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -434,8 +434,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('@expTestData').then((expTestData) => {
       cy.checkTaskSummaryDetails().then((taskSummary) => {
-        console.log('expected data', expTestData.taskSummary);
-        console.log('actual data', taskSummary);
         expect(taskSummary).to.deep.equal(expTestData.taskSummary);
       });
     });
@@ -464,7 +462,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
             cy.wait(4000);
             cy.get('@expTestData').then((expTestData) => {
               cy.verifyTaskListInfo(`${response.businessKey}`).then((taskListDetails) => {
-                console.log('task Details', taskListDetails);
                 expect(expTestData.taskListDetails).to.deep.equal(taskListDetails);
               });
             });
@@ -476,8 +473,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('@expTestData').then((expTestData) => {
       cy.checkTaskSummaryDetails().then((taskSummary) => {
-        console.log('expected data', expTestData.taskSummary);
-        console.log('actual data', taskSummary);
         expect(taskSummary).to.deep.equal(expTestData.taskSummary);
       });
     });
@@ -495,7 +490,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
             cy.wait(4000);
             cy.get('@expTestData').then((expTestData) => {
               cy.verifyTaskListInfo(`${response.businessKey}`).then((taskListDetails) => {
-                console.log('task Details', taskListDetails);
                 expect(expTestData.taskListDetails).to.deep.equal(taskListDetails);
               });
             });
@@ -511,8 +505,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('@expTestData').then((expTestData) => {
       cy.checkTaskSummaryDetails().then((taskSummary) => {
-        console.log('expected data', expTestData.taskSummary);
-        console.log('actual data', taskSummary);
         expect(taskSummary).to.deep.equal(expTestData.taskSummary);
       });
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -487,7 +487,7 @@ Cypress.Commands.add('checkTaskSummary', (registrationNumber, bookingDateTime) =
 });
 
 Cypress.Commands.add('deleteAutomationTestData', () => {
-  let dateNowFormatted = Cypress.dayjs().subtract('1', 'd').format('DD-MM-YYYY');
+  let dateNowFormatted = Cypress.dayjs().subtract(1, 'day').format('DD-MM-YYYY');
   cy.request({
     method: 'POST',
     url: `https://${cerberusServiceUrl}/camunda/engine-rest/process-instance`,
@@ -561,9 +561,126 @@ Cypress.Commands.add('verifyTaskSummary', (taskSummary) => {
   cy.get('.card').should('contain.text', taskSummary);
 });
 
-Cypress.Commands.add('verifyTaskListInfo', (taskListDetail, businessKey) => {
+// Cypress.Commands.add('verifyTaskListInfo', (taskListDetail, businessKey) => {
+//   cy.visit('/tasks');
+//   cy.get('.task-list--item').contains(encodeURIComponent(businessKey)).closest('section').should('contain.text', taskListDetail);
+// });
+
+Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
+  let taskSummary = {};
   cy.visit('/tasks');
-  cy.get('.task-list--item').contains(encodeURIComponent(businessKey)).closest('section').should('contain.text', taskListDetail);
+  cy.get('.task-list--item').contains(encodeURIComponent(businessKey)).closest('section').then((element) => {
+    cy.wrap(element).find('h4.task-heading').invoke('text').then((mode) => {
+      taskSummary.mode = mode;
+    });
+    cy.wrap(element).find('.task-risk-statement').invoke('text').then((rules) => {
+      taskSummary.rules = rules;
+    });
+    cy.wrap(element).find('.content-line-one li').each((section, index) => {
+      cy.wrap(section).invoke('text').then((info) => {
+        if (index === 0) {
+          taskSummary.voyage = info;
+        } else {
+          taskSummary.arrival = info;
+        }
+      });
+    });
+
+    cy.wrap(element).find('.content-line-two li').each((section, index) => {
+      cy.wrap(section).invoke('text').then((info) => {
+        if (index === 0) {
+          taskSummary.departurePort = info;
+        } else if (index === 1) {
+          taskSummary.departureDateTime = info;
+        } else if (index === 2) {
+          taskSummary.arrivalPort = info;
+        } else {
+          taskSummary.arrivalDateTime = info;
+        }
+      });
+    });
+
+    cy.wrap(element).contains('Driver details').next().then((driverDetails) => {
+      cy.wrap(driverDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.driverFirstName = info;
+          } else if (index === 1) {
+            taskSummary.driverLastName = info;
+          } else {
+            taskSummary.driverNumberOfTrips = info;
+          }
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Vehicle details').next().then((vehicleDetails) => {
+      cy.wrap(vehicleDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.vehicleRegistration = info;
+          } else if (index === 1) {
+            taskSummary.vehicleMake = info;
+          } else if (index === 2) {
+            taskSummary.vehicleModel = info;
+          } else {
+            taskSummary.vehicleNumberOfTrips = info;
+          }
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Account details').next().then((accountDetails) => {
+      cy.wrap(accountDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.bookedDateTime = info;
+          } else {
+            taskSummary.bookedDetails = info;
+          }
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Haulier details').next().then((haulierDetails) => {
+      cy.wrap(haulierDetails).find('li').each((details) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          taskSummary.haulier = info;
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Goods details').next().then((goodsDetails) => {
+      cy.wrap(goodsDetails).find('li').each((details) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          taskSummary.goods = info;
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Passenger details').next().then((passengerDetails) => {
+      cy.wrap(passengerDetails).find('li').each((details) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          taskSummary.passengerDetails = info;
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Trailer details').next().then((trailerDetails) => {
+      cy.wrap(trailerDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.trailerRegitration = info;
+          } else {
+            taskSummary.trailerTrips = info;
+          }
+        });
+      });
+    });
+  })
+    .then(() => {
+      return taskSummary;
+    });
 });
 
 Cypress.Commands.add('verifyTaskDetailSection', (expData, versionInRow, sectionname) => {
@@ -645,9 +762,18 @@ Cypress.Commands.add('verifyTaskDetailAllSections', (expectedDetails, versionInR
   }
 });
 
-Cypress.Commands.add('checkTaskSummaryDetails', (expectedSummary) => {
-  cy.get('.govuk-grid-row dl.mode-details dd').each((element, index) => {
-    cy.wrap(element).should('contain.text', expectedSummary[index]);
+Cypress.Commands.add('checkTaskSummaryDetails', () => {
+  let taskSummary = {};
+  cy.get('.govuk-grid-row dl.mode-details dt').each((keyElement) => {
+    cy.wrap(keyElement).invoke('text').then((key) => {
+      cy.log('key', key);
+      cy.wrap(keyElement).next().invoke('text').then((value) => {
+        cy.log('value', value);
+        taskSummary[key] = value;
+      });
+    });
+  }).then(() => {
+    return taskSummary;
   });
 });
 
@@ -683,7 +809,7 @@ Cypress.Commands.add('removeOptionFromMultiSelectDropdown', (elementName, values
 });
 
 Cypress.Commands.add('createCerberusTask', (payload, taskName) => {
-  let expectedTaskSummary = [];
+  let expectedTaskSummary = {};
   let date = new Date();
   let dateNowFormatted = Cypress.dayjs(date).format('DD-MM-YYYY');
   const dateFormat = 'D MMM YYYY [at] HH:mm';
@@ -700,18 +826,20 @@ Cypress.Commands.add('createCerberusTask', (payload, taskName) => {
       let departureDateTime = Cypress.dayjs(voyage.actualDepartureTimestamp).utc().format(dateFormat);
       let arrivalDateTime = Cypress.dayjs(voyage.actualArrivalTimestamp).utc().format(dateFormat);
       cy.log('departure and arrival time', departureDateTime, arrivalDateTime);
-      expectedTaskSummary.push(`${voyage.carrier} voyage of ${voyage.craftId}`);
-      expectedTaskSummary.push(`${voyage.departureLocation}, ${departureDateTime}`);
-      expectedTaskSummary.push(`${voyage.arrivalLocation}, ${arrivalDateTime}`);
-      expectedTaskSummary.push('unknown');
-      expectedTaskSummary.push('unknown');
+      expectedTaskSummary.Ferry = `${voyage.carrier} voyage of ${voyage.craftId}`;
+      expectedTaskSummary.Departure = `${voyage.departureLocation}, ${departureDateTime}`;
+      expectedTaskSummary.Arrival = `${voyage.arrivalLocation}, ${arrivalDateTime}`;
+      expectedTaskSummary.Account = 'unknown';
+      expectedTaskSummary.Haulier = 'unknown';
     }
     task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
     cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-${mode}-${taskName}`).then((response) => {
       cy.wait(4000);
       cy.checkTaskDisplayed(`${response.businessKey}`);
       if (taskName.includes('TSV')) {
-        cy.checkTaskSummaryDetails(expectedTaskSummary);
+        cy.checkTaskSummaryDetails().then((taskSummary) => {
+          expect(expectedTaskSummary).to.deep.equal(taskSummary);
+        });
       }
       cy.checkTaskSummary(registrationNumber, bookingDateTime);
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -561,11 +561,6 @@ Cypress.Commands.add('verifyTaskSummary', (taskSummary) => {
   cy.get('.card').should('contain.text', taskSummary);
 });
 
-// Cypress.Commands.add('verifyTaskListInfo', (taskListDetail, businessKey) => {
-//   cy.visit('/tasks');
-//   cy.get('.task-list--item').contains(encodeURIComponent(businessKey)).closest('section').should('contain.text', taskListDetail);
-// });
-
 Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
   let taskSummary = {};
   cy.visit('/tasks');
@@ -576,6 +571,7 @@ Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
     cy.wrap(element).find('.task-risk-statement').invoke('text').then((rules) => {
       taskSummary.rules = rules;
     });
+
     cy.wrap(element).find('.content-line-one li').each((section, index) => {
       cy.wrap(section).invoke('text').then((info) => {
         if (index === 0) {


### PR DESCRIPTION
## Description
Add tests to check the Booking date & time and Departure time difference on TaskList page and task summary.

## To Test
npm run cypress:runner

run following tests from spec `task-details.spec.js` 
`Vehicle and Trailer - Unknown values in Task List & Task Summary`
`Should display correct values for PERFDRIVER Driver, Booking, Vehicle, tasklist, task summary`
`Should display correct values for PERFDRIVER Driver, Booking, Vehicle, tasklist, task summary`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
