### PR TITLE
COP-9191 - Extend getTaskCount switch to include on load scenarios

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -461,7 +461,7 @@ const TaskListPage = () => {
   const [filterList, setFilterList] = useState([]);
   const [filtersSelected, setFiltersSelected] = useState([]);
   const [filtersToApply, setFiltersToApply] = useState('');
-  const [resetFilters, setResetFilters] = useState(false);
+  const [updateTaskCount, setUpdateTaskCount] = useState(false);
   const [storedFilters, setStoredFilters] = useState(localStorage?.getItem('filters')?.split(',') || '');
   const [taskCountsByStatus, setTaskCountsByStatus] = useState({});
   const targetStatus = (targetStatusConfig(filtersToApply));
@@ -495,7 +495,7 @@ const TaskListPage = () => {
         TASK_STATUS_TARGET_ISSUED: countIssued.data.count.toString(),
         TASK_STATUS_COMPLETED: countCompleted.data.count.toString(),
       });
-      setResetFilters(false);
+      setUpdateTaskCount(false);
     } catch (e) {
       setError(e.message);
     }
@@ -522,6 +522,7 @@ const TaskListPage = () => {
   const handleFilterApply = (e) => {
     localStorage.removeItem('filters');
     e.preventDefault();
+    setUpdateTaskCount(true);
     if (filtersSelected.length > 0) {
       localStorage.setItem('filters', filtersSelected);
       setFiltersToApply(filtersSelected);
@@ -536,7 +537,7 @@ const TaskListPage = () => {
     setFiltersSelected([]); // reset to null
     setFilterList(filterListConfig); // reset to default
     localStorage.removeItem('filters');
-    setResetFilters(true);
+    setUpdateTaskCount(true);
 
     filterList.map((filterSet) => {
       const optionItem = document.getElementsByName(filterSet.filterName);
@@ -550,10 +551,10 @@ const TaskListPage = () => {
   };
 
   useEffect(() => {
-    if (filtersToApply || resetFilters) {
+    if (updateTaskCount) {
       getTaskCountsByTab();
     }
-  }, [filtersToApply, resetFilters]);
+  }, [updateTaskCount]);
 
   useEffect(() => {
     const isTargeter = (keycloak.tokenParsed.groups).indexOf(TARGETER_GROUP) > -1;
@@ -564,6 +565,7 @@ const TaskListPage = () => {
     if (isTargeter) {
       setStoredFilters(hasStoredFilters?.split(',') || '');
       setAuthorisedGroup(true);
+      setUpdateTaskCount(true);
       setFilterList(filterListConfig);
       setFiltersToApply(storedFilters);
       setFiltersSelected(storedFilters);


### PR DESCRIPTION
## Description
Selecting 'both' after some combinations of check/uncheck resulted in the get counts call not running
Updated the switch to trigger getting a new set of counts to handle all scenarios

## To Test

- select has selectors and apply
- select has no selectors and apply
- select both and apply
Counts should update on each apply

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
