### PR TITLE
COP-9273: Update tests to check the differences in versions when the value is empty

### DIFF
--- a/cypress/fixtures/RoRo-task-v1.json
+++ b/cypress/fixtures/RoRo-task-v1.json
@@ -822,7 +822,7 @@
                 "vehicle": {
                   "type": "OBJVEHC",
                   "make": null,
-                  "model": null,
+                  "model": "Discovery",
                   "vin": null,
                   "registrationNumber": "GB09KLT-10684",
                   "registrationCountry": "GB",

--- a/cypress/fixtures/RoRo-task-v3.json
+++ b/cypress/fixtures/RoRo-task-v3.json
@@ -325,7 +325,7 @@
                     "value": null,
                     "valueList": {
                       "val": [
-                        "Bailey|Ken|F|-90|FR|OBJDOCPAS|244746NL|18700||PERPAS|ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c"
+                        "Bailey|Ken|F|-90||OBJDOCPAS|244746NL|18700||PERPAS|ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c"
                       ]
                     },
                     "startTimestamp": null,
@@ -414,9 +414,9 @@
                   "familyName": "Brownshoes",
                   "givenName": "Bobby",
                   "fullName": "Bobby Brownshoes",
-                  "dateOfBirth": 440,
+                  "dateOfBirth": null,
                   "dateOfDeath": null,
-                  "gender": "F",
+                  "gender": "",
                   "nationality": "FR",
                   "yearOfBirth": 1971,
                   "monthOfBirth": 3,
@@ -550,7 +550,7 @@
                 "attributes": {
                   "attrs": {
                     "holderName": "Testing Printers Ltd",
-                    "shortName": "Test Highlights name",
+                    "shortName": "",
                     "accountNumber": "Test",
                     "referenceNumber": "PO000355555"
                   }
@@ -822,7 +822,7 @@
                 "vehicle": {
                   "type": "OBJVEHC",
                   "make": "LandRover",
-                  "model": "Discovery",
+                  "model": null,
                   "vin": null,
                   "registrationNumber": "GB09KLT-2000",
                   "registrationCountry": "DE",
@@ -1125,7 +1125,7 @@
                 "contact":
                   {
                     "type": "LOCTEL",
-                    "value": "01234 56724747"
+                    "value": ""
                   },
                 "attributes": null,
                 "matching": null,

--- a/cypress/fixtures/task-version-differences.json
+++ b/cypress/fixtures/task-version-differences.json
@@ -1,0 +1,47 @@
+{
+  "versions": [
+    {
+      "Vehicle registration": "GB09KLT-2000",
+      "Make": "LandRover",
+      "Country of registration": "DE",
+      "Colour": "Red",
+      "Net weight": "4000kg",
+      "Gross weight": "43680kg",
+      "Trailer country of registration": "NL",
+      "Empty or loaded": "Loaded",
+      "Trailer length": "46m",
+      "Trailer height": "4.6m",
+      "Full name": "Testing Printers Ltd",
+      "Short name": "",
+      "Reference number": "PO000355555",
+      "Address": "Unit 11-12 Pink Way Bognoris Regis E209JB GB",
+      "Telephone": "",
+      "Name": "Matthew",
+      "Mobile": "01243784444",
+      "Name-dup": "Bobby Brownshoes",
+      "Date of birth": "",
+      "Gender": "",
+      "Nationality": "FR",
+      "Travel document type": "OBJDOCPAS",
+      "Travel document number": "244746NL",
+      "Travel document expiry": "14/03/2021",
+      "Name-dup-1": "Ken Bailey",
+      "Date of birth-dup": "03/10/1969",
+      "Gender-dup": "F",
+      "Nationality-dup": "",
+      "Travel document type-dup": "OBJDOCPAS",
+      "Travel document number-dup": "244746NL",
+      "Travel document expiry-dup": "14/03/2021",
+      "Date and time": "19 Nov 2021 at 09:15, a day before travel"
+    },
+    {
+      "Travel document type": "",
+      "Travel document number": "244999NL",
+      "Date of birth": "23/09/1969",
+      "Date and time": "18 Nov 2021 at 09:15, 10 months after travel",
+      "Check-in": "3 Aug 2020 at 12:05",
+      "Model": ""
+    }
+  ]
+
+}

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -425,55 +425,14 @@ describe('Task Details of different tasks on task details Page', () => {
   it('Should verify difference between versions displayed on task details page', () => {
     const firstVersionIndex = 2;
     const versionDiff = [
-      '33 changes in this version',
-      '5 changes in this version',
+      '32 changes in this version',
+      '6 changes in this version',
       'No changes in this version',
     ];
 
-    const expectedHighlights = [
-      [
-        'GB09KLT-2000',
-        'LandRover',
-        'Discovery',
-        'DE',
-        'Red',
-        '4000kg',
-        '43680kg',
-        'NL',
-        'Loaded',
-        '46m',
-        '4.6m',
-        'Testing Printers Ltd',
-        'Test Highlights name',
-        'PO000355555',
-        'Unit 11-12 Pink Way Bognoris Regis E209JB GB',
-        '01234 56724747',
-        'Matthew',
-        '01243784444',
-        'Bobby Brownshoes',
-        '17/03/1971',
-        'F',
-        'FR',
-        'OBJDOCPAS',
-        '244746NL',
-        '14/03/2021',
-        'Ken Bailey',
-        '03/10/1969',
-        'F',
-        'FR',
-        'OBJDOCPAS',
-        '244746NL',
-        '14/03/2021',
-        '19 Nov 2021 at 09:15, a day before travel',
-      ],
-      [
-        '244999NL',
-        '23/09/1969',
-        '18 Nov 2021 at 09:15, 10 months after travel',
-        '3 Aug 2020 at 12:05',
-      ],
-    ];
+    cy.fixture('/task-version-differences.json').as('differences');
 
+    let differencesInEachVersion = [];
     cy.getBusinessKey('-RORO-Accompanied-Freight-different-versions-task_').then((businessKeys) => {
       expect(businessKeys.length).to.not.equal(0);
       cy.visit(`/tasks/${businessKeys[0]}`);
@@ -487,14 +446,15 @@ describe('Task Details of different tasks on task details Page', () => {
       });
 
       if (index !== firstVersionIndex) {
-        cy.expandTaskDetails(index).then(() => {
-          cy.wrap(element).find('.task-versions--highlight').each((diff, diffIndex) => {
-            cy.wrap(diff).invoke('text').then((highlight) => {
-              expect(highlight).to.be.equal(expectedHighlights[index][diffIndex]);
-            });
-          });
+        cy.getTaskVersionsDifference(element, index).then((differences) => {
+          differencesInEachVersion.push(differences);
         });
       }
+    });
+
+    // COP-9273 Verify number of difference between the versions for both Keys and values displayed & highlighted
+    cy.get('@differences').then((expectedData) => {
+      expect(expectedData.versions).to.deep.equal(differencesInEachVersion);
     });
   });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -993,3 +993,43 @@ Cypress.Commands.add('verifyBookingDateTime', (expectedBookingDateTime) => {
     });
   });
 });
+
+Cypress.Commands.add('getTaskVersionsDifference', (version, index) => {
+  let valueLocator = '.govuk-summary-list__value .task-versions--highlight';
+  let difference = {};
+  cy.expandTaskDetails(index).then(() => {
+    cy.wrap(version).find('.govuk-summary-list__key .task-versions--highlight').each((item) => {
+      cy.wrap(item).parents('.govuk-summary-list__row').then((valueElement) => {
+        if (valueElement.find(valueLocator).length > 0) {
+          cy.wrap(item).invoke('text').then((key) => {
+            cy.wrap(valueElement).find(valueLocator).invoke('text').then((value) => {
+              if (key in difference) {
+                if (`${key}-dup` in difference) {
+                  difference[`${key}-dup-${1}`] = value;
+                } else {
+                  difference[`${key}-dup`] = value;
+                }
+              } else {
+                difference[key] = value;
+              }
+            });
+          });
+        } else {
+          cy.wrap(item).invoke('text').then((key) => {
+            if (key in difference) {
+              if (`${key}-dup` in difference) {
+                difference[`${key}-dup-${1}`] = '';
+              } else {
+                difference[`${key}-dup`] = '';
+              }
+            } else {
+              difference[key] = '';
+            }
+          });
+        }
+      });
+    });
+  }).then(() => {
+    return difference;
+  });
+});


### PR DESCRIPTION
## Description
Automation tests updated to check the difference between the versions when the value of the field is empty.

## To Test
npm run cypress:runner

execute the test, `Should verify difference between versions displayed on task details page` from spec `task-version-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
