### PR TITLE
COP-9367 API Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker run --name cerberus-service -p 8080:8080 \
   --env KEYCLOAK_REALM=cop-local \
   --env FORM_API_URL=https://form-api-server.dev.cop.homeoffice.gov.uk \
   --env REFDATA_API_URL=https://api.dev.refdata.homeoffice.gov.uk \
-  --env CERBERUS_API_URL=https://workflow-service.dev.cerberus.cop.homeoffice.gov.uk/camunda/engine-rest/ \
+  --env CERBERUS_API_URL=https://workflow-service.dev.cerberus.cop.homeoffice.gov.uk/camunda/ \
   cerberus-service
 ```
 

--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -88,7 +88,7 @@ spec:
           - name: REFDATA_API_URL
             value: "https://{{.REFDATA_API_URL}}"
           - name: CERBERUS_API_URL
-            value: "https://{{.CERBERUS_WORKFLOW_SERVICE_URL}}/camunda/engine-rest/"
+            value: "https://{{.CERBERUS_WORKFLOW_SERVICE_URL}}/camunda/"
       volumes:
       - name: certs
         secret:

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,8 @@ const config = {
   },
   refdataApiUrl: process.env.REFDATA_API_URL,
   formApiUrl: process.env.FORM_API_URL,
-  camundaApiUrl: '/camunda',
+  camundaApiUrl: '/camunda/engine-rest',
+  camundaApiUrlV1: '/camunda/v1',
   dayjsConfig: {
     relativeTime: {
       future: '%s before travel',

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -563,7 +563,6 @@ const TaskListPage = () => {
                       </legend>
                       <ul className={`govuk-${filterSet.filterClassPrefix} govuk-${filterSet.filterClassPrefix}--small`}>
                         {filterSet.filterOptions.map((option) => {
-                          console.log(option)
                           let checked = !!((storedFilters && !!storedFilters.find((filter) => filter === option.optionName)));
                           return (
                             <li

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -66,51 +66,47 @@ const targetStatusConfig = (filtersToApply) => {
 
 const filterListConfig = [
   {
-    filterName: 'Mode',
-    filterType: 'radio',
-    filterClassPrefix: 'radios',
+    filterName: 'movementModes',
+    filterType: 'checkbox',
+    filterClassPrefix: 'checkboxes',
+    filterLabel: 'Modes',
     filterOptions: [
       {
-        name: 'roro-unaccompanied-freight',
-        code: 'movementMode_eq_roro-unaccompanied-freight',
-        label: 'RoRo unaccompanied freight',
+        optionName: 'RORO_UNACCOMPANIED_FREIGHT',
+        optionLabel: 'RoRo unaccompanied freight',
         checked: false,
       },
       {
-        name: 'roro-accompanied-freight',
-        code: 'movementMode_eq_roro-accompanied-freight',
-        label: 'RoRo accompanied freight',
+        optionName: 'RORO_ACCOMPANIED_FREIGHT',
+        optionLabel: 'RoRo accompanied freight',
         checked: false,
       },
       {
-        name: 'roro-tourist',
-        code: 'movementMode_eq_roro-tourist',
-        label: 'RoRo tourist',
+        optionName: 'RORO_TOURIST',
+        optionLabel: 'RoRo Tourist',
         checked: false,
       },
     ],
   },
   {
-    filterName: 'Selectors',
+    filterName: 'hasSelectors',
     filterType: 'radio',
     filterClassPrefix: 'radios',
+    filterLabel: 'Selectors',
     filterOptions: [
       {
-        name: 'has-no-selector',
-        code: 'hasSelectors_eq_no',
-        label: 'Not present',
+        optionName: 'true',
+        optionLabel: 'Present',
         checked: false,
       },
       {
-        name: 'has-selector',
-        code: 'hasSelectors_eq_yes',
-        label: 'Present',
+        optionName: 'false',
+        optionLabel: 'Not present',
         checked: false,
       },
       {
-        name: 'both',
-        code: 'noCode', // as 'both' is all tasks we return a word we can set to null in the call
-        label: 'Any',
+        optionName: 'any',
+        optionLabel: 'Any',
         checked: false,
       },
     ],

--- a/src/routes/__fixtures__/taskListData.fixture.json
+++ b/src/routes/__fixtures__/taskListData.fixture.json
@@ -1,0 +1,207 @@
+[
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "",
+    "status": "NEW",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "business:key=a_b_c"
+      },
+      "threatIndicators": [
+        {
+          "userfacingtext": "Paid by cash",
+          "score": 21
+        },
+        {
+          "userfacingtext": "Late booking tourist (24-72 hours)",
+          "score": 4
+        }
+      ],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [
+        {
+          "contents": {
+            "category": "B",
+            "groupReference": "Local ref",
+            "threatType": "National Security at the Border",
+            "selectorId": 6
+          },
+          "childSets": []
+        },
+        {
+          "name": "Paid by Cash",
+          "rulePriority": "Tier 1",
+          "ruleVersion": 1,
+          "abuseType": "National Security at the Border",
+          "agencyCode": "",
+          "description": "Test",
+          "ruleId": 293
+        },
+        {
+          "name": "Paid by cash1",
+          "rulePriority": "Tier 1",
+          "ruleVersion": 1,
+          "abuseType": "Class A Drugs",
+          "agencyCode": "",
+          "description": "Paid by cash",
+          "ruleId": 346
+        }
+      ],
+      "numberOfVersions": 2,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  },
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "test",
+    "status": "IN_PROGRESS",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "business:key=d_e_f"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  },
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "test",
+    "status": "ISSUED",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "ghi"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  },
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "status": "COMPLETE",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "jkl"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  },
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "status": "NEW",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "business:key=m_n_o"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [
+        {
+          "name": "Paid by Cash",
+          "rulePriority": "Tier 1",
+          "ruleVersion": 1,
+          "abuseType": "Class A Drugs",
+          "agencyCode": "",
+          "description": "Test",
+          "ruleId": 293
+        }
+      ],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  }
+]

--- a/src/routes/__fixtures__/taskListData_COMPLETE.fixture.json
+++ b/src/routes/__fixtures__/taskListData_COMPLETE.fixture.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "status": "COMPLETE",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "jkl"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  }
+]

--- a/src/routes/__fixtures__/taskListData_IN_PROGRESS.fixture.json
+++ b/src/routes/__fixtures__/taskListData_IN_PROGRESS.fixture.json
@@ -1,0 +1,129 @@
+[
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "test",
+    "status": "IN_PROGRESS",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "business:key=d_e_f"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  },
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "test",
+    "status": "IN_PROGRESS",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "business:key=d_e_f123"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  },
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "test",
+    "status": "IN_PROGRESS",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "business:key=d_e_f234"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  },{
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "anotheruser",
+    "status": "IN_PROGRESS",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "business:key=d_e_f456"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  }
+]

--- a/src/routes/__fixtures__/taskListData_ISSUED.fixture.json
+++ b/src/routes/__fixtures__/taskListData_ISSUED.fixture.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "31af5396-5bfd-11ec-b723-66e520b0c21b",
+    "assignee": "test",
+    "status": "ISSUED",
+    "arrivalDate": "2022-01-02T10:12:35Z",
+    "movementMode": "RORO_TOURIST",
+    "summary": {
+      "parentBusinessKey": {
+        "businessKey": "ghi"
+      },
+      "threatIndicators": [],
+      "category": "target_B",
+      "eventPort": "",
+      "risks": [],
+      "numberOfVersions": 1,
+      "roro": {
+        "roroFreightType": "unaccompanied",
+        "details": {
+          "movementStatus": "Pre-Arrival",
+          "bookingDateTime": "2020-08-03T11:25:00,2020-08-04T20:00:00",
+          "vessel": {},
+          "eta": "2022-01-02T10:12:35Z",
+          "departureTime": "2020-08-04T20:00:00Z",
+          "arrivalLocation": "POO",
+          "departureLocation": "NEW",
+          "vehicle": {},
+          "load": {},
+          "account": {}
+        }
+      }
+    }
+  }
+]

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -4,24 +4,40 @@ import MockAdapter from 'axios-mock-adapter';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '../../__mocks__/keycloakMock';
 import TaskListPage from '../TaskLists/TaskListPage';
-import variableInstanceTaskSummaryBasedOnTIS from '../__fixtures__/variableInstanceTaskSummaryBasedOnTIS.fixture.json';
+import taskListData from '../__fixtures__/taskListData.fixture.json';
+import taskListDataComplete from '../__fixtures__/taskListData_COMPLETE.fixture.json';
+import taskListDataInProgress from '../__fixtures__/taskListData_IN_PROGRESS.fixture.json';
+import taskListDataIssued from '../__fixtures__/taskListData_ISSUED.fixture.json';
 import { TaskSelectedTabContext } from '../../context/TaskSelectedTabContext';
 
 describe('TaskListPage', () => {
   const mockAxios = new MockAdapter(axios);
   const envUrl = `${window.location.protocol}//${window.location.hostname}`;
