### PR TITLE
COP-9402: Update tests to verify the Rules matches with the latest changes on UI

### DIFF
--- a/cypress/fixtures/accompanied-task-2-passengers-details.json
+++ b/cypress/fixtures/accompanied-task-2-passengers-details.json
@@ -74,12 +74,12 @@
     "Check-in": ""
   },
   "rules": {
-    "Name": "Paid by cash1",
-    "Priority": "Tier 1",
-    "Version": "1",
-    "Abuse type": "Class A Drugs",
+    "Rule name": "Paid by Cash",
+    "Threat": "Tier 1",
+    "Rule verison": "1",
+    "Abuse Type": "National Security at the Border",
     "Agency": "",
-    "Description": "Paid by cash"
+    "Description": "Test"
   },
   "vessel": {
     "name": "PRIDE OF CANTERBURY",

--- a/cypress/fixtures/task-details-versions.json
+++ b/cypress/fixtures/task-details-versions.json
@@ -75,25 +75,27 @@
           "Paid by cash": "30"
         }
       },
-      "selectorMatch": {
-        "Attribute": "",
-        "Category": "B",
-        "Creator": "Joe Jones",
-        "Entity": "",
-        "Group number": "2020-6",
-        "Group reference": "Local ref",
-        "Inbound action": "Advise originator",
-        "Notes": "Supplemental notes",
-        "Operator": "",
-        "Outbound action": "Full attention",
-        "Point of contact": "poc",
-        "Point of contact message": "Message for the POC",
-        "Requesting officer": "Peter Price",
-        "Source reference": "intel source",
-        "Threat type": "National Security at the Border",
-        "Value": "",
-        "Warnings": "Supplemental warnings"
-      },
+      "selectorMatch": [
+        {
+          "Attribute": "",
+          "Category": "B",
+          "Creator": "Joe Jones",
+          "Entity": "",
+          "Group number": "2020-6",
+          "Group reference": "Local ref",
+          "Inbound action": "Advise originator",
+          "Notes": "Supplemental notes",
+          "Operator": "",
+          "Outbound action": "Full attention",
+          "Point of contact": "poc",
+          "Point of contact message": "Message for the POC",
+          "Requesting officer": "Peter Price",
+          "Source reference": "intel source",
+          "Threat type": "National Security at the Border",
+          "Value": "",
+          "Warnings": "Supplemental warnings"
+        }
+      ],
       "rulesMatched": {
         "Rule name": "Paid by Cash",
         "Threat": "Tier 1",
@@ -287,25 +289,46 @@
           "Paid by cash": "30"
         }
       },
