### PR TITLE
COP-9286 UX to display total risk score in task details

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -16,6 +16,7 @@ import config from '../../config';
 import useAxiosInstance from '../../utils/axiosInstance';
 import targetDatetimeDifference from '../../utils/calculateDatetimeDifference';
 import { useKeycloak } from '../../utils/keycloak';
+import { calculateTaskListTotalRiskScore } from '../../utils/rickScoreCalculator';
 // Components/Pages
 import ClaimButton from '../../components/ClaimTaskButton';
 import ErrorSummary from '../../govuk/ErrorSummary';
@@ -171,19 +172,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
     }
   };
 
-  const calculateTotalRiskScore = (target) => {
-    let totalRiskScore = 0;
-    if (target.threatIndicators?.length > 0) {
-      target.threatIndicators.map((threatIndicatorScore) => {
-        totalRiskScore += threatIndicatorScore?.score || 0;
-      });
-    }
-    return (
-      totalRiskScore > 0 ? <li className="govuk-!-font-weight-bold">Risk Score: {totalRiskScore}</li> : <li>Risk Score: 0</li>
-    );
-  };
-
-  const hasUpdatedSTatus = (target) => {
+  const hasUpdatedStatus = (target) => {
     if (target.numberOfVersions > 1) {
       return (
         <div className="govuk-grid-row">
@@ -331,7 +320,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
               </div>
             </div>
 
-            {hasUpdatedSTatus(target)}
+            {hasUpdatedStatus(target)}
 
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-full">
@@ -454,7 +443,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError }) => {
                 <ul className="govuk-list task-labels govuk-!-margin-top-2 govuk-!-margin-bottom-0">
                   <li className="task-labels-item">
                     <strong className="govuk-!-font-weight-bold">
-                      {calculateTotalRiskScore(target)}
+                      {calculateTaskListTotalRiskScore(target)}
                     </strong>
                   </li>
                 </ul>

--- a/src/routes/__assets__/TaskDetailsPage.scss
+++ b/src/routes/__assets__/TaskDetailsPage.scss
@@ -1,61 +1,89 @@
 @import "~govuk-frontend/govuk/vendor/_sass-mq";
 @import "~govuk-frontend/govuk/settings/spacing";
 @import "~govuk-frontend/govuk/helpers/spacing";
-
 @include mq($from: tablet) {
-  .task-versions .govuk-accordion__section-summary {
-    display: flex;
-    justify-content: space-between;
-  }
-
-  .task-versions--right {
-    margin-top: -40px;
-  }
+    .task-versions .govuk-accordion__section-summary {
+        display: flex;
+        justify-content: space-between;
+    }
+    .task-versions--right {
+        margin-top: -40px;
+    }
 }
 
 .task-versions--highlight {
-  border-bottom: 3px solid #ffbf47;
-  margin-right: 1px;
-  background-color: #fff2d3;
-  padding: 2px 0 0;
+    border-bottom: 3px solid #ffbf47;
+    margin-right: 1px;
+    background-color: #fff2d3;
+    padding: 2px 0 0;
 }
 
 @include mq($from: tablet) {
-  .task-actions--buttons {
-    display: flex;
-    justify-content: flex-end;
-    align-items: flex-end;
-    margin-top: 20pt;
-  }
+    .task-actions--buttons {
+        display: flex;
+        justify-content: flex-end;
+        align-items: flex-end;
+        margin-top: 20pt;
+    }
 }
 
 .card {
-  padding: 1em;
-  font-size: 1em;
-  margin-bottom: 2em;
-  background-color: #f3f2f1;
+    padding: 1em;
+    font-size: 1em;
+    margin-bottom: 2em;
+    background-color: #f3f2f1;
 }
 
 .mode-details {
-  display: flex;
-  justify-content: flex-start;
-  margin: 0;
-  font-family: "nta", Arial, sans-serif;
-  font-size: 0.9em;
-  flex-wrap: wrap;
+    display: flex;
+    justify-content: flex-start;
+    margin: 0;
+    font-family: "nta", Arial, sans-serif;
+    font-size: 0.9em;
+    flex-wrap: wrap;
 }
 
-.mode-details dt, .mode-details dd {
-  display: inline-block;
+.mode-details dt,
+.mode-details dd {
+    display: inline-block;
 }
 
 .mode-details dt {
-  width: 20%;
+    width: 20%;
 }
 
 .mode-details dd {
-  width: 80%;
-  font-weight: bold;
-  margin: 0 0 0.5em 0;
+    width: 80%;
+    font-weight: bold;
+    margin: 0 0 0.5em 0;
 }
 
+.govuk-summary-list__key {
+    &.font__light {
+        font-weight: lighter;
+        color: #505a5f;
+    }
+    &.font__bold {
+        font-weight: bold;
+    }
+}
+
+.govuk-summary-list__value {
+    &.font__light {
+        font-weight: lighter;
+        color: #505a5f;
+    }
+    &.font__bold {
+        font-weight: bold;
+    }
+}
+
+.govuk-summary-list__row {
+    &.font__light {
+        font-weight: lighter;
+        color: #505a5f;
+    }
+    &.font__bold {
+        font-weight: bold;
+    }
+}

--- a/src/routes/__fixtures__/variableInstanceStatusIssued.fixture.json
+++ b/src/routes/__fixtures__/variableInstanceStatusIssued.fixture.json
@@ -1,107 +1,106 @@
-[
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "cerberusPayload"
-  },
-  {
-    "type": "Json",
-    "value": "[[{\"fieldSetName\": \"Vehicle details\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Vehicle registration\",\"type\": \"STRING\",\"content\": \"COP1\",\"versionLastUpdated\": null,\"propName\": \"registrationNumber\"},{\"fieldName\": \"Type\",\"type\": \"STRING\",\"content\": \"HGV\",\"versionLastUpdated\": null,\"propName\": \"type\"},{\"fieldName\": \"Make\",\"type\": \"STRING\",\"content\": \"Model-xyz\",\"versionLastUpdated\": null,\"propName\": \"make\"},{\"fieldName\": \"Model\",\"type\": \"STRING\",\"content\": \"Make-123\",\"versionLastUpdated\": null,\"propName\": \"model\"},{\"fieldName\": \"Country of registration\",\"type\": \"STRING\",\"content\": \"GB\",\"versionLastUpdated\": null,\"propName\": \"registrationNationality\"},{\"fieldName\": \"Colour\",\"type\": \"STRING\",\"content\": \"Colour-White\",\"versionLastUpdated\": null,\"propName\": \"colour\"},{\"fieldName\": \"Net weight\",\"type\": \"WEIGHT\",\"content\": \"3455\",\"versionLastUpdated\": null,\"propName\": \"netWeight\"},{\"fieldName\": \"Gross weight\",\"type\": \"WEIGHT\",\"content\": \"43623\",\"versionLastUpdated\": null,\"propName\": \"grossWeight\"},{\"fieldName\": \"Trailer registration number\",\"type\": \"STRING\",\"content\": \"NL-234-392\",\"versionLastUpdated\": null,\"propName\": \"trailerRegistrationNumber\"},{\"fieldName\": \"Trailer type\",\"type\": \"STRING\",\"content\": \"TR\",\"versionLastUpdated\": null,\"propName\": \"trailerType\"},{\"fieldName\": \"Trailer country of registration\",\"type\": \"STRING\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"trailerRegistrationNationality\"},{\"fieldName\": \"Empty or loaded\",\"type\": \"STRING\",\"content\": \"Loaded\",\"versionLastUpdated\": null,\"propName\": \"trailerEmptyOrLoaded\"},{\"fieldName\": \"Trailer length\",\"type\": \"DISTANCE\",\"content\": \"36\",\"versionLastUpdated\": null,\"propName\": \"trailerLength\"},{\"fieldName\": \"Trailer height\",\"type\": \"DISTANCE\",\"content\": \"3.6\",\"versionLastUpdated\": null,\"propName\": \"trailerHeight\"}],\"type\": \"null\",\"propName\": \"vehicle\"},{\"fieldSetName\": \"Haulier details\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"Matthesons\",\"versionLastUpdated\": null,\"propName\": \"name\"},{\"fieldName\": \"Address\",\"type\": \"STRING\",\"content\": \"Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB\",\"versionLastUpdated\": null,\"propName\": \"address\"},{\"fieldName\": \"Telephone\",\"type\": \"TELEPHONE\",\"content\": \"01243785239\",\"versionLastUpdated\": null,\"propName\": \"telephone\"},{\"fieldName\": \"Mobile\",\"type\": \"TELEPHONE\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"mobile\"},{\"fieldName\": \"Address line 1\",\"type\": \"HIDDEN\",\"content\": \"Unit 9-12 Pinkerton Way\",\"versionLastUpdated\": null,\"propName\": \"addressLine1\"},{\"fieldName\": \"Address line 2\",\"type\": \"HIDDEN\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"addressLine2\"},{\"fieldName\": \"City\",\"type\": \"HIDDEN\",\"content\": \"Bognor Regis\",\"versionLastUpdated\": null,\"propName\": \"city\"},{\"fieldName\": \"Postcode\",\"type\": \"HIDDEN\",\"content\": \"KJFSG094\",\"versionLastUpdated\": null,\"propName\": \"postcode\"},{\"fieldName\": \"Country\",\"type\": \"HIDDEN\",\"content\": \"GB\",\"versionLastUpdated\": null,\"propName\": \"country\"}],\"type\": \"null\",\"propName\": \"haulier\"},{\"fieldSetName\": \"Account details\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Full name\",\"type\": \"STRING\",\"content\": \"Univeral Printers Ltd\",\"versionLastUpdated\": null,\"propName\": \"name\"},{\"fieldName\": \"Short name\",\"type\": \"STRING\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"shortName\"},{\"fieldName\": \"Reference number\",\"type\": \"STRING\",\"content\": \"PO000359675\",\"versionLastUpdated\": null,\"propName\": \"referenceNumber\"},{\"fieldName\": \"Address\",\"type\": \"STRING\",\"content\": \"Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB\",\"versionLastUpdated\": null,\"propName\": \"address\"},{\"fieldName\": \"Telephone\",\"type\": \"TELEPHONE\",\"content\": \"01243785239\",\"versionLastUpdated\": null,\"propName\": \"telephone\"},{\"fieldName\": \"Mobile\",\"type\": \"TELEPHONE\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"mobile\"},{\"fieldName\": \"Email\",\"type\": \"EMAIL\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"email\"}],\"type\": \"null\",\"propName\": \"account\"},{\"fieldSetName\": \"Driver\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"Ben Bailey\",\"versionLastUpdated\": null,\"propName\": \"name\"},{\"fieldName\": \"Date of birth\",\"type\": \"SHORT_DATE\",\"content\": -66,\"versionLastUpdated\": null,\"propName\": \"dob\"},{\"fieldName\": \"Gender\",\"type\": \"STRING\",\"content\": \"M\",\"versionLastUpdated\": null,\"propName\": \"gender\"},{\"fieldName\": \"Nationality\",\"type\": \"STRING\",\"content\": \"GB\",\"versionLastUpdated\": null,\"propName\": \"nationality\"},{\"fieldName\": \"Travel document type\",\"type\": \"STRING\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"docType\"},{\"fieldName\": \"Travel document number\",\"type\": \"STRING\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"docNumber\"},{\"fieldName\": \"Travel document expiry\",\"type\": \"SHORT_DATE\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"docExpiry\"},{\"fieldName\": \"Pole ID\",\"type\": \"HIDDEN\",\"content\": \"ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c\",\"versionLastUpdated\": null,\"propName\": \"poleId\"},{\"fieldName\": \"First name\",\"type\": \"HIDDEN\",\"content\": \"Ben\",\"versionLastUpdated\": null,\"propName\": \"firstName\"},{\"fieldName\": \"Last name\",\"type\": \"HIDDEN\",\"content\": \"Bailey\",\"versionLastUpdated\": null,\"propName\": \"lastName\"},{\"fieldName\": \"Middle name\",\"type\": \"HIDDEN\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"middleName\"}],\"type\": \"null\",\"propName\": \"driver\"},{\"fieldSetName\": \"Passengers\",\"hasChildSet\": true,\"contents\": [],\"childSets\": [{\"fieldSetName\": \"\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"Bob Brown\",\"versionLastUpdated\": null,\"propName\": \"name\"},{\"fieldName\": \"Date of birth\",\"type\": \"SHORT_DATE\",\"content\": 435,\"versionLastUpdated\": null,\"propName\": \"dob\"},{\"fieldName\": \"Gender\",\"type\": \"STRING\",\"content\": \"M\",\"versionLastUpdated\": null,\"propName\": \"gender\"},{\"fieldName\": \"Nationality\",\"type\": \"STRING\",\"content\": \"IR\",\"versionLastUpdated\": null,\"propName\": \"nationality\"},{\"fieldName\": \"Travel document type\",\"type\": \"STRING\",\"content\": \"OBJDOCPAS\",\"versionLastUpdated\": null,\"propName\": \"docType\"},{\"fieldName\": \"Travel document number\",\"type\": \"STRING\",\"content\": \"ST678457\",\"versionLastUpdated\": null,\"propName\": \"docNumber\"},{\"fieldName\": \"Travel document expiry\",\"type\": \"SHORT_DATE\",\"content\": 18659,\"versionLastUpdated\": null,\"propName\": \"docExpiry\"},{\"fieldName\": \"Pole ID\",\"type\": \"HIDDEN\",\"content\": \"ROROXML:P=8049bc0c58748004ad81925020b26ce3\",\"versionLastUpdated\": null,\"propName\": \"poleId\"},{\"fieldName\": \"First name\",\"type\": \"HIDDEN\",\"content\": \"Bob\",\"versionLastUpdated\": null,\"propName\": \"firstName\"},{\"fieldName\": \"Last name\",\"type\": \"HIDDEN\",\"content\": \"Brown\",\"versionLastUpdated\": null,\"propName\": \"lastName\"},{\"fieldName\": \"Middle name\",\"type\": \"HIDDEN\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"middleName\"}],\"type\": \"null\",\"propName\": \"\"}],\"type\": \"STANDARD\",\"propName\": \"passengers\"},{\"fieldSetName\": \"Goods\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Description\",\"type\": \"STRING\",\"content\": \"Printed Paper\",\"versionLastUpdated\": null,\"propName\": \"description\"},{\"fieldName\": \"Is cargo hazardous?\",\"type\": \"STRING\",\"content\": \"No\",\"versionLastUpdated\": null,\"propName\": \"isHazardous\"},{\"fieldName\": \"Weight of goods\",\"type\": \"WEIGHT\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"weight\"}],\"type\": \"null\",\"propName\": \"goods\"},{\"fieldSetName\": \"Booking and check-in\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Reference\",\"type\": \"STRING\",\"content\": \"357485636\",\"versionLastUpdated\": null,\"propName\": \"reference\"},{\"fieldName\": \"Ticket number\",\"type\": \"STRING\",\"content\": \"DFDS-1000974\",\"versionLastUpdated\": null,\"propName\": \"ticketNumber\"},{\"fieldName\": \"Type\",\"type\": \"STRING\",\"content\": \"Test\",\"versionLastUpdated\": null,\"propName\": \"bookingType\"},{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"test\",\"versionLastUpdated\": null,\"propName\": \"name\"},{\"fieldName\": \"Address\",\"type\": \"STRING\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"address\"},{\"fieldName\": \"Date and time\",\"type\": \"BOOKING_DATETIME\",\"content\": \"2020-08-02T09:15:00,2020-08-04T13:05:00\",\"versionLastUpdated\": null,\"propName\": \"dateBooked\"},{\"fieldName\": \"Country\",\"type\": \"STRING\",\"content\": \"GB\",\"versionLastUpdated\": null,\"propName\": \"country\"},{\"fieldName\": \"Payment method\",\"type\": \"STRING\",\"content\": \"Account\",\"versionLastUpdated\": null,\"propName\": \"paymentMethod\"},{\"fieldName\": \"Ticket price\",\"type\": \"CURRENCY\",\"content\": \"30 quid\",\"versionLastUpdated\": null,\"propName\": \"ticketPrice\"},{\"fieldName\": \"Ticket type\",\"type\": \"STRING\",\"content\": \"Return\",\"versionLastUpdated\": null,\"propName\": \"ticketType\"},{\"fieldName\": \"Check-in\",\"type\": \"DATETIME\",\"content\": \"2020-08-04T12:05:00\",\"versionLastUpdated\": null,\"propName\": \"checkIn\"}],\"type\": \"null\",\"propName\": \"booking\"},{\"fieldSetName\": \"Targeting indicators\",\"hasChildSet\": true,\"contents\": [],\"childSets\": [{\"fieldSetName\": \"\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"UK port hop inbound\",\"versionLastUpdated\": null,\"propName\": \"userfacingtext\"},{\"fieldName\": \"ID\",\"type\": \"HIDDEN\",\"content\": 5,\"versionLastUpdated\": null,\"propName\": \"id\"},{\"fieldName\": \"Feature name\",\"type\": \"HIDDEN\",\"content\": \"VEHICLE-PORT-HOP-IN2OUT\",\"versionLastUpdated\": null,\"propName\": \"featurename\"},{\"fieldName\": \"Vehicle\",\"type\": \"HIDDEN\",\"content\": true,\"versionLastUpdated\": null,\"propName\": \"vehicle\"},{\"fieldName\": \"Driver\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"driver\"},{\"fieldName\": \"Person\",\"type\": \"HIDDEN\",\"content\": true,\"versionLastUpdated\": null,\"propName\": \"person\"},{\"fieldName\": \"Haulier\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"haulier\"},{\"fieldName\": \"Movement\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"movement\"},{\"fieldName\": \"Booking\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"booking\"},{\"fieldName\": \"Organisation\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"organisation\"},{\"fieldName\": \"Score\",\"type\": \"HIDDEN\",\"content\": 20,\"versionLastUpdated\": null,\"propName\": \"score\"},{\"fieldName\": \"Valid from\",\"type\": \"HIDDEN\",\"content\": \"2021-06-03T00:00:01.000Z\",\"versionLastUpdated\": null,\"propName\": \"validfrom\"},{\"fieldName\": \"Valid to\",\"type\": \"HIDDEN\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"validto\"},{\"fieldName\": \"Updated by\",\"type\": \"HIDDEN\",\"content\": \"Mohammed Abdul Odud\",\"versionLastUpdated\": null,\"propName\": \"updatedby\"}],\"type\": \"null\",\"propName\": \"\"},{\"fieldSetName\": \"\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"First use of account (Driver)\",\"versionLastUpdated\": null,\"propName\": \"userfacingtext\"},{\"fieldName\": \"ID\",\"type\": \"HIDDEN\",\"content\": 9,\"versionLastUpdated\": null,\"propName\": \"id\"},{\"fieldName\": \"Feature name\",\"type\": \"HIDDEN\",\"content\": \"FIRST-TIME-ACCOUNT-DRIVER\",\"versionLastUpdated\": null,\"propName\": \"featurename\"},{\"fieldName\": \"Vehicle\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"vehicle\"},{\"fieldName\": \"Driver\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"driver\"},{\"fieldName\": \"Person\",\"type\": \"HIDDEN\",\"content\": true,\"versionLastUpdated\": null,\"propName\": \"person\"},{\"fieldName\": \"Haulier\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"haulier\"},{\"fieldName\": \"Movement\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"movement\"},{\"fieldName\": \"Booking\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"booking\"},{\"fieldName\": \"Organisation\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"organisation\"},{\"fieldName\": \"Score\",\"type\": \"HIDDEN\",\"content\": 30,\"versionLastUpdated\": null,\"propName\": \"score\"},{\"fieldName\": \"Valid from\",\"type\": \"HIDDEN\",\"content\": \"2021-06-03T00:00:01.000Z\",\"versionLastUpdated\": null,\"propName\": \"validfrom\"},{\"fieldName\": \"Valid to\",\"type\": \"HIDDEN\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"validto\"},{\"fieldName\": \"Updated by\",\"type\": \"HIDDEN\",\"content\": \"Mohammed Abdul Odud\",\"versionLastUpdated\": null,\"propName\": \"updatedby\"}],\"type\": \"null\",\"propName\": \"\"},{\"fieldSetName\": \"\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"First time through this UK port (Trailer)\",\"versionLastUpdated\": null,\"propName\": \"userfacingtext\"},{\"fieldName\": \"ID\",\"type\": \"HIDDEN\",\"content\": 16,\"versionLastUpdated\": null,\"propName\": \"id\"},{\"fieldName\": \"Feature name\",\"type\": \"HIDDEN\",\"content\": \"FIRST-TIME-TRAILER-THIS-PORT\",\"versionLastUpdated\": null,\"propName\": \"featurename\"},{\"fieldName\": \"Vehicle\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"vehicle\"},{\"fieldName\": \"Driver\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"driver\"},{\"fieldName\": \"Person\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"person\"},{\"fieldName\": \"Haulier\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"haulier\"},{\"fieldName\": \"Movement\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"movement\"},{\"fieldName\": \"Booking\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"booking\"},{\"fieldName\": \"Organisation\",\"type\": \"HIDDEN\",\"content\": false,\"versionLastUpdated\": null,\"propName\": \"organisation\"},{\"fieldName\": \"Score\",\"type\": \"HIDDEN\",\"content\": 30,\"versionLastUpdated\": null,\"propName\": \"score\"},{\"fieldName\": \"Valid from\",\"type\": \"HIDDEN\",\"content\": \"2021-06-03T00:00:01.000Z\",\"versionLastUpdated\": null,\"propName\": \"validfrom\"},{\"fieldName\": \"Valid to\",\"type\": \"HIDDEN\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"validto\"},{\"fieldName\": \"Updated by\",\"type\": \"HIDDEN\",\"content\": \"Mohammed Abdul Odud\",\"versionLastUpdated\": null,\"propName\": \"updatedby\"}],\"type\": \"null\",\"propName\": \"\"}],\"type\": \"STANDARD\",\"propName\": \"targetingIndicators\"},{\"fieldSetName\": \"Rules matched\",\"hasChildSet\": true,\"contents\": [],\"childSets\": [{\"fieldSetName\": \"\",\"hasChildSet\": false,\"contents\": [{\"fieldName\": \"Name\",\"type\": \"STRING\",\"content\": \"Scenario 1 Rule\",\"versionLastUpdated\": null,\"propName\": \"name\"},{\"fieldName\": \"Priority\",\"type\": \"STRING\",\"content\": \"Tier 1\",\"versionLastUpdated\": null,\"propName\": \"rulePriority\"},{\"fieldName\": \"Version\",\"type\": \"STRING\",\"content\": 1,\"versionLastUpdated\": null,\"propName\": \"ruleVersion\"},{\"fieldName\": \"Abuse type\",\"type\": \"STRING\",\"content\": \"Class A Drugs\",\"versionLastUpdated\": null,\"propName\": \"abuseType\"},{\"fieldName\": \"Agency\",\"type\": \"STRING\",\"content\": null,\"versionLastUpdated\": null,\"propName\": \"agencyCode\"},{\"fieldName\": \"Description\",\"type\": \"STRING\",\"content\": \"COP Scenario 1\",\"versionLastUpdated\": null,\"propName\": \"description\"},{\"fieldName\": \"Rule ID\",\"type\": \"HIDDEN\",\"content\": 191,\"versionLastUpdated\": null,\"propName\": \"ruleId\"}],\"type\": \"null\",\"propName\": \"\"}],\"type\": \"STANDARD\",\"propName\": \"rules\"},{\"fieldSetName\": \"0 selector matches\",\"hasChildSet\": true,\"contents\": [],\"childSets\": [],\"type\": \"STANDARD\",\"propName\": \"selectors\"}]]",
-    "name": "taskDetails"
-  },
-  {
-    "type": "String",
-    "value": "MOVEMENT_ID",
-    "name": "movementId"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "taskSummary"
-  },
-  {
-    "type": "String",
-    "value": "Issued",
-    "name": "processState"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "serviceMovementHistory"
-  },
-  {
-    "type": "Json",
-    "value": "{\"movement\":{\"mode\":\"RORO Unaccompanied Freight\"}}",
-    "name": "serviceMovement"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "selectorHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "ruleHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "voyageHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "orgHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "personHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "addressHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "contactHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "vehicleHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "vesselHistory"
-  },
-  {
-    "type": "Json",
-    "value": "[[]]",
-    "name": "documentHistory"
-  },
-  {
-    "type": "Integer",
-    "value": 1,
-    "name": "version"
-  },
-  {
-    "type": "Json",
-    "value": "[{\"note\":\"Target received\",\"timeStamp\":1619171257457,\"userId\":\"Cerberus - Rules Based Targetting\"}]",
-    "name": "notes"
-  },
-  {
-    "type": "Json",
-    "value": "{\"hasBusinessKey\":true,\"mode\":\"\",\"category\":\"target_B\",\"eventPort\":\"\",\"roro\":{\"roroFreightType\":\"unaccompanied\",\"details\":{\"vessel\":{\"name\":\"VALENTINE\",\"company\":\"COBELFRET FERRIES NV\"},\"vehicle\":{\"registrationNationality\":\"\",\"trailer\":{\"type\":\"\",\"registrationNationality\":\"\",\"regNumber\":\"\"},\"registrationNumber\":\"fg3478\",\"make\":\"\",\"colour\":\"\",\"model\":\"\"},\"load\":{\"countryOfDestination\":\"\",\"manifestedLoad\":\"car parts\"},\"account\":{\"name\":\"IF Logistics\",\"number\":\"IF-123482\"},\"haulier\":{\"name\":\"\",\"address\":\"\",\"country\":\"\"},\"passengers\":[],\"eta\":null,\"departureTime\":1596636000000}},\"threatIndicators\":[\"National Security at the Border\"]}",
-    "name": "FORM"
-  },
-  {
-    "type": "Json",
-    "value": "{\"parentBusinessKey\":{\"businessKey\":\"ghi\"},\"roro\":{\"details\":{\"vessel\":{},\"vehicle\":{\"trailer\":{}},\"load\":{},\"account\":{},\"passengers\":[{}],\"haulier\":{\"address\":{}}}}}",
-    "name": "taskSummaryBasedOnTIS"
-  }
+[{
+        "type": "Json",
+        "value": "[[]]",
+        "name": "cerberusPayload"
+    },
+    {
+        "type": "Json",
+        "value": "[[{\"fieldSetName\":\"Vehicledetails\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Vehicleregistration\",\"type\":\"STRING\",\"content\":\"COP1\",\"versionLastUpdated\":null,\"propName\":\"registrationNumber\"},{\"fieldName\":\"Type\",\"type\":\"STRING\",\"content\":\"HGV\",\"versionLastUpdated\":null,\"propName\":\"type\"},{\"fieldName\":\"Make\",\"type\":\"STRING\",\"content\":\"Model-xyz\",\"versionLastUpdated\":null,\"propName\":\"make\"},{\"fieldName\":\"Model\",\"type\":\"STRING\",\"content\":\"Make-123\",\"versionLastUpdated\":null,\"propName\":\"model\"},{\"fieldName\":\"Countryofregistration\",\"type\":\"STRING\",\"content\":\"GB\",\"versionLastUpdated\":null,\"propName\":\"registrationNationality\"},{\"fieldName\":\"Colour\",\"type\":\"STRING\",\"content\":\"Colour-White\",\"versionLastUpdated\":null,\"propName\":\"colour\"},{\"fieldName\":\"Netweight\",\"type\":\"WEIGHT\",\"content\":\"3455\",\"versionLastUpdated\":null,\"propName\":\"netWeight\"},{\"fieldName\":\"Grossweight\",\"type\":\"WEIGHT\",\"content\":\"43623\",\"versionLastUpdated\":null,\"propName\":\"grossWeight\"},{\"fieldName\":\"Trailerregistrationnumber\",\"type\":\"STRING\",\"content\":\"NL-234-392\",\"versionLastUpdated\":null,\"propName\":\"trailerRegistrationNumber\"},{\"fieldName\":\"Trailertype\",\"type\":\"STRING\",\"content\":\"TR\",\"versionLastUpdated\":null,\"propName\":\"trailerType\"},{\"fieldName\":\"Trailercountryofregistration\",\"type\":\"STRING\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"trailerRegistrationNationality\"},{\"fieldName\":\"Emptyorloaded\",\"type\":\"STRING\",\"content\":\"Loaded\",\"versionLastUpdated\":null,\"propName\":\"trailerEmptyOrLoaded\"},{\"fieldName\":\"Trailerlength\",\"type\":\"DISTANCE\",\"content\":\"36\",\"versionLastUpdated\":null,\"propName\":\"trailerLength\"},{\"fieldName\":\"Trailerheight\",\"type\":\"DISTANCE\",\"content\":\"3.6\",\"versionLastUpdated\":null,\"propName\":\"trailerHeight\"}],\"type\":\"null\",\"propName\":\"vehicle\"},{\"fieldSetName\":\"Haulierdetails\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Name\",\"type\":\"STRING\",\"content\":\"Matthesons\",\"versionLastUpdated\":null,\"propName\":\"name\"},{\"fieldName\":\"Address\",\"type\":\"STRING\",\"content\":\"Unit9-12PinkertonWayBognorRegisKJFSG094GB\",\"versionLastUpdated\":null,\"propName\":\"address\"},{\"fieldName\":\"Telephone\",\"type\":\"TELEPHONE\",\"content\":\"01243785239\",\"versionLastUpdated\":null,\"propName\":\"telephone\"},{\"fieldName\":\"Mobile\",\"type\":\"TELEPHONE\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"mobile\"},{\"fieldName\":\"Addressline1\",\"type\":\"HIDDEN\",\"content\":\"Unit9-12PinkertonWay\",\"versionLastUpdated\":null,\"propName\":\"addressLine1\"},{\"fieldName\":\"Addressline2\",\"type\":\"HIDDEN\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"addressLine2\"},{\"fieldName\":\"City\",\"type\":\"HIDDEN\",\"content\":\"BognorRegis\",\"versionLastUpdated\":null,\"propName\":\"city\"},{\"fieldName\":\"Postcode\",\"type\":\"HIDDEN\",\"content\":\"KJFSG094\",\"versionLastUpdated\":null,\"propName\":\"postcode\"},{\"fieldName\":\"Country\",\"type\":\"HIDDEN\",\"content\":\"GB\",\"versionLastUpdated\":null,\"propName\":\"country\"}],\"type\":\"null\",\"propName\":\"haulier\"},{\"fieldSetName\":\"Accountdetails\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Fullname\",\"type\":\"STRING\",\"content\":\"UniveralPrintersLtd\",\"versionLastUpdated\":null,\"propName\":\"name\"},{\"fieldName\":\"Shortname\",\"type\":\"STRING\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"shortName\"},{\"fieldName\":\"Referencenumber\",\"type\":\"STRING\",\"content\":\"PO000359675\",\"versionLastUpdated\":null,\"propName\":\"referenceNumber\"},{\"fieldName\":\"Address\",\"type\":\"STRING\",\"content\":\"Unit9-12PinkertonWayBognorRegisKJFSG094GB\",\"versionLastUpdated\":null,\"propName\":\"address\"},{\"fieldName\":\"Telephone\",\"type\":\"TELEPHONE\",\"content\":\"01243785239\",\"versionLastUpdated\":null,\"propName\":\"telephone\"},{\"fieldName\":\"Mobile\",\"type\":\"TELEPHONE\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"mobile\"},{\"fieldName\":\"Email\",\"type\":\"EMAIL\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"email\"}],\"type\":\"null\",\"propName\":\"account\"},{\"fieldSetName\":\"Driver\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Name\",\"type\":\"STRING\",\"content\":\"BenBailey\",\"versionLastUpdated\":null,\"propName\":\"name\"},{\"fieldName\":\"Dateofbirth\",\"type\":\"SHORT_DATE\",\"content\":-66,\"versionLastUpdated\":null,\"propName\":\"dob\"},{\"fieldName\":\"Gender\",\"type\":\"STRING\",\"content\":\"M\",\"versionLastUpdated\":null,\"propName\":\"gender\"},{\"fieldName\":\"Nationality\",\"type\":\"STRING\",\"content\":\"GB\",\"versionLastUpdated\":null,\"propName\":\"nationality\"},{\"fieldName\":\"Traveldocumenttype\",\"type\":\"STRING\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"docType\"},{\"fieldName\":\"Traveldocumentnumber\",\"type\":\"STRING\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"docNumber\"},{\"fieldName\":\"Traveldocumentexpiry\",\"type\":\"SHORT_DATE\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"docExpiry\"},{\"fieldName\":\"PoleID\",\"type\":\"HIDDEN\",\"content\":\"ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58c\",\"versionLastUpdated\":null,\"propName\":\"poleId\"},{\"fieldName\":\"Firstname\",\"type\":\"HIDDEN\",\"content\":\"Ben\",\"versionLastUpdated\":null,\"propName\":\"firstName\"},{\"fieldName\":\"Lastname\",\"type\":\"HIDDEN\",\"content\":\"Bailey\",\"versionLastUpdated\":null,\"propName\":\"lastName\"},{\"fieldName\":\"Middlename\",\"type\":\"HIDDEN\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"middleName\"}],\"type\":\"null\",\"propName\":\"driver\"},{\"fieldSetName\":\"Passengers\",\"hasChildSet\":true,\"contents\":[],\"childSets\":[{\"fieldSetName\":\"\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Name\",\"type\":\"STRING\",\"content\":\"BobBrown\",\"versionLastUpdated\":null,\"propName\":\"name\"},{\"fieldName\":\"Dateofbirth\",\"type\":\"SHORT_DATE\",\"content\":435,\"versionLastUpdated\":null,\"propName\":\"dob\"},{\"fieldName\":\"Gender\",\"type\":\"STRING\",\"content\":\"M\",\"versionLastUpdated\":null,\"propName\":\"gender\"},{\"fieldName\":\"Nationality\",\"type\":\"STRING\",\"content\":\"IR\",\"versionLastUpdated\":null,\"propName\":\"nationality\"},{\"fieldName\":\"Traveldocumenttype\",\"type\":\"STRING\",\"content\":\"OBJDOCPAS\",\"versionLastUpdated\":null,\"propName\":\"docType\"},{\"fieldName\":\"Traveldocumentnumber\",\"type\":\"STRING\",\"content\":\"ST678457\",\"versionLastUpdated\":null,\"propName\":\"docNumber\"},{\"fieldName\":\"Traveldocumentexpiry\",\"type\":\"SHORT_DATE\",\"content\":18659,\"versionLastUpdated\":null,\"propName\":\"docExpiry\"},{\"fieldName\":\"PoleID\",\"type\":\"HIDDEN\",\"content\":\"ROROXML:P=8049bc0c58748004ad81925020b26ce3\",\"versionLastUpdated\":null,\"propName\":\"poleId\"},{\"fieldName\":\"Firstname\",\"type\":\"HIDDEN\",\"content\":\"Bob\",\"versionLastUpdated\":null,\"propName\":\"firstName\"},{\"fieldName\":\"Lastname\",\"type\":\"HIDDEN\",\"content\":\"Brown\",\"versionLastUpdated\":null,\"propName\":\"lastName\"},{\"fieldName\":\"Middlename\",\"type\":\"HIDDEN\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"middleName\"}],\"type\":\"null\",\"propName\":\"\"}],\"type\":\"STANDARD\",\"propName\":\"passengers\"},{\"fieldSetName\":\"Goods\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Description\",\"type\":\"STRING\",\"content\":\"PrintedPaper\",\"versionLastUpdated\":null,\"propName\":\"description\"},{\"fieldName\":\"Iscargohazardous?\",\"type\":\"STRING\",\"content\":\"No\",\"versionLastUpdated\":null,\"propName\":\"isHazardous\"},{\"fieldName\":\"Weightofgoods\",\"type\":\"WEIGHT\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"weight\"}],\"type\":\"null\",\"propName\":\"goods\"},{\"fieldSetName\":\"Bookingandcheck-in\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Reference\",\"type\":\"STRING\",\"content\":\"357485636\",\"versionLastUpdated\":null,\"propName\":\"reference\"},{\"fieldName\":\"Ticketnumber\",\"type\":\"STRING\",\"content\":\"DFDS-1000974\",\"versionLastUpdated\":null,\"propName\":\"ticketNumber\"},{\"fieldName\":\"Type\",\"type\":\"STRING\",\"content\":\"Test\",\"versionLastUpdated\":null,\"propName\":\"bookingType\"},{\"fieldName\":\"Name\",\"type\":\"STRING\",\"content\":\"test\",\"versionLastUpdated\":null,\"propName\":\"name\"},{\"fieldName\":\"Address\",\"type\":\"STRING\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"address\"},{\"fieldName\":\"Dateandtime\",\"type\":\"BOOKING_DATETIME\",\"content\":\"2020-08-02T09:15:00,2020-08-04T13:05:00\",\"versionLastUpdated\":null,\"propName\":\"dateBooked\"},{\"fieldName\":\"Country\",\"type\":\"STRING\",\"content\":\"GB\",\"versionLastUpdated\":null,\"propName\":\"country\"},{\"fieldName\":\"Paymentmethod\",\"type\":\"STRING\",\"content\":\"Account\",\"versionLastUpdated\":null,\"propName\":\"paymentMethod\"},{\"fieldName\":\"Ticketprice\",\"type\":\"CURRENCY\",\"content\":\"30quid\",\"versionLastUpdated\":null,\"propName\":\"ticketPrice\"},{\"fieldName\":\"Tickettype\",\"type\":\"STRING\",\"content\":\"Return\",\"versionLastUpdated\":null,\"propName\":\"ticketType\"},{\"fieldName\":\"Check-in\",\"type\":\"DATETIME\",\"content\":\"2020-08-04T12:05:00\",\"versionLastUpdated\":null,\"propName\":\"checkIn\"}],\"type\":\"null\",\"propName\":\"booking\"},{\"fieldSetName\":\"Targetingindicators\",\"hasChildSet\":true,\"contents\":[],\"childSets\":[],\"type\":\"STANDARD\",\"propName\":\"targetingIndicators\"},{\"fieldSetName\":\"Rulesmatched\",\"hasChildSet\":true,\"contents\":[],\"childSets\":[{\"fieldSetName\":\"\",\"hasChildSet\":false,\"contents\":[{\"fieldName\":\"Name\",\"type\":\"STRING\",\"content\":\"Scenario1Rule\",\"versionLastUpdated\":null,\"propName\":\"name\"},{\"fieldName\":\"Priority\",\"type\":\"STRING\",\"content\":\"Tier1\",\"versionLastUpdated\":null,\"propName\":\"rulePriority\"},{\"fieldName\":\"Version\",\"type\":\"STRING\",\"content\":1,\"versionLastUpdated\":null,\"propName\":\"ruleVersion\"},{\"fieldName\":\"Abusetype\",\"type\":\"STRING\",\"content\":\"ClassADrugs\",\"versionLastUpdated\":null,\"propName\":\"abuseType\"},{\"fieldName\":\"Agency\",\"type\":\"STRING\",\"content\":null,\"versionLastUpdated\":null,\"propName\":\"agencyCode\"},{\"fieldName\":\"Description\",\"type\":\"STRING\",\"content\":\"COPScenario1\",\"versionLastUpdated\":null,\"propName\":\"description\"},{\"fieldName\":\"RuleID\",\"type\":\"HIDDEN\",\"content\":191,\"versionLastUpdated\":null,\"propName\":\"ruleId\"}],\"type\":\"null\",\"propName\":\"\"}],\"type\":\"STANDARD\",\"propName\":\"rules\"},{\"fieldSetName\":\"0selectormatches\",\"hasChildSet\":true,\"contents\":[],\"childSets\":[],\"type\":\"STANDARD\",\"propName\":\"selectors\"}]]",
+        "name": "taskDetails"
+    },
+    {
+        "type": "String",
+        "value": "MOVEMENT_ID",
+        "name": "movementId"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "taskSummary"
+    },
+    {
+        "type": "String",
+        "value": "Issued",
+        "name": "processState"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "serviceMovementHistory"
+    },
+    {
+        "type": "Json",
+        "value": "{\"movement\":{\"mode\":\"RORO Unaccompanied Freight\"}}",
+        "name": "serviceMovement"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "selectorHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "ruleHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "voyageHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "orgHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "personHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "addressHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "contactHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "vehicleHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "vesselHistory"
+    },
+    {
+        "type": "Json",
+        "value": "[[]]",
+        "name": "documentHistory"
+    },
+    {
+        "type": "Integer",
+        "value": 1,
+        "name": "version"
+    },
+    {
+        "type": "Json",
+        "value": "[{\"note\":\"Target received\",\"timeStamp\":1619171257457,\"userId\":\"Cerberus - Rules Based Targetting\"}]",
+        "name": "notes"
+    },
+    {
+        "type": "Json",
+        "value": "{\"hasBusinessKey\":true,\"mode\":\"\",\"category\":\"target_B\",\"eventPort\":\"\",\"roro\":{\"roroFreightType\":\"unaccompanied\",\"details\":{\"vessel\":{\"name\":\"VALENTINE\",\"company\":\"COBELFRET FERRIES NV\"},\"vehicle\":{\"registrationNationality\":\"\",\"trailer\":{\"type\":\"\",\"registrationNationality\":\"\",\"regNumber\":\"\"},\"registrationNumber\":\"fg3478\",\"make\":\"\",\"colour\":\"\",\"model\":\"\"},\"load\":{\"countryOfDestination\":\"\",\"manifestedLoad\":\"car parts\"},\"account\":{\"name\":\"IF Logistics\",\"number\":\"IF-123482\"},\"haulier\":{\"name\":\"\",\"address\":\"\",\"country\":\"\"},\"passengers\":[],\"eta\":null,\"departureTime\":1596636000000}},\"threatIndicators\":[\"National Security at the Border\"]}",
+        "name": "FORM"
+    },
+    {
+        "type": "Json",
+        "value": "{\"parentBusinessKey\":{\"businessKey\":\"ghi\"},\"roro\":{\"details\":{\"vessel\":{},\"vehicle\":{\"trailer\":{}},\"load\":{},\"account\":{},\"passengers\":[{}],\"haulier\":{\"address\":{}}}}}",
+        "name": "taskSummaryBasedOnTIS"
+    }
 ]

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -319,4 +319,48 @@ describe('TaskDetailsPage', () => {
 
     expect(screen.queryByText('There is a problem')).toBeInTheDocument();
   });
+
+  it('should render indicators in task versions', async () => {
+    mockTaskDetailsAxiosCalls({
+      processInstanceResponse: [{ id: '123' }],
+      taskResponse: [
+        {
+          processInstanceId: '123',
+          assignee: 'test',
+          id: 'task123',
+          taskDefinitionKey: 'otherType',
+        },
+      ],
+      variableInstanceResponse: variableInstanceStatusComplete,
+      operationsHistoryResponse: operationsHistoryFixture,
+      taskHistoryResponse: taskHistoryFixture,
+      noteFormResponse: { test },
+    });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryAllByText('Indicator')).toHaveLength(1);
+  });
+
+  it('should not render indicators in task versions when none are present', async () => {
+    mockTaskDetailsAxiosCalls({
+      processInstanceResponse: [{ id: '123' }],
+      taskResponse: [
+        {
+          processInstanceId: '123',
+          assignee: 'test',
+          id: 'task123',
+          taskDefinitionKey: 'otherType',
+        },
+      ],
+      variableInstanceResponse: variableInstanceStatusIssued,
+      operationsHistoryResponse: operationsHistoryFixture,
+      taskHistoryResponse: taskHistoryFixture,
+      noteFormResponse: { test },
+    });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryAllByText('Indicator')).toHaveLength(0);
+  });
 });

