### PR TITLE
COP-9662 Update API path for live probe in deployment.yml

### DIFF
--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -70,7 +70,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - wget -O - localhost:8080/camunda 2>&1| grep "HTTP/1.1 401"
+              - wget -O - localhost:8080/camunda/engine-rest 2>&1| grep "HTTP/1.1 401" 
         ports:
           - name: frontend
             containerPort: {{.CERBERUS_UI_PORT}}


### PR DESCRIPTION
## Description
We hit 2 different APIs from the UI now
- `/camunda/engine-rest`
- `/camunda/v1`

Previously everything was configured with the assumption `camunda\engine-rest` was the only one and we have discovered we now need to update the API path here to include engine-rest so it hits the correct endpoint that it's checking.

## To Test

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