-  const tabData = {
-    selectedTabIndex: 1,
-    selectTabIndex: jest.fn(),
+  const countResponse = {
+    filterParams: {
+      movementModes: [],
+      hasSelectors: null,
+    },
+    statusCounts: {
+      inProgress: 37,
+      issued: 15,
+      complete: 19,
+      new: 76,
+    },
   };
+  let tabData = {};
 
-  const setTabAndTaskValues = (value = tabData, taskStatus = 'new') => {
+  const setTabAndTaskValues = (value, taskStatus = 'new') => {
     return (<TaskSelectedTabContext.Provider value={value}><TaskListPage taskStatus={taskStatus} setError={() => { }} /></TaskSelectedTabContext.Provider>);
   };
 
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => { });
     mockAxios.reset();
+    tabData = {
+      selectedTabIndex: 0,
+      selectTabIndex: jest.fn(),
+    };
   });
 
   it('should render loading spinner on component load', async () => {
@@ -31,47 +47,38 @@ describe('TaskListPage', () => {
 
   it('should render counts in tab name', async () => {
     mockAxios
-      .onGet('/task')
-      .reply(200, [])
-      .onGet('/task/count')
-      .reply(200, { count: 7 })
-      .onGet('/process-instance')
-      .reply(200, [])
-      .onGet('/process-instance/count')
-      .reply(200, { count: 5 })
-      .onGet('/variable-instance')
-      .reply(200, [])
-      .onGet('/history/process-instance')
-      .reply(200, [])
-      .onGet('/history/process-instance/count')
-      .reply(200, { count: 0 })
-      .onGet('/history/variable-instance')
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
       .reply(200, []);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
-    expect(screen.getByText('New (7)')).toBeInTheDocument();
-    expect(screen.getByText('Issued (5)')).toBeInTheDocument();
+    expect(screen.getByText('New (76)')).toBeInTheDocument();
+    expect(screen.getByText('In progress (37)')).toBeInTheDocument();
+    expect(screen.getByText('Issued (15)')).toBeInTheDocument();
+    expect(screen.getByText('Complete (19)')).toBeInTheDocument();
   });
 
   it('should render no tasks available message when New, In Progress, Target Issued and Complete tabs are clicked and there are no tasks', async () => {
     mockAxios
-      .onGet('/task')
-      .reply(200, [])
-      .onGet('/task/count')
-      .reply(200, { count: 0 })
-      .onGet('/process-instance')
-      .reply(200, [])
-      .onGet('/process-instance/count')
-      .reply(200, { count: 0 })
-      .onGet('/variable-instance')
-      .reply(200, [])
-      .onGet('/history/process-instance')
-      .reply(200, [])
-      .onGet('/history/process-instance/count')
-      .reply(200, { count: 0 })
-      .onGet('/history/variable-instance')
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [
+        {
+          filterParams: {
+            movementModes: [],
+            hasSelectors: null,
+          },
+          statusCounts: {
+            inProgress: 0,
+            issued: 0,
+            complete: 0,
+            new: 0,
+          },
+        },
+      ])
+      .onPost('/targeting-tasks/pages')
       .reply(200, []);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
@@ -102,122 +109,90 @@ describe('TaskListPage', () => {
 
   it('should render each "View details" link per task', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 0 })
-      .onGet('/task')
-      .reply(200, [{}])
-      .onGet('/process-instance/count')
-      .reply(200, { count: 10 })
-      .onGet('/process-instance')
-      .reply(200, [
-        { id: '123' },
-        { id: '456' },
-        { id: '789' },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListData);
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues({ selectedTabIndex: 0, selectTabIndex: jest.fn() }, 'new')));
 
     await waitFor(() => expect(screen.getAllByText('View details')[0].href).toBe(`${envUrl}/tasks/business:key=a_b_c`));
     await waitFor(() => expect(screen.getAllByText('View details')[1].href).toBe(`${envUrl}/tasks/business:key=d_e_f`));
     await waitFor(() => expect(screen.getAllByText('View details')[2].href).toBe(`${envUrl}/tasks/ghi`));
-
-    fireEvent.click(screen.getByRole('link', { name: /Issued/i }));
-    await waitFor(() => expect(screen.getAllByText('View details')[0].href).toBe(`${envUrl}/tasks/business:key=a_b_c`));
-    await waitFor(() => expect(screen.getAllByText('View details')[1].href).toBe(`${envUrl}/tasks/business:key=d_e_f`));
-    await waitFor(() => expect(screen.getAllByText('View details')[2].href).toBe(`${envUrl}/tasks/ghi`));
-
-    fireEvent.click(screen.getByRole('link', { name: /In progress/i }));
-    await waitFor(() => expect(screen.getAllByText('View details')[0].href).toBe(`${envUrl}/tasks/business:key=a_b_c`));
-    await waitFor(() => expect(screen.getAllByText('View details')[1].href).toBe(`${envUrl}/tasks/business:key=d_e_f`));
-    await waitFor(() => expect(screen.getAllByText('View details')[2].href).toBe(`${envUrl}/tasks/ghi`));
+    await waitFor(() => expect(screen.getAllByText('View details')[3].href).toBe(`${envUrl}/tasks/jkl`));
+    await waitFor(() => expect(screen.getAllByText('View details')[4].href).toBe(`${envUrl}/tasks/business:key=m_n_o`));
   });
 
-  it('should render links to tasks when completed tasks exists', async () => {
+  it('should render each "View details" link per task for In Progress tab', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 0 })
-      .onGet('/task')
-      .reply(200, [{}])
-      .onGet('/variable-instance')
-      .reply(200, [{}])
-      .onGet('/history/process-instance/count')
-      .reply(200, { count: 10 })
-      .onGet('/history/process-instance')
-      .reply(200, [
-        { id: '123' },
-        { id: '456' },
-        { id: '789' },
-      ])
-      .onGet('/history/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListDataInProgress);
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues({ selectedTabIndex: 1, selectTabIndex: jest.fn() }, 'inProgress')));
+    await waitFor(() => expect(screen.getAllByText('View details')[0].href).toBe(`${envUrl}/tasks/business:key=d_e_f`));
+    await waitFor(() => expect(screen.getAllByText('View details')[1].href).toBe(`${envUrl}/tasks/business:key=d_e_f123`));
+    await waitFor(() => expect(screen.getAllByText('View details')[2].href).toBe(`${envUrl}/tasks/business:key=d_e_f234`));
+  });
 
-    fireEvent.click(screen.getByRole('link', { name: /Complete/i }));
-    await waitFor(() => expect(screen.getAllByText('View details')[0].href).toBe(`${envUrl}/tasks/business:key=a_b_c`));
-    await waitFor(() => expect(screen.getAllByText('View details')[1].href).toBe(`${envUrl}/tasks/business:key=d_e_f`));
-    await waitFor(() => expect(screen.getAllByText('View details')[2].href).toBe(`${envUrl}/tasks/ghi`));
+  it('should render each "View details" link per task for Issued tab', async () => {
+    mockAxios
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListDataIssued);
+
+    await waitFor(() => render(setTabAndTaskValues({ selectedTabIndex: 2, selectTabIndex: jest.fn() }, 'issued')));
+    await waitFor(() => expect(screen.getAllByText('View details')[0].href).toBe(`${envUrl}/tasks/ghi`));
+  });
+
+  it('should render each "View details" link per task for Completed tab', async () => {
+    mockAxios
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListDataComplete);
+
+    await waitFor(() => render(setTabAndTaskValues({ selectedTabIndex: 3, selectTabIndex: jest.fn() }, 'completed')));
+    await waitFor(() => expect(screen.getAllByText('View details')[0].href).toBe(`${envUrl}/tasks/jkl`));
   });
 
   it('should render new tasks on page load with a Claim button', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 10 })