-      "selectorMatch": {
-        "Attribute": "",
-        "Category": "B",
-        "Creator": "Joe Jones",
-        "Entity": "",
-        "Group number": "2020-6",
-        "Group reference": "Local ref",
-        "Inbound action": "Advise originator",
-        "Notes": "Supplemental notes",
-        "Operator": "",
-        "Outbound action": "Full attention",
-        "Point of contact": "poc",
-        "Point of contact message": "Message for the POC",
-        "Requesting officer": "Peter Price",
-        "Source reference": "intel source",
-        "Threat type": "National Security at the Border",
-        "Value": "",
-        "Warnings": "Supplemental warnings"
-      },
+      "selectorMatch": [
+        {
+          "Group number":"2021-278",
+          "Requesting officer":"ytjtj",
+          "Source reference":"yjjt",
+          "Group reference":"SR-219",
+          "Category":"B",
+          "Threat type":"National Security at the Border",
+          "Point of contact message":"jyjt",
+          "Point of contact":"yjt",
+          "Inbound action":"No action required",
+          "Outbound action":"No action required",
+          "Warnings":"jtyj",
+          "Notes":"notes",
+          "Creator":"user",
+          "Entity":"Message",
+          "Attribute":"mode",
+          "Operator":"in",
+          "Value":"RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+        },
+        {
+          "Group number":"2021-279",
+          "Requesting officer":"fe",
+          "Source reference":"fefe",
+          "Group reference":"SR-220",
+          "Category":"A",
+          "Threat type":"Class A Drugs",
+          "Point of contact message":"fdvdfb",
+          "Point of contact":"bfb",
+          "Inbound action":"No action required",
+          "Outbound action":"No action required",
+          "Warnings":"bdfbdfbf",
+          "Notes":"notes",
+          "Creator":"user",
+          "Entity":"Message",
+          "Attribute":"mode",
+          "Operator":"in",
+          "Value":"RORO Unaccompanied Freight"
+        }
+      ],
       "rulesMatched": {
         "Rule name": "Paid by Cash",
         "Threat": "Tier 1",

--- a/cypress/fixtures/task-details-versions.json
+++ b/cypress/fixtures/task-details-versions.json
@@ -69,7 +69,11 @@
         "Check-in": "3 Aug 2020 at 12:05"
       },
       "TargetingIndicators": {
-        "Name": "Paid by cash"
+        "Total Score": "30",
+        "Total Indicators": "1",
+        "indicators": {
+          "Paid by cash": "30"
+        }
       },
       "selectorMatch": {
         "Attribute": "",
@@ -91,18 +95,12 @@
         "Warnings": "Supplemental warnings"
       },
       "rulesMatched": {
-        "Name": "Paid by Cash",
-        "Priority": "Tier 1",
-        "Version": "1",
-        "Abuse type": "National Security at the Border",
+        "Rule name": "Paid by Cash",
+        "Threat": "Tier 1",
+        "Rule verison": "1",
+        "Abuse Type": "National Security at the Border",
         "Agency": "",
-        "Description": "Test",
-        "Name": "Paid by cash1",
-        "Priority": "Tier 1",
-        "Version": "1",
-        "Abuse type": "Class A Drugs",
-        "Agency": "",
-        "Description": "Paid by cash"
+        "Description": "Test"
       }
     },
     {
@@ -174,7 +172,11 @@
         "Check-in": "3 Aug 2020 at 12:05"
       },
       "TargetingIndicators": {
-        "Name": "Tractor unit only"
+        "Total Score": "30",
+        "Total Indicators": "1",
+        "indicators": {
+          "Paid by cash": "30"
+        }
       },
       "selectorMatch": {
         "Attribute": "",
@@ -279,7 +281,11 @@
         "Check-in": "3 Aug 2021 at 12:05"
       },
       "TargetingIndicators": {
-        "Name": "Paid by cash"
+        "Total Score": "30",
+        "Total Indicators": "1",
+        "indicators": {
+          "Paid by cash": "30"
+        }
       },
       "selectorMatch": {
         "Attribute": "",
@@ -301,18 +307,12 @@
         "Warnings": "Supplemental warnings"
       },
       "rulesMatched": {
-        "Name": "cash paid rule",
-        "Priority": "Tier 1",
-        "Version": "1",
-        "Abuse type": "National Security at the Border",
+        "Rule name": "Paid by Cash",
+        "Threat": "Tier 1",
+        "Rule verison": "1",
+        "Abuse Type": "National Security at the Border",
         "Agency": "",
-        "Description": "Test",
-        "Name": "Paid by cash1",
-        "Priority": "Tier 1",
-        "Version": "1",
-        "Abuse type": "Class A Drugs",
-        "Agency": "",
-        "Description": "Paid by cash"
+        "Description": "Test"
       }
     }
   ]

--- a/cypress/fixtures/unaccompanied-task-details.json
+++ b/cypress/fixtures/unaccompanied-task-details.json
@@ -54,23 +54,48 @@
       "Empty vehicle": "20"
     }
   },
