### PR TITLE
COP-9191 Filters bug fixes

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -547,21 +547,24 @@ const TaskListPage = () => {
   };
 
   useEffect(() => {
-    getTaskCountsByTab();
+    if (filtersToApply) {
+      getTaskCountsByTab();
+    }
   }, [filtersToApply]);
 
   useEffect(() => {
     const isTargeter = (keycloak.tokenParsed.groups).indexOf(TARGETER_GROUP) > -1;
+    const hasStoredFilters = localStorage?.getItem('filters');
     if (!isTargeter) {
       setAuthorisedGroup(false);
     }
     if (isTargeter) {
-      setStoredFilters(localStorage?.getItem('filters')?.split(',') || '');
+      setStoredFilters(hasStoredFilters?.split(',') || '');
       setAuthorisedGroup(true);
       setFilterList(filterListConfig);
       setFiltersToApply(storedFilters);
       setFiltersSelected(storedFilters);
-      getTaskCountsByTab();
+      if (!hasStoredFilters) { getTaskCountsByTab(); }
     }
   }, []);
 

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -108,7 +108,7 @@ const filterListConfig = [
       },
       {
         name: 'both',
-        code: '', // as 'both' is all tasks we just return null for the filter when selected
+        code: 'noCode', // as 'both' is all tasks we return a word we can set to null in the call
         label: 'Both',
         checked: false,
       },
@@ -503,7 +503,7 @@ const TaskListPage = () => {
     // map over radios and uncheck anything not selected
     if (type === 'radio') {
       // add currently selected code
-      const filtersSelectedArray = [...filtersSelected, code];
+      const filtersSelectedArray = code === 'noCode' ? [...filtersSelected] : [...filtersSelected, code];
       // Remove codes from deselected radio buttons
       const filterSetArray = filterListConfig.find((set) => set.filterName === name);
       const filterSetOptionCodes = filterSetArray.filterOptions.map((option) => {


### PR DESCRIPTION
## Description
- refreshing page was sometimes resulting in the original count of tasks being displayed
- > added conditionals to when we run task counts to avoid running before filters applied
- selecting and deselecting both was sometimes resulting in a dangling comma in the filter array (`,word` or `word,,word`) which caused the get call to 404
- > updated how we handle 'both' which requires no code in the filter array to prevent chance of comma

## To Test

- select a mode
- select both & apply
- select yes & apply
- select both & apply
- select no & apply
- refresh the page 9ish time

none of the above should result in an inconsistent count or 404

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
