### PR TITLE
COP-8933: Back to task list link taking user back to the selected tab…

### DIFF
--- a/src/components/__tests__/ClaimTaskButton.test.jsx
+++ b/src/components/__tests__/ClaimTaskButton.test.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import '../../__mocks__/keycloakMock';
+import { TaskSelectedTabContext } from '../../context/TaskSelectedTabContext';
 import ClaimButton from '../ClaimTaskButton';
 import TaskListPage from '../../routes/TaskLists/TaskListPage';
 
@@ -89,7 +90,12 @@ describe('Claim/Unclaim buttons', () => {
     await waitFor(() => { fireEvent.click(screen.getByText(/Unclaim/i)); });
     expect(mockAxios.history.post[0].url).toEqual(`task/${task.id}/unclaim`);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    const tabData = {
+      selectedTabIndex: 0,
+      selectTabIndex: jest.fn(),
+    };
+    await waitFor(() => render(<TaskSelectedTabContext.Provider value={tabData}><TaskListPage taskStatus="new" setError={() => { }} /></TaskSelectedTabContext.Provider>));
+
     expect(screen.getByText('New tasks')).toBeInTheDocument();
     expect(screen.queryByText('In progress tasks')).not.toBeInTheDocument();
     expect(screen.queryByText('Target issued tasks')).not.toBeInTheDocument();

--- a/src/context/TaskSelectedTabContext.jsx
+++ b/src/context/TaskSelectedTabContext.jsx
@@ -1,0 +1,16 @@
+import React, { useState, createContext } from 'react';
+
+const TaskSelectedTabContext = createContext();
+
+const TaskSelectedTabProvider = ({ children }) => {
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+
+  const selectTabIndex = (tabIndex) => setSelectedTabIndex(tabIndex);
+  return (
+    <TaskSelectedTabContext.Provider value={{ selectedTabIndex, selectTabIndex }}>
+      {children}
+    </TaskSelectedTabContext.Provider>
+  );
+};
+
+export { TaskSelectedTabContext, TaskSelectedTabProvider };

--- a/src/govuk/Tabs.jsx
+++ b/src/govuk/Tabs.jsx
@@ -4,15 +4,17 @@
  * Code: https://github.com/alphagov/govuk-frontend/blob/master/package/govuk/components/tabs/README.md
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import classNames from 'classnames';
 import { TASK_STATUS_NEW } from '../constants';
+import { TaskSelectedTabContext } from '../context/TaskSelectedTabContext';
 
 const Tabs = ({
   id, idPrefix, className, title, items, onTabClick, tabIndex, ...attributes
 }) => {
-  const [currentTabIndex, setCurrentTabIndex] = useState(0);
+  const { selectedTabIndex, selectTabIndex } = useContext(TaskSelectedTabContext);
+  const [currentTabIndex, setCurrentTabIndex] = useState(selectedTabIndex);
   const currentTab = items[currentTabIndex];
   const currentTabId = currentTab.id || `${idPrefix}-${currentTabIndex}`;
   const panelIsReactElement = typeof currentTab.panel === 'string' || Array.isArray(currentTab.panel) || React.isValidElement(currentTab.panel);
@@ -48,6 +50,7 @@ const Tabs = ({
                   <a
                     className="govuk-tabs__tab"
                     onClick={(e) => {
+                      selectTabIndex(index);
                       setCurrentTabIndex(index);
                       e.preventDefault();
                       if (onTabClick) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { render } from 'react-dom';
 import AppRouter from './routes';
 import { KeycloakProvider } from './utils/keycloak';
+import { TaskSelectedTabProvider } from './context/TaskSelectedTabContext';
 import './__assets__/index.scss';
 
 render(
   <KeycloakProvider>
-    <AppRouter />
+    <TaskSelectedTabProvider>
+      <AppRouter />
+    </TaskSelectedTabProvider>
   </KeycloakProvider>,
   document.getElementById('root'),
 );

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -5,17 +5,27 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '../../__mocks__/keycloakMock';
 import TaskListPage from '../TaskLists/TaskListPage';
 import variableInstanceTaskSummaryBasedOnTIS from '../__fixtures__/variableInstanceTaskSummaryBasedOnTIS.fixture.json';
+import { TaskSelectedTabContext } from '../../context/TaskSelectedTabContext';
 
 describe('TaskListPage', () => {
   const mockAxios = new MockAdapter(axios);
   const envUrl = `${window.location.protocol}//${window.location.hostname}`;
+  const tabData = {
+    selectedTabIndex: 1,
+    selectTabIndex: jest.fn(),
+  };
+
+  const setTabAndTaskValues = (value = tabData, taskStatus = 'new') => {
+    return (<TaskSelectedTabContext.Provider value={value}><TaskListPage taskStatus={taskStatus} setError={() => { }} /></TaskSelectedTabContext.Provider>);
+  };
+
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => { });
     mockAxios.reset();
   });
 
   it('should render loading spinner on component load', async () => {
-    render(<TaskListPage taskStatus="new" setError={() => { }} />);
+    render(setTabAndTaskValues(tabData, 'new'));
     expect(screen.getByText('Loading')).toBeInTheDocument();
   });
 
@@ -38,7 +48,7 @@ describe('TaskListPage', () => {
       .onGet('/history/variable-instance')
       .reply(200, []);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
     expect(screen.getByText('New (7)')).toBeInTheDocument();
@@ -64,7 +74,7 @@ describe('TaskListPage', () => {
       .onGet('/history/variable-instance')
       .reply(200, []);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
     expect(screen.getByText('New (0)')).toBeInTheDocument();
@@ -107,7 +117,7 @@ describe('TaskListPage', () => {
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Da%2Fb%2Fc/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Da%2Fb%2Fc`));
     await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Dd%2Fe%2Ff/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Dd%2Fe%2Ff`));
@@ -143,7 +153,7 @@ describe('TaskListPage', () => {
       .onGet('/history/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     fireEvent.click(screen.getByRole('link', { name: /Complete/i }));
     await waitFor(() => expect(screen.getByRole('link', { name: /business%3Akey%3Da%2Fb%2Fc/i }).href).toBe(`${envUrl}/tasks/business%3Akey%3Da%2Fb%2Fc`));
@@ -164,7 +174,7 @@ describe('TaskListPage', () => {
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.getAllByText('Claim')).toHaveLength(3);
   });
@@ -182,7 +192,8 @@ describe('TaskListPage', () => {
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+
     fireEvent.click(screen.getByRole('link', { name: /In progress/i }));
 
     await waitFor(() => expect(screen.getAllByText('Unclaim')).toHaveLength(1));
@@ -206,7 +217,8 @@ describe('TaskListPage', () => {
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+
     fireEvent.click(screen.getByRole('link', { name: /Issued/i }));
 
     await waitFor(() => expect(screen.getByText('Target issued tasks')).toBeInTheDocument());
@@ -230,7 +242,8 @@ describe('TaskListPage', () => {
       .onGet('/history/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+
     fireEvent.click(screen.getByRole('link', { name: /Complete/i }));
 
     await waitFor(() => expect(screen.getByText('Completed tasks')).toBeInTheDocument());
@@ -250,7 +263,7 @@ describe('TaskListPage', () => {
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.getAllByText('SELECTOR: Local ref, B, National Security at the Border and 2 other rules')).toHaveLength(1);
     expect(screen.getAllByText('Rulename, Tier 1, Class A Drugs and 0 other rules')).toHaveLength(1);
@@ -269,7 +282,7 @@ describe('TaskListPage', () => {
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.getAllByText('2 indicators')).toHaveLength(1);
     expect(screen.getAllByText('Paid by cash')).toHaveLength(1);
@@ -289,7 +302,7 @@ describe('TaskListPage', () => {
       .onGet('/variable-instance')
       .reply(200, variableInstanceTaskSummaryBasedOnTIS);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.getAllByText('Risk Score: 25')).toHaveLength(1);
   });
@@ -301,7 +314,7 @@ describe('TaskListPage', () => {
       .onGet('/task')
       .reply(500);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.getByText('No tasks available')).toBeInTheDocument();
     expect(screen.queryByText('Request failed with status code 500')).toBeInTheDocument();
@@ -313,7 +326,7 @@ describe('TaskListPage', () => {
       .onGet('/task/count')
       .reply(500);
 
-    await waitFor(() => render(<TaskListPage taskStatus="new" setError={() => { }} />));
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.getByText('No tasks available')).toBeInTheDocument();
     expect(screen.queryByText('Request failed with status code 500')).toBeInTheDocument();

--- a/src/routes/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/__tests__/TaskListPageFilters.test.jsx
@@ -4,9 +4,14 @@ import MockAdapter from 'axios-mock-adapter';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '../../__mocks__/keycloakMock';
 import TaskListPage from '../TaskLists/TaskListPage';
+import { TaskSelectedTabContext } from '../../context/TaskSelectedTabContext';
 
 describe('TaskListFilters', () => {
   const mockAxios = new MockAdapter(axios);
+  const tabData = {
+    selectedTabIndex: 1,
+    selectTabIndex: jest.fn(),
+  };
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => { });
     jest.clearAllMocks();
@@ -14,8 +19,11 @@ describe('TaskListFilters', () => {
     mockAxios.reset();
   });
 
+  beforeEach(() => {
+    render(<TaskSelectedTabContext.Provider value={tabData}><TaskListPage /></TaskSelectedTabContext.Provider>);
+  });
+
   it('should display filter options based on filter config (filters.js)', async () => {
-    render(<TaskListPage />);
     // Titles & Actions
     expect(screen.getByText('Filters')).toBeInTheDocument();
     expect(screen.getByText('Apply filters')).toBeInTheDocument();
@@ -33,7 +41,6 @@ describe('TaskListFilters', () => {
   });
 
   it('should allow user to select a single radio button in each group', async () => {
-    render(<TaskListPage />);
     // group one select
     fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
     // group two select first 'has', then 'has no'
@@ -48,7 +55,6 @@ describe('TaskListFilters', () => {
   });
 
   it('should store selection to localstorage when apply filters button is clicked', async () => {
-    render(<TaskListPage />);
     fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
     fireEvent.click(screen.getByLabelText('Has selector'));
     fireEvent.click(screen.getByText('Apply filters'));
@@ -58,7 +64,7 @@ describe('TaskListFilters', () => {
 
   it('should clear filters when clearAll is clicked', async () => {
     localStorage.setItem('filters', 'movementMode_eq_roro-accompanied-freight,hasSelectors_eq_yes');
-    render(<TaskListPage />);
+
     fireEvent.click(screen.getByText('Clear all filters'));
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
@@ -71,10 +77,8 @@ describe('TaskListFilters', () => {
 
   it('should persist filters when they exist in local storage', async () => {
     localStorage.setItem('filters', 'movementMode_eq_roro-accompanied-freight');
-    render(<TaskListPage />);
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo accompanied freight')).toBeChecked();
     expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
     expect(screen.getByLabelText('Has no selector')).not.toBeChecked();
     expect(screen.getByLabelText('Has selector')).not.toBeChecked();


### PR DESCRIPTION
… state

## Description
COP-8933: Back to task list link taking user back to the selected tab state .

## To Test
1. Select a task in any tab state(New, In progress, Issued, Complete) on Task management landing page.
2. The journey would take the user to the Task details page for the selected task
3. Click on Back to task list link
4. The previously selected tab would be active

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
