### PR TITLE
Risk score 0 when none is avaiable

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -179,7 +179,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
       });
     }
     return (
-      totalRiskScore > 0 ? <li className="govuk-!-font-weight-bold">Risk Score: {totalRiskScore}</li> : <li>Risk Score:</li>
+      totalRiskScore > 0 ? <li className="govuk-!-font-weight-bold">Risk Score: {totalRiskScore}</li> : <li>Risk Score: 0</li>
     );
   };
 


### PR DESCRIPTION
## Description
This PR fixes a bug where the when there were no risk scores, it would return **Risk Score: ** instead of **Risk Score: 0**

## To Test
- On the tasts list, each task will have a Risk score: along with a value if risk scores are present e.g. **Risk Score: 25** and just **Risk Score: 0** if there's no risk score to calculate.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
