### PR TITLE
COP-9661 Add functions to persist filters on page refresh

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -466,6 +466,8 @@ const TaskListPage = () => {
     if (e) { e.preventDefault(); }
     let apiParams = [];
     if (!resetToDefault) {
+      localStorage.setItem('filterMovementMode', movementModesSelected);
+      localStorage.setItem('hasSelector', hasSelectors);
       apiParams = {
         movementModes: movementModesSelected || [],
         hasSelectors,
@@ -483,6 +485,9 @@ const TaskListPage = () => {
 
   const handleFilterReset = (e) => {
     e.preventDefault();
+    // Clear localStorage
+    localStorage.removeItem('filterMovementMode');
+    localStorage.removeItem('hasSelector');
     // Clear checked options
     if (hasSelectors) {
       document.getElementById(hasSelectors).checked = false;
@@ -498,10 +503,31 @@ const TaskListPage = () => {
     handleFilterApply(e, 'resetToDefault'); // run with default params
   };
 
+  const applySavedFiltersOnLoad = () => {
+    const selectors = localStorage.getItem('hasSelector');
+    const movementModes = localStorage.getItem('filterMovementMode') ? localStorage.getItem('filterMovementMode').split(',') : [];
+    setHasSelectors(selectors);
+    setMovementModesSelected(movementModes);
+
+    const selectedArray = [];
+    if (selectors) { selectedArray.push(selectors); }
+    if (movementModes?.length > 0) { selectedArray.push(...movementModes); }
+    setStoredFilters(selectedArray);
+
+    const apiParams = {
+      movementModes,
+      hasSelectors: selectors,
+    };
+
+    getTaskCount(apiParams);
+    setFiltersToApply(apiParams);
+    setLoading(false);
+  };
+
   useEffect(() => {
     const selectedArray = [];
-    selectedArray.push(hasSelectors);
-    selectedArray.push(...movementModesSelected);
+    if (hasSelectors) { selectedArray.push(hasSelectors); }
+    if (movementModesSelected?.length > 0) { selectedArray.push(...movementModesSelected); }
     setStoredFilters(selectedArray);
   }, [hasSelectors, movementModesSelected]);
 
@@ -512,7 +538,7 @@ const TaskListPage = () => {
     }
     if (isTargeter) {
       setAuthorisedGroup(true);
-      handleFilterApply();
+      applySavedFiltersOnLoad();
     }
   }, []);
 

--- a/src/routes/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/__tests__/TaskListPageFilters.test.jsx
@@ -15,7 +15,7 @@ describe('TaskListFilters', () => {
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => { });
     jest.clearAllMocks();
-    localStorage.removeItem('filters');
+    localStorage.clear();
     mockAxios.reset();
   });
 
@@ -23,7 +23,7 @@ describe('TaskListFilters', () => {
     render(<TaskSelectedTabContext.Provider value={tabData}><TaskListPage /></TaskSelectedTabContext.Provider>);
   });
 
-  it('should display filter options based on filter config (filters.js)', async () => {
+  it('should display filter options based on filter config (filters.js)', () => {
     // Titles & Actions
     expect(screen.getByText('Filters')).toBeInTheDocument();
     expect(screen.getByText('Apply filters')).toBeInTheDocument();
@@ -44,7 +44,7 @@ describe('TaskListFilters', () => {
     expect(screen.getByLabelText('Any')).not.toBeChecked();
   });
 
-  it('should allow user to select a single radio button in each group', async () => {
+  it('should allow user to select a single radio button in each group', () => {
     // group one select
     fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
     // group two select first 'has', then 'has no'
@@ -58,7 +58,7 @@ describe('TaskListFilters', () => {
     expect(screen.getByLabelText('Present')).not.toBeChecked(); // this is reset to 'not' when 'has no' is selected
   });
 
-  it('should store selection to localstorage when apply filters button is clicked', async () => {
+  it('should store selection to localstorage when apply filters button is clicked', () => {
     fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
     fireEvent.click(screen.getByLabelText('Present'));
     fireEvent.click(screen.getByText('Apply filters'));
@@ -67,9 +67,9 @@ describe('TaskListFilters', () => {
     expect(localStorage.getItem('filterMovementMode')).toBe('RORO_ACCOMPANIED_FREIGHT');
   });
 
-  it('should clear filters when clearAll is clicked', async () => {
+  it('should clear filters when clearAll is clicked', () => {
     localStorage.setItem('hasSelector', 'true');
-    localStorage.getItem('filterMovementMode', 'RORO_ACCOMPANIED_FREIGHT');
+    localStorage.setItem('filterMovementMode', 'RORO_ACCOMPANIED_FREIGHT');
     expect(localStorage.getItem('hasSelector')).toBe('true');
     expect(localStorage.getItem('filterMovementMode')).toBe('RORO_ACCOMPANIED_FREIGHT');
 
@@ -84,7 +84,7 @@ describe('TaskListFilters', () => {
     expect(localStorage.getItem('filterMovementMode')).toBeFalsy();
   });
 
-  it('should persist filters when they exist in local storage', async () => {
+  it('should persist filters when they exist in local storage', () => {
     localStorage.setItem('filterMovementMode', 'RORO_ACCOMPANIED_FREIGHT');
 
     expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();

--- a/src/routes/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/__tests__/TaskListPageFilters.test.jsx
@@ -58,16 +58,20 @@ describe('TaskListFilters', () => {
     expect(screen.getByLabelText('Present')).not.toBeChecked(); // this is reset to 'not' when 'has no' is selected
   });
 
-  // it('should store selection to localstorage when apply filters button is clicked', async () => {
-  //   fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
-  //   fireEvent.click(screen.getByLabelText('Present'));
-  //   fireEvent.click(screen.getByText('Apply filters'));
+  it('should store selection to localstorage when apply filters button is clicked', async () => {
+    fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
+    fireEvent.click(screen.getByLabelText('Present'));
+    fireEvent.click(screen.getByText('Apply filters'));
 
-  //   expect(localStorage.getItem('filters')).toBe('true,RORO_ACCOMPANIED_FREIGHT');
-  // });
+    expect(localStorage.getItem('hasSelector')).toBe('true');
+    expect(localStorage.getItem('filterMovementMode')).toBe('RORO_ACCOMPANIED_FREIGHT');
+  });
 
   it('should clear filters when clearAll is clicked', async () => {
-    // localStorage.setItem('filters', 'true,RORO_ACCOMPANIED_FREIGHT');
+    localStorage.setItem('hasSelector', 'true');
+    localStorage.getItem('filterMovementMode', 'RORO_ACCOMPANIED_FREIGHT');
+    expect(localStorage.getItem('hasSelector')).toBe('true');
+    expect(localStorage.getItem('filterMovementMode')).toBe('RORO_ACCOMPANIED_FREIGHT');
 
     fireEvent.click(screen.getByText('Clear all filters'));
 
@@ -76,16 +80,17 @@ describe('TaskListFilters', () => {
     expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
     expect(screen.getByLabelText('Not present')).not.toBeChecked();
     expect(screen.getByLabelText('Present')).not.toBeChecked();
-    // expect(localStorage.getItem('filters')).toBeFalsy();
+    expect(localStorage.getItem('hasSelector')).toBeFalsy();
+    expect(localStorage.getItem('filterMovementMode')).toBeFalsy();
   });
 
-  // it('should persist filters when they exist in local storage', async () => {
-  //   localStorage.setItem('filters', 'RORO_ACCOMPANIED_FREIGHT');
+  it('should persist filters when they exist in local storage', async () => {
+    localStorage.setItem('filterMovementMode', 'RORO_ACCOMPANIED_FREIGHT');
 
-  //   expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
-  //   expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
-  //   expect(screen.getByLabelText('Not present')).not.toBeChecked();
-  //   expect(screen.getByLabelText('Present')).not.toBeChecked();
-  //   expect(localStorage.getItem('filters')).toBe('RORO_ACCOMPANIED_FREIGHT');
-  // });
+    expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present')).not.toBeChecked();
+    expect(screen.getByLabelText('Present')).not.toBeChecked();
+    expect(localStorage.getItem('filterMovementMode')).toBe('RORO_ACCOMPANIED_FREIGHT');
+  });
 });


### PR DESCRIPTION
## Description
AC: persist filter selections on page refresh

Store selections in localstorage
Load filters localstorage, set checked state, get counts & tasks on page load

## To Test

- select some filters & apple
- refresh page : filters should remain selected and counts/tasks should be for those filters
- clear filters
- refresh page : page should load with no filters

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