-      .onGet('/task')
-      .reply(200, [
-        { processInstanceId: '123', assignee: null },
-        { processInstanceId: '456', assignee: null },
-        { processInstanceId: '789', assignee: null },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListData);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
-
     expect(screen.getAllByText('Claim')).toHaveLength(3);
   });
 
   it('should render tasks assigned to the current user with an Unclaim button', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 10 })
-      .onGet('/task')
-      .reply(200, [
-        { processInstanceId: '123', assignee: 'test' },
-        { processInstanceId: '456', assignee: 'another-user' },
-        { processInstanceId: '789', assignee: 'another-user' },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListDataInProgress);
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues({ selectedTabIndex: 1, selectTabIndex: jest.fn() }, 'inProgress')));
 
     fireEvent.click(screen.getByRole('link', { name: /In progress/i }));
 
-    await waitFor(() => expect(screen.getAllByText('Unclaim')).toHaveLength(1));
+    await waitFor(() => expect(screen.getAllByText('Unclaim')).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText('Assigned to anotheruser')).toHaveLength(1));
     await waitFor(() => expect(screen.queryByText('Claim')).not.toBeInTheDocument());
   });
 
   it('should render issued tasks with no claim buttons', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 0 })
-      .onGet('/task')
-      .reply(200, [{}])
-      .onGet('/process-instance/count')
-      .reply(200, { count: 10 })
-      .onGet('/process-instance')
-      .reply(200, [
-        { id: '123' },
-        { id: '456' },
-        { id: '789' },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListDataIssued);
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues({ selectedTabIndex: 2, selectTabIndex: jest.fn() }, 'issued')));
 
     fireEvent.click(screen.getByRole('link', { name: /Issued/i }));
 
