### PR TITLE
cop-8934 - no passenger details

### DIFF
--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -1,24 +1,31 @@
-import React, { Fragment } from 'react';
-import dayjs from 'dayjs';
-import * as pluralise from 'pluralise';
-import { v4 as uuidv4 } from 'uuid';
+import React, { Fragment } from "react";
+import dayjs from "dayjs";
+import * as pluralise from "pluralise";
+import { v4 as uuidv4 } from "uuid";
 
-import Accordion from '../../govuk/Accordion';
-import { LONG_DATE_FORMAT } from '../../constants';
-import formatField from '../../utils/formatField';
+import Accordion from "../../govuk/Accordion";
+import { LONG_DATE_FORMAT } from "../../constants";
+import formatField from "../../utils/formatField";
 
-const renderFieldSetContents = (contents) => (
+const renderFieldSetContents = (contents) =>
   contents.map(({ fieldName, content, type }) => {
-    if (!type.includes('HIDDEN')) {
+    if (!type.includes("HIDDEN")) {
       return (
         <div className="govuk-summary-list__row" key={uuidv4()}>
-          <dt className="govuk-summary-list__key">{type.includes('CHANGED') ? <span className="task-versions--highlight">{fieldName}</span> : fieldName}</dt>
-          <dd className="govuk-summary-list__value">{formatField(type, content)}</dd>
+          <dt className="govuk-summary-list__key">
+            {type.includes("CHANGED") ? (
+              <span className="task-versions--highlight">{fieldName}</span>
+            ) : (
+              fieldName
+            )}
+          </dt>
+          <dd className="govuk-summary-list__value">
+            {formatField(type, content)}
+          </dd>
         </div>
       );
     }
-  })
-);
+  });
 
 const renderChildSets = (childSets) => {
   return childSets.map((child) => {
@@ -40,12 +47,12 @@ const renderChildSets = (childSets) => {
 
 const renderFieldSets = (fieldSet) => {
   /*
-  * When there are multiple entries for a section
-  * e.g. 'Passengers' can have multiple passengers
-  * the 'hasChildSet' flag will be set to true
-  * which indicates we need to map out the childSet contents
-  * and not the parent contents
-  */
+   * When there are multiple entries for a section
+   * e.g. 'Passengers' can have multiple passengers
+   * the 'hasChildSet' flag will be set to true
+   * which indicates we need to map out the childSet contents
+   * and not the parent contents
+   */
   if (fieldSet.hasChildSet) {
     return (
       <Fragment key={uuidv4()}>
@@ -57,15 +64,64 @@ const renderFieldSets = (fieldSet) => {
   return renderFieldSetContents(fieldSet.contents);
 };
 
-const TaskVersions = ({ taskVersions, businessKey, taskVersionDifferencesCounts }) => {
+/**
+ * This will loop through each section to render, when arrives the on passengers section
+ * it will loop thorough the passengers data and for each passenger, it will loop through
+ * the data fields in that passenger, once it finds a content field that is not null, it
+ * will force exit the loop, perform a check and render. If it loops through and all field
+ * contents are null, it will not render that passenger section.
+ */
+const renderVersionSection = (field) => {
+  switch (true) {
+    case field.propName.includes("passengers"): {
+      let isValidToRender = false;
+      if (field.childSets.length > 0) {
+        for (const passengerChildSets of field.childSets) {
+          for (const passengerDataFieldObj of passengerChildSets.contents) {
+            if (passengerDataFieldObj.content !== null) {
+              isValidToRender = true;
+              break;
+            }
+          }
+        }
+        if (isValidToRender) {
+          return (
+            <div key={field.propName}>
+              <h2 className="govuk-heading-m">{field.fieldSetName}</h2>
+              <dl className="govuk-summary-list govuk-!-margin-bottom-9">
+                {renderFieldSets(field)}
+              </dl>
+            </div>
+          );
+        }
+      }
+      break;
+    }
+    default:
+      return (
+        <div key={field.propName}>
+          <h2 className="govuk-heading-m">{field.fieldSetName}</h2>
+          <dl className="govuk-summary-list govuk-!-margin-bottom-9">
+            {renderFieldSets(field)}
+          </dl>
+        </div>
+      );
+  }
+};
+
+const TaskVersions = ({
+  taskVersions,
+  businessKey,
+  taskVersionDifferencesCounts,
+}) => {
   /*
-  * There can be multiple versions of the data
-  * We need to display each version
-  * We currently get the data as an array of unnamed objects
-  * That contain an array of unnamed objects
-  * There is a plan to name the objects in the future
-  * But for now we have to find the relevant object by looking at the propName
-  */
+   * There can be multiple versions of the data
+   * We need to display each version
+   * We currently get the data as an array of unnamed objects
+   * That contain an array of unnamed objects
+   * There is a plan to name the objects in the future
+   * But for now we have to find the relevant object by looking at the propName
+   */
   return (
     <Accordion
       className="task-versions"
@@ -73,40 +129,46 @@ const TaskVersions = ({ taskVersions, businessKey, taskVersionDifferencesCounts 
       items={
         /* the task data is provided in an array,
          * there is only ever one item in the array
-        */
+         */
         taskVersions.map((version, index) => {
-          const booking = version.find((fieldset) => fieldset.propName === 'booking') || null;
-          const bookingDate = booking?.contents.find((field) => field.propName === 'dateBooked').content || null;
+          const booking =
+            version.find((fieldset) => fieldset.propName === "booking") || null;
+          const bookingDate =
+            booking?.contents.find((field) => field.propName === "dateBooked")
+              .content || null;
           const versionNumber = taskVersions.length - index;
           const detailSection = version.map((field) => {
-            return (
-              <div key={field.propName}>
-                <h2 className="govuk-heading-m">{field.fieldSetName}</h2>
-                <dl className="govuk-summary-list govuk-!-margin-bottom-9">
-                  {renderFieldSets(field)}
-                </dl>
-              </div>
-            );
+            return renderVersionSection(field);
           });
-          return (
-            {
-              expanded: index === 0,
-              heading: `Version ${versionNumber}`,
-              summary: (
-                <>
-                  <div className="task-versions--left">
-                    <div className="govuk-caption-m">{dayjs.utc(bookingDate ? bookingDate.split(',')[0] : null).format(LONG_DATE_FORMAT)}</div>
+          return {
+            expanded: index === 0,
+            heading: `Version ${versionNumber}`,
+            summary: (
+              <>
+                <div className="task-versions--left">
+                  <div className="govuk-caption-m">
+                    {dayjs
+                      .utc(bookingDate ? bookingDate.split(",")[0] : null)
+                      .format(LONG_DATE_FORMAT)}
                   </div>
-                  <div className="task-versions--right">
-                    <ul className="govuk-list">
-                      <li>{pluralise.withCount(taskVersionDifferencesCounts[index], '% change', '% changes', 'No changes')} in this version</li>
-                    </ul>
-                  </div>
-                </>
-              ),
-              children: detailSection,
-            }
-          );
+                </div>
+                <div className="task-versions--right">
+                  <ul className="govuk-list">
+                    <li>
+                      {pluralise.withCount(
+                        taskVersionDifferencesCounts[index],
+                        "% change",
+                        "% changes",
+                        "No changes"
+                      )}{" "}
+                      in this version
+                    </li>
+                  </ul>
+                </div>
+              </>
+            ),
+            children: detailSection,
+          };
         })
       }
     />

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -1,31 +1,30 @@
-import React, { Fragment } from "react";
-import dayjs from "dayjs";
-import * as pluralise from "pluralise";
-import { v4 as uuidv4 } from "uuid";
+import React, { Fragment } from 'react';
+import dayjs from 'dayjs';
+import * as pluralise from 'pluralise';
+import { v4 as uuidv4 } from 'uuid';
 
-import Accordion from "../../govuk/Accordion";
-import { LONG_DATE_FORMAT } from "../../constants";
-import formatField from "../../utils/formatField";
+import Accordion from '../../govuk/Accordion';
+import { LONG_DATE_FORMAT } from '../../constants';
+import formatField from '../../utils/formatField';
 
-const renderFieldSetContents = (contents) =>
-  contents.map(({ fieldName, content, type }) => {
-    if (!type.includes("HIDDEN")) {
-      return (
-        <div className="govuk-summary-list__row" key={uuidv4()}>
-          <dt className="govuk-summary-list__key">
-            {type.includes("CHANGED") ? (
-              <span className="task-versions--highlight">{fieldName}</span>
-            ) : (
-              fieldName
-            )}
-          </dt>
-          <dd className="govuk-summary-list__value">
-            {formatField(type, content)}
-          </dd>
-        </div>
-      );
-    }
-  });
+const renderFieldSetContents = (contents) => contents.map(({ fieldName, content, type }) => {
+  if (!type.includes('HIDDEN')) {
+    return (
+      <div className="govuk-summary-list__row" key={uuidv4()}>
+        <dt className="govuk-summary-list__key">
+          {type.includes('CHANGED') ? (
+            <span className="task-versions--highlight">{fieldName}</span>
+          ) : (
+            fieldName
+          )}
+        </dt>
+        <dd className="govuk-summary-list__value">
+          {formatField(type, content)}
+        </dd>
+      </div>
+    );
+  }
+});
 
 const renderChildSets = (childSets) => {
   return childSets.map((child) => {
@@ -73,7 +72,7 @@ const renderFieldSets = (fieldSet) => {
  */
 const renderVersionSection = (field) => {
   switch (true) {
-    case field.propName.includes("passengers"): {
+    case field.propName.includes('passengers'): {
       let isValidToRender = false;
       if (field.childSets.length > 0) {
         for (const passengerChildSets of field.childSets) {
@@ -131,11 +130,9 @@ const TaskVersions = ({
          * there is only ever one item in the array
          */
         taskVersions.map((version, index) => {
-          const booking =
-            version.find((fieldset) => fieldset.propName === "booking") || null;
-          const bookingDate =
-            booking?.contents.find((field) => field.propName === "dateBooked")
-              .content || null;
+          const booking = version.find((fieldset) => fieldset.propName === 'booking') || null;
+          const bookingDate = booking?.contents.find((field) => field.propName === 'dateBooked')
+            .content || null;
           const versionNumber = taskVersions.length - index;
           const detailSection = version.map((field) => {
             return renderVersionSection(field);
@@ -148,7 +145,7 @@ const TaskVersions = ({
                 <div className="task-versions--left">
                   <div className="govuk-caption-m">
                     {dayjs
-                      .utc(bookingDate ? bookingDate.split(",")[0] : null)
+                      .utc(bookingDate ? bookingDate.split(',')[0] : null)
                       .format(LONG_DATE_FORMAT)}
                   </div>
                 </div>
@@ -157,10 +154,10 @@ const TaskVersions = ({
                     <li>
                       {pluralise.withCount(
                         taskVersionDifferencesCounts[index],
-                        "% change",
-                        "% changes",
-                        "No changes"
-                      )}{" "}
+                        '% change',
+                        '% changes',
+                        'No changes',
+                      )}{' '}
                       in this version
                     </li>
                   </ul>

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -361,11 +361,11 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
                   Passenger details
                 </h3>
                 <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
-                  {target.roro.details.passengers ? (
+                  {target.roro.details.passengers && target.roro.details.passengers.length > 0 ? (
                     <>
                       <li className="govuk-!-font-weight-bold">{pluralise.withCount(passengers.length, '% passenger', '% passengers')}</li>
                     </>
-                  ) : (<li className="govuk-!-font-weight-bold">Unknown</li>)}
+                  ) : (<li className="govuk-!-font-weight-bold">None</li>)}
                 </ul>
               </div>
 


### PR DESCRIPTION
## Description
This PR solves 2 minor cosmetic problems (COP-8934).

1) On task details page, if there are no passangers for a task, the passengar details field would show **unknown**, this now says **None**
2) When vieing a task in detail, if there were no passenger(s), the passenger(s) section would still be rendered with empty fields, this now renderes i fthere are passengers and doesn't when there no passengers.

## To Test
- Pull and run against dev
- On the task list, when there are no passengers, under **Passenger detials** header, it should say **None** .
- When viewing a task in detail (click on a task), select a task with no passenger(s), when viewing the version section, the passenger section will not be rendered. 
- Repeating the steps mentioned above for a task with passengers will result in the the passenger(s) section being rendered in the task verson(s).


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
