### PR TITLE
COP-9051: Add tests to verify Risk score on task list page

### DIFF
--- a/cypress/fixtures/RoRo-task-v1-target-update.json
+++ b/cypress/fixtures/RoRo-task-v1-target-update.json
@@ -822,7 +822,7 @@
                 "vehicle": {
                   "type": "OBJVEHC",
                   "make": null,
-                  "model": null,
+                  "model": "Discovery",
                   "vin": null,
                   "registrationNumber": "GB09KLT-10684",
                   "registrationCountry": "GB",

--- a/cypress/fixtures/RoRo-task-v3-target-update.json
+++ b/cypress/fixtures/RoRo-task-v3-target-update.json
@@ -840,7 +840,7 @@
                 "vehicle": {
                   "type": "OBJVEHC",
                   "make": null,
-                  "model": null,
+                  "model": "Discovery",
                   "vin": null,
                   "registrationNumber": "GB09KLT-10684",
                   "registrationCountry": "GB",

--- a/cypress/integration/cerberus/task-risk-score-verify.spec.js
+++ b/cypress/integration/cerberus/task-risk-score-verify.spec.js
@@ -1,0 +1,45 @@
+describe('View total Risk score from Targeting Indicators in the task list Page', () => {
+  beforeEach(() => {
+    cy.login(Cypress.env('userName'));
+  });
+
+  it('Should verify the Risk Score for a task with 2 Target Indicators', () => {
+    // COP-9051
+    cy.getBusinessKey('-RORO-Accompanied-Freight-target-indicators-same-version_').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.verifyTaskListInfo(`${businessKeys[0]}`).then((taskListDetails) => {
+        expect('Risk Score: 50').to.deep.equal(taskListDetails.riskScore);
+      });
+    });
+  });
+
+  it('Should verify the Risk Score for Task with multiple versions', () => {
+    // COP-9051 The aggregated score is for the TIs in the latest version and does NOT include the score for TIs in previous 2 versions
+    cy.getBusinessKey('-RORO-Accompanied-Freight-target-indicators-diff-version_').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.verifyTaskListInfo(`${businessKeys[0]}`).then((taskListDetails) => {
+        expect('Risk Score: 80').to.deep.equal(taskListDetails.riskScore);
+      });
+    });
+  });
+
+  it('Should verify the Risk Score for Task with 16 TIs displays the correct aggregated score', () => {
+    // COP-9051
+    cy.getBusinessKey('-Target-Indicators-Details').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.verifyTaskListInfo(`${businessKeys[0]}`).then((taskListDetails) => {
+        expect('Risk Score: 4140').to.deep.equal(taskListDetails.riskScore);
+      });
+    });
+  });
+
+  it('Should verify the Risk Score for Tasks without TIs present are not displaying a score/value', () => {
+    // COP-9051
+    cy.getBusinessKey('-RORO-Unaccompanied-Freight-RoRo-UNACC-SBT_').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.verifyTaskListInfo(`${businessKeys[0]}`).then((taskListDetails) => {
+        expect('Risk Score:').to.deep.equal(taskListDetails.riskScore);
+      });
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -673,6 +673,10 @@ Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
         });
       });
     });
+
+    cy.wrap(element).find('.task-labels-item strong').invoke('text').then((riskScore) => {
+      taskSummary.riskScore = riskScore;
+    });
   })
     .then(() => {
       return taskSummary;


### PR DESCRIPTION
## Description
Add tests to verify the following scenarios

1.) Multiple Tasks with 1 TI displays correct score for the TI

2.) Task with 16 TIs displays the correct aggregated score

3.) Task with multiple versions - The aggregated score is for the TIs in the latest version and does NOT include the score for TIs in previous 2 versions

4.) Tasks without TIs present are not displaying a score/value

## To Test
npm run cypress:runner
run all the tests from spec `task-risk-score-verify.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