@@ -227,22 +202,12 @@ describe('TaskListPage', () => {
 
   it('should render complete tasks with no claim buttons', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 0 })
-      .onGet('/task')
-      .reply(200, [{}])
-      .onGet('/history/process-instance/count')
-      .reply(200, { count: 10 })
-      .onGet('/history/process-instance')
-      .reply(200, [
-        { id: '123' },
-        { id: '456' },
-        { id: '789' },
-      ])
-      .onGet('/history/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListDataComplete);
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues({ selectedTabIndex: 3, selectTabIndex: jest.fn() }, 'complete')));
 
     fireEvent.click(screen.getByRole('link', { name: /Complete/i }));
 
@@ -252,35 +217,31 @@ describe('TaskListPage', () => {
 
   it('should display the first risk and a count of risks & handle empty arrays', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 10 })
-      .onGet('/task')
-      .reply(200, [
-        { processInstanceId: '123', assignee: null },
-        { processInstanceId: '456', assignee: null },
-        { processInstanceId: '789', assignee: null },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages',
+        { status: 'NEW',
+          filterParams: {},
+          sortParams: [{ field: 'arrival-date', order: 'desc' }],
+          pageParams: { limit: 100, offset: 0 } })
+      .reply(200, taskListData);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.getAllByText('SELECTOR: Local ref, B, National Security at the Border and 2 other rules')).toHaveLength(1);
-    expect(screen.getAllByText('Rulename, Tier 1, Class A Drugs and 0 other rules')).toHaveLength(1);
+    expect(screen.getAllByText('Paid by Cash, Tier 1, Class A Drugs and 0 other rules')).toHaveLength(1);
   });
 
   it('should display a count and list of targeting indicators', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 10 })