--- a/src/utils/rickScoreCalculator.jsx
+++ b/src/utils/rickScoreCalculator.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const calculateTaskVersionTotalRiskScore = (fieldChildsets) => {
+  let totalRiskScore = 0;
+  fieldChildsets.map((childSet) => {
+    let targetingIndicator = childSet.contents.filter(({ propName }) => propName === 'score');
+    if (targetingIndicator.length > 0) {
+      totalRiskScore += targetingIndicator[0]?.content || 0;
+    }
+  });
+  return totalRiskScore;
+};
+
+const calculateTaskListTotalRiskScore = (target) => {
+  let totalRiskScore = 0;
+  if (target.threatIndicators?.length > 0) {
+    target.threatIndicators.map((threatIndicatorScore) => {
+      totalRiskScore += threatIndicatorScore?.score || 0;
+    });
+  }
+  return (
+    totalRiskScore > 0 ? <span className="govuk-!-font-weight-bold">Risk Score: {totalRiskScore}</span> : <span>Risk Score: 0</span>
+  );
+};
+
+export { calculateTaskVersionTotalRiskScore, calculateTaskListTotalRiskScore };


### PR DESCRIPTION
## Description
This PR restructures the Targeting Indicators layout in task details.
JIRA Ticker: https://support.cop.homeoffice.gov.uk/browse/COP-9286

## To Test
- Pull & run against dev
- Confirm that new layout against old layout

> **New layout**
![Targeting Indicators - New Layout](https://user-images.githubusercontent.com/19333750/145439343-bc5d109c-c38e-4d73-88ac-5e7e88c47aa7.png)

vs.

 > **Old layout**
![Targeting Indicators - Old Layout](https://user-images.githubusercontent.com/19333750/145439591-d68bbf33-43b6-4b2a-8663-40d0a33415a8.png)


> Due to the tight coupling of the task details page layout, The new layout will nto exactly match that of the prototype suplied in the Jira ticket [https://support.cop.homeoffice.gov.uk/browse/COP-9286](url).

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
