### PR TITLE
COP-9511 Change wording of selector filter

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -97,19 +97,19 @@ const filterListConfig = [
       {
         name: 'has-no-selector',
         code: 'hasSelectors_eq_no',
-        label: 'Has no selector',
+        label: 'Not present',
         checked: false,
       },
       {
         name: 'has-selector',
         code: 'hasSelectors_eq_yes',
-        label: 'Has selector',
+        label: 'Present',
         checked: false,
       },
       {
         name: 'both',
         code: 'noCode', // as 'both' is all tasks we return a word we can set to null in the call
-        label: 'Both',
+        label: 'Any',
         checked: false,
       },
     ],

--- a/src/routes/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/__tests__/TaskListPageFilters.test.jsx
@@ -36,27 +36,27 @@ describe('TaskListFilters', () => {
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo accompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
-    expect(screen.getByLabelText('Has no selector')).not.toBeChecked();
-    expect(screen.getByLabelText('Has selector')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present')).not.toBeChecked();
+    expect(screen.getByLabelText('Present')).not.toBeChecked();
   });
 
   it('should allow user to select a single radio button in each group', async () => {
     // group one select
     fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
     // group two select first 'has', then 'has no'
-    fireEvent.click(screen.getByLabelText('Has selector'));
-    fireEvent.click(screen.getByLabelText('Has no selector'));
+    fireEvent.click(screen.getByLabelText('Present'));
+    fireEvent.click(screen.getByLabelText('Not present'));
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo accompanied freight')).toBeChecked();
     expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
-    expect(screen.getByLabelText('Has no selector')).toBeChecked();
-    expect(screen.getByLabelText('Has selector')).not.toBeChecked(); // this is reset to 'not' when 'has no' is selected
+    expect(screen.getByLabelText('Not present')).toBeChecked();
+    expect(screen.getByLabelText('Present')).not.toBeChecked(); // this is reset to 'not' when 'has no' is selected
   });
 
   it('should store selection to localstorage when apply filters button is clicked', async () => {
     fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
-    fireEvent.click(screen.getByLabelText('Has selector'));
+    fireEvent.click(screen.getByLabelText('Present'));
     fireEvent.click(screen.getByText('Apply filters'));
 
     expect(localStorage.getItem('filters')).toBe('movementMode_eq_roro-accompanied-freight,hasSelectors_eq_yes');
@@ -70,8 +70,8 @@ describe('TaskListFilters', () => {
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo accompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
-    expect(screen.getByLabelText('Has no selector')).not.toBeChecked();
-    expect(screen.getByLabelText('Has selector')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present')).not.toBeChecked();
+    expect(screen.getByLabelText('Present')).not.toBeChecked();
     expect(localStorage.getItem('filters')).toBeFalsy();
   });
 
@@ -80,8 +80,8 @@ describe('TaskListFilters', () => {
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
-    expect(screen.getByLabelText('Has no selector')).not.toBeChecked();
-    expect(screen.getByLabelText('Has selector')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present')).not.toBeChecked();
+    expect(screen.getByLabelText('Present')).not.toBeChecked();
     expect(localStorage.getItem('filters')).toBe('movementMode_eq_roro-accompanied-freight');
   });
 });


### PR DESCRIPTION
## Description
This PR is a minor cosmetic changing of the selector filter names.
JIRA Ticket: [https://support.cop.homeoffice.gov.uk/browse/COP-9511](url)

## To Test
- Pull and run against dev
- On the task list, locate the filter section, specifically the selectors radio button group.
- It should now say: 
> **Not present** 
> **Present**
> **Any** 

instead of 

> **Has no selector**
> **Has selector**
> **Both**

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