-      .onGet('/task')
-      .reply(200, [
-        { processInstanceId: '123', assignee: null },
-        { processInstanceId: '456', assignee: null },
-        { processInstanceId: '789', assignee: null },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages',
+        { status: 'NEW',
+          filterParams: {},
+          sortParams: [{ field: 'arrival-date', order: 'desc' }],
+          pageParams: { limit: 100, offset: 0 } })
+      .reply(200, taskListData);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
@@ -291,16 +252,14 @@ describe('TaskListPage', () => {
 
   it('should calculate total risk score', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 10 })
-      .onGet('/task')
-      .reply(200, [
-        { processInstanceId: '123', assignee: null },
-        { processInstanceId: '456', assignee: null },
-        { processInstanceId: '789', assignee: null },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages',
+        { status: 'NEW',
+          filterParams: {},
+          sortParams: [{ field: 'arrival-date', order: 'desc' }],
+          pageParams: { limit: 100, offset: 0 } })
+      .reply(200, taskListData);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
@@ -309,16 +268,10 @@ describe('TaskListPage', () => {
 
   it('should render updated on task where numberOfVersions is greater than 1', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 10 })
-      .onGet('/task')
-      .reply(200, [
-        { processInstanceId: '123', assignee: null },
-        { processInstanceId: '456', assignee: null },
-        { processInstanceId: '789', assignee: null },
-      ])
-      .onGet('/variable-instance')
-      .reply(200, variableInstanceTaskSummaryBasedOnTIS);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListData);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
@@ -327,10 +280,10 @@ describe('TaskListPage', () => {
 
   it('should handle errors gracefully', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(200, { count: 10 })
-      .onGet('/task')
-      .reply(500);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(500, []);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
@@ -341,12 +294,13 @@ describe('TaskListPage', () => {
 
   it('should handle count errors gracefully', async () => {
     mockAxios
-      .onGet('/task/count')
-      .reply(500);
+      .onPost('/targeting-tasks/status-counts')
+      .reply(500, [])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListData);
 
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
-    expect(screen.getByText('No tasks available')).toBeInTheDocument();
     expect(screen.queryByText('Request failed with status code 500')).toBeInTheDocument();
     expect(screen.queryByText('There is a problem')).toBeInTheDocument();
   });

--- a/src/routes/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/__tests__/TaskListPageFilters.test.jsx
@@ -28,16 +28,20 @@ describe('TaskListFilters', () => {
     expect(screen.getByText('Filters')).toBeInTheDocument();
     expect(screen.getByText('Apply filters')).toBeInTheDocument();
     expect(screen.getByText('Clear all filters')).toBeInTheDocument();
-    expect(screen.getByText('Mode')).toBeInTheDocument();
+    expect(screen.getByText('Modes')).toBeInTheDocument();
     expect(screen.getByText('Selectors')).toBeInTheDocument();
 
-    // Radio buttons
-    expect(screen.getAllByRole('radio').length).toBe(6);
+    // Check boxes
+    expect(screen.getAllByRole('checkbox').length).toBe(3);
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo accompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
+
+    // Radio buttons
+    expect(screen.getAllByRole('radio').length).toBe(3);
     expect(screen.getByLabelText('Not present')).not.toBeChecked();
     expect(screen.getByLabelText('Present')).not.toBeChecked();
+    expect(screen.getByLabelText('Any')).not.toBeChecked();
   });
 
   it('should allow user to select a single radio button in each group', async () => {
@@ -49,7 +53,7 @@ describe('TaskListFilters', () => {
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo accompanied freight')).toBeChecked();
-    expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
     expect(screen.getByLabelText('Not present')).toBeChecked();
     expect(screen.getByLabelText('Present')).not.toBeChecked(); // this is reset to 'not' when 'has no' is selected
   });
@@ -59,29 +63,29 @@ describe('TaskListFilters', () => {
     fireEvent.click(screen.getByLabelText('Present'));
     fireEvent.click(screen.getByText('Apply filters'));
 
-    expect(localStorage.getItem('filters')).toBe('movementMode_eq_roro-accompanied-freight,hasSelectors_eq_yes');
+    expect(localStorage.getItem('filters')).toBe('true,RORO_ACCOMPANIED_FREIGHT');
   });
 
   it('should clear filters when clearAll is clicked', async () => {
-    localStorage.setItem('filters', 'movementMode_eq_roro-accompanied-freight,hasSelectors_eq_yes');
+    localStorage.setItem('filters', 'true,RORO_ACCOMPANIED_FREIGHT');
 
     fireEvent.click(screen.getByText('Clear all filters'));
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
     expect(screen.getByLabelText('RoRo accompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
     expect(screen.getByLabelText('Not present')).not.toBeChecked();
     expect(screen.getByLabelText('Present')).not.toBeChecked();
     expect(localStorage.getItem('filters')).toBeFalsy();
   });
 
   it('should persist filters when they exist in local storage', async () => {
-    localStorage.setItem('filters', 'movementMode_eq_roro-accompanied-freight');
+    localStorage.setItem('filters', 'RORO_ACCOMPANIED_FREIGHT');
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo tourist')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
     expect(screen.getByLabelText('Not present')).not.toBeChecked();
     expect(screen.getByLabelText('Present')).not.toBeChecked();
-    expect(localStorage.getItem('filters')).toBe('movementMode_eq_roro-accompanied-freight');
+    expect(localStorage.getItem('filters')).toBe('RORO_ACCOMPANIED_FREIGHT');
   });
 });


### PR DESCRIPTION
## Description
To enable checkbox filters and filter counts we have a new API to use to get tasks & counts

- it refactors the getting counts to use the new API
- This PR **breaks** filtering temporarily

## To Test

- update your run script to remove `/engine-rest` from the camunda URL
- go to /tasks
- task counts in tabs should reflect the number of tasks for the status
- pagination should work (you can test it by setting `itemsPerPage` to a lower number on line 92)

# DO NOT MERGE THIS PR
It breaks filters and they are being recreated with the new API and will be merged into this branch before merging to dev

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
