### PR TITLE
fixed layout bug where target indicator & risk score were on the same line

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -172,15 +172,15 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
   };
 
   const calculateTotalRiskScore = (target) => {
+    let totalRiskScore = 0;
     if (target.threatIndicators?.length > 0) {
-      let totalRiskScore = 0;
       target.threatIndicators.map((threatIndicatorScore) => {
         totalRiskScore += threatIndicatorScore?.score || 0;
       });
-      return (
-        totalRiskScore > 0 ? <li className="govuk-!-font-weight-bold">Risk Score: {totalRiskScore}</li> : 'Risk Score:'
-      );
     }
+    return (
+      totalRiskScore > 0 ? <li className="govuk-!-font-weight-bold">Risk Score: {totalRiskScore}</li> : <li>Risk Score:</li>
+    );
   };
 
   const loadTasks = async () => {
@@ -444,6 +444,12 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
                       {calculateTotalRiskScore(target)}
                     </strong>
                   </li>
+                </ul>
+              </div>
+            </div>
+            <div className="govuk-grid-row">
+              <div className="govuk-grid-column-full">
+                <ul className="govuk-list task-labels govuk-!-margin-top-2 govuk-!-margin-bottom-0">
                   <li className="task-labels-item">
                     {formatTargetIndicators(target)}
                   </li>


### PR DESCRIPTION
## Description
This PR fixes a layout bug where target indicator & risk score would appear on the same line.

## To Test
On the tasks list page, the Risk Score should appear above the targeting indicators.