-  "selector_matches": {
-    "Attribute": "",
-    "Category": "B",
-    "Creator": "Joe Jones",
-    "Entity": "",
-    "Group number": "2020-6",
-    "Group reference": "Local ref",
-    "Inbound action": "Advise originator",
-    "Notes": "Supplemental notes",
-    "Operator": "",
-    "Outbound action": "Full attention",
-    "Point of contact": "poc",
-    "Point of contact message": "Message for the POC",
-    "Requesting officer": "Peter Price",
-    "Source reference": "intel source",
-    "Threat type": "National Security at the Border",
-    "Value": "",
-    "Warnings": "Supplemental warnings"
-  }
+  "selector_matches": [
+    {
+      "Attribute": "",
+      "Category": "B",
+      "Creator": "Joe Jones",
+      "Entity": "",
+      "Group number": "2020-6",
+      "Group reference": "Local ref",
+      "Inbound action": "Advise originator",
+      "Notes": "Supplemental notes",
+      "Operator": "",
+      "Outbound action": "Full attention",
+      "Point of contact": "poc",
+      "Point of contact message": "Message for the POC",
+      "Requesting officer": "Peter Price",
+      "Source reference": "intel source",
+      "Threat type": "National Security at the Border",
+      "Value": "",
+      "Warnings": "Supplemental warnings"
+    },
+    {
+      "Attribute": "registrationNumber",
+      "Category": "C",
+      "Creator": "user",
+      "Entity": "Trailer",
+      "Group number": "2021-281",
+      "Group reference": "SR-222",
+      "Inbound action": "No action required",
+      "Notes": "notes",
+      "Operator": "equal",
+      "Outbound action": "No action required",
+      "Point of contact": "ewfe",
+      "Point of contact message": "effew",
+      "Requesting officer": "efew",
+      "Source reference": "ffew",
+      "Threat type": "National Security at the Border",
+      "Value": "qwerty",
+      "Warnings": "fewfwe",
+      "Entity": "Message",
+      "Attribute": "mode",
+      "Operator": "in",
+      "Value": "RORO Unaccompanied Freight"
+    }
+  ]
 }

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -30,9 +30,11 @@ describe('Create task with different payload from Cerberus', () => {
     cy.createCerberusTask('RoRo-Tourist.json', 'TOURIST-WITH-PASSENGERS').then(() => {
       cy.wait(2000);
       cy.expandTaskDetails(0).then(() => {
-        cy.contains('h2', 'Rules matched').next().contains('.govuk-summary-list__key', 'Abuse type')
-          .next()
-          .should('have.text', 'Obscene Material');
+        cy.contains('h2', 'Rules matched').nextAll().within(() => {
+          cy.getAllRuleMatches().then((actualRuleMatches) => {
+            expect(actualRuleMatches['Abuse Type']).to.be.equal('Obscene Material');
+          });
+        });
       });
     });
   });

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -72,9 +72,9 @@ describe('Task Details of different tasks on task details Page', () => {
         });
       });
 
-      cy.contains('h2', '1 selector matches').next().within(() => {
-        cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.selector_matches);
+      cy.contains('h2', '2 selector matches').then((locator) => {
+        cy.getAllSelectorMatches(locator).then((actualSelectorMatches) => {
+          expect(actualSelectorMatches).to.deep.equal(expectedDetails.selector_matches);
         });
       });
       // COP-6433 : Auto-expand current task version
@@ -289,9 +289,9 @@ describe('Task Details of different tasks on task details Page', () => {
         });
       });
 
-      cy.contains('h2', 'Rules matched').next().within(() => {
-        cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.rules);
+      cy.contains('h2', 'Rules matched').nextAll().within(() => {
+        cy.getAllRuleMatches().then((actualRuleMatches) => {
+          expect(actualRuleMatches).to.deep.equal(expectedDetails.rules);
         });
       });
     });
@@ -718,7 +718,7 @@ describe('Task Details of different tasks on task details Page', () => {
     });
 
     cy.visit('/tasks');
-    cy.get('.govuk-task-list-card').contains('AUTOTEST-16-12-2021-RORO-Accompanied-Freight-target-indicators-same-version_981578:CMID=TEST').closest('section').then((element) => {
+    cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
       cy.wrap(element).find('.govuk-tag--updatedTarget').should('not.exist');
     });
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -764,7 +764,14 @@ Cypress.Commands.add('verifyTaskDetailAllSections', (expectedDetails, versionInR
     });
   }
   if (Object.prototype.hasOwnProperty.call(expectedDetails, 'selectorMatch')) {
-    cy.verifyTaskDetailSection(expectedDetails.selectorMatch, versionInRow, sectionHeading.get('selectorMatch'));
+    let regex = new RegExp('^[0-9]+ selector matches$', 'g');
+    cy.get(`[id$=-content-${versionInRow}]`).within(() => {
+      cy.contains('h2', regex).then((locator) => {
+        cy.getAllSelectorMatches(locator).then((actualSelectorMatches) => {
+          expect(actualSelectorMatches).to.deep.equal(expectedDetails.selectorMatch);
+        });
+      });
+    });
   }
   if (Object.prototype.hasOwnProperty.call(expectedDetails, 'TargetingIndicators')) {
     cy.get(`[id$=-content-${versionInRow}]`).within(() => {


### PR DESCRIPTION
## Description
Update automation tests to verify the Rules matches with the latest changes on UI. Following scenarios are covered,

Scenario 1: 1 Matched rule
GIVEN a task has a matched rules
WHEN I view the task details
THEN the matched rule is displayed as the prototype

Scenario 2: More than 1 Matched rule
GIVEN a task has multiple matched rules
WHEN I view the task details
THEN the first rule is displayed as Rule Matched and any other rules are displayed in "Other rule matches" as the prototype


## To Test
npm run cypress:runner
run all the tests from spec `task-version-details.spec.js`
run test `Should create a task with a payload contains RoRo Tourist and check AbuseType set to correct value` from spec `create-tasks.spec.js`.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
