### PR TITLE
COP-9368: Add test to check latest departure date/time displayed in UI for tasks with multiple versions

### DIFF
--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -520,8 +520,6 @@ describe('Task Details of different tasks on task details Page', () => {
     let date = new Date();
     const businessKey = `AUTOTEST-${dateNowFormatted}-RORO-Accompanied-Freight-passenger-info_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
     let departureDateTime;
-    let arrivalDataTime;
-    let bookingDateTime;
     const dateFormat = 'D MMM YYYY [at] HH:mm';
 
     date.setDate(date.getDate() + 8);
@@ -556,14 +554,14 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.fixture('/task-version-passenger/RoRo-task-v3.json').then((task) => {
       task.businessKey = businessKey;
       task.variables.rbtPayload.value.data.movementId = businessKey;
-      arrivalDataTime = Cypress.dayjs(date.getTime()).utc().format(dateFormat);
+      let arrivalDataTime = Cypress.dayjs(date.getTime()).utc().format(dateFormat);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
       departureDateTime = Cypress.dayjs().add(13, 'day').valueOf();
       task.variables.rbtPayload.value.data.movement.voyage.voyage.scheduledDepartureTimestamp = departureDateTime;
       departureDateTime = Cypress.dayjs(departureDateTime).utc().format(dateFormat);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualDepartureTimestamp = Cypress.dayjs().add(13, 'day').valueOf();
       task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime = Cypress.dayjs().format('YYYY-MM-DDThh:mm:ss');
-      bookingDateTime = Cypress.dayjs(task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime).utc().format(dateFormat);
+      let bookingDateTime = Cypress.dayjs(task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime).utc().format(dateFormat);
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, null).then((response) => {
         cy.wait(15000);

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -519,12 +519,20 @@ describe('Task Details of different tasks on task details Page', () => {
   it('Should verify single task created for the same target with different versions with different passengers information', () => {
     let date = new Date();
     const businessKey = `AUTOTEST-${dateNowFormatted}-RORO-Accompanied-Freight-passenger-info_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+    let departureDateTime;
+    let arrivalDataTime;
+    let bookingDateTime;
+    const dateFormat = 'D MMM YYYY [at] HH:mm';
 
     date.setDate(date.getDate() + 8);
     cy.fixture('/task-version-passenger/RoRo-task-v1.json').then((task) => {
       task.businessKey = businessKey;
       task.variables.rbtPayload.value.data.movementId = businessKey;
+      arrivalDataTime = Cypress.dayjs(date.getTime()).utc().format(dateFormat);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.scheduledDepartureTimestamp = Cypress.dayjs().add(15, 'day').valueOf();
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualDepartureTimestamp = Cypress.dayjs().add(15, 'day').valueOf();
+      task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime = Cypress.dayjs().subtract(2, 'day').format('YYYY-MM-DDThh:mm:ss');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, null);
     });
@@ -534,7 +542,11 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.fixture('/task-version-passenger/RoRo-task-v2.json').then((task) => {
       task.businessKey = businessKey;
       task.variables.rbtPayload.value.data.movementId = businessKey;
+      arrivalDataTime = Cypress.dayjs(date.getTime()).utc().format(dateFormat);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.scheduledDepartureTimestamp = Cypress.dayjs().add(2, 'month').valueOf();
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualDepartureTimestamp = Cypress.dayjs().add(2, 'day').valueOf();
+      task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime = Cypress.dayjs().subtract(1, 'day').format('YYYY-MM-DDThh:mm:ss');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, null);
     });
@@ -544,15 +556,34 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.fixture('/task-version-passenger/RoRo-task-v3.json').then((task) => {
       task.businessKey = businessKey;
       task.variables.rbtPayload.value.data.movementId = businessKey;
+      arrivalDataTime = Cypress.dayjs(date.getTime()).utc().format(dateFormat);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+      departureDateTime = Cypress.dayjs().add(13, 'day').valueOf();
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.scheduledDepartureTimestamp = departureDateTime;
+      departureDateTime = Cypress.dayjs(departureDateTime).utc().format(dateFormat);
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualDepartureTimestamp = Cypress.dayjs().add(13, 'day').valueOf();
+      task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime = Cypress.dayjs().format('YYYY-MM-DDThh:mm:ss');
+      bookingDateTime = Cypress.dayjs(task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime).utc().format(dateFormat);
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, null).then((response) => {
         cy.wait(15000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
-        let encodedBusinessKey = encodeURIComponent(`${response.businessKey}`);
-        cy.getAllProcessInstanceId(encodedBusinessKey).then((res) => {
+        cy.getAllProcessInstanceId(`${response.businessKey}`).then((res) => {
           expect(res.body.length).to.not.equal(0);
           expect(res.body.length).to.equal(1);
+        });
+
+        // COP-9368 Latest departure date/time should be displayed in UI for tasks with multiple versions
+        let expectedTaskSummary = {
+          'Ferry': 'DFDS voyage of DOVER SEAWAYS',
+          'Departure': `DOV, ${departureDateTime}`,
+          'Arrival': `CAL, ${arrivalDataTime}`,
+          'Account': `Univeral Printers Ltd, booked on ${bookingDateTime}`,
+          'Haulier': 'Matthesons',
+        };
+
+        cy.checkTaskSummaryDetails().then((taskSummary) => {
+          expect(taskSummary).to.deep.equal(expectedTaskSummary);
         });
       });
     });


### PR DESCRIPTION
## Description
Add test to check latest departure date/time displayed in UI for tasks with multiple versions

## To Test
npm run cypress:runner
run the test `Should verify single task created for the same target with different versions with different passengers information` from spec `task-version-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
