### PR TITLE
COP-9556: Update test to check the Assessment Complete and Dismissed outcome and notes in the activity log

### DIFF
--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -230,42 +230,53 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       'Other',
     ];
 
+    let businessKey;
+
+    const expectedActivity = 'Assessment complete, the reason is \'vesselArrived\'. Accompanying note: \'This is for testing\'';
+
     cy.fixture('tasks.json').then((task) => {
       let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-${mode}-ASSESSMENT`).then((taskResponse) => {
         cy.wait(4000);
-        cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
+        businessKey = taskResponse.businessKey;
+        cy.getTasksByBusinessKey(businessKey).then((tasks) => {
           cy.navigateToTaskDetailsPage(tasks);
         });
+
+        cy.wait(2000);
+
+        cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
+
+        cy.contains('Assessment complete').click();
+
+        cy.clickNext();
+
+        cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for completing your assessment');
+
+        cy.get('.formio-component-reason .govuk-radios__label').each(($reason, index) => {
+          expect($reason).to.be.visible;
+          let reasonText = $reason.text().replace(/^\s+|\s+$/g, '');
+          expect(reasonText).to.contain(reasons[index]);
+        });
+
+        cy.selectRadioButton('reason', 'Vessel arrived');
+
+        cy.clickNext();
+
+        cy.typeValueInTextArea('addANote', 'This is for testing');
+
+        cy.clickSubmit();
+
+        cy.verifySuccessfulSubmissionHeader('Task has been completed');
+
+        cy.visit(`/tasks/${businessKey}`);
       });
     });
 
-    cy.wait(2000);
-
-    cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
-
-    cy.contains('Assessment complete').click();
-
-    cy.clickNext();
-
-    cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for completing your assessment');
-
-    cy.get('.formio-component-reason .govuk-radios__label').each(($reason, index) => {
-      expect($reason).to.be.visible;
-      let reasonText = $reason.text().replace(/^\s+|\s+$/g, '');
-      expect(reasonText).to.contain(reasons[index]);
+    cy.getActivityLogs().then((activities) => {
+      expect(activities).to.contain(expectedActivity);
     });
-
-    cy.selectRadioButton('reason', 'Vessel arrived');
-
-    cy.clickNext();
-
-    cy.typeValueInTextArea('addANote', 'This is for testing');
-
-    cy.clickSubmit();
-
-    cy.verifySuccessfulSubmissionHeader('Task has been completed');
   });
 
   it('Should dismiss a task with a reason', () => {
@@ -276,52 +287,63 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       'Other',
     ];
 
+    let businessKey;
+
+    const expectedActivity = 'Task dismissed, the reason is \'other reason for testing\'. Accompanying note: \'This is for testing\'';
+
     cy.fixture('tasks.json').then((task) => {
       let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-${mode}-DISMISS`).then((taskResponse) => {
         cy.wait(4000);
+        businessKey = taskResponse.businessKey;
         cy.getTasksByBusinessKey(taskResponse.businessKey).then((tasks) => {
           cy.navigateToTaskDetailsPage(tasks);
         });
+
+        cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
+        cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+
+        cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
+
+        cy.wait('@claim').then(({ response }) => {
+          expect(response.statusCode).to.equal(204);
+        });
+
+        cy.wait(2000);
+
+        cy.contains('Dismiss').click();
+
+        cy.get('.formio-component-reason .govuk-radios__label').each((reason, index) => {
+          cy.wrap(reason)
+            .should('contain.text', reasons[index]).and('be.visible');
+        });
+
+        cy.clickNext();
+
+        cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for dismissing the task');
+
+        cy.selectRadioButton('reason', 'Other');
+
+        cy.typeValueInTextField('otherReason', 'other reason for testing');
+
+        cy.clickNext();
+
+        cy.waitForNoErrors();
+
+        cy.typeValueInTextArea('addANote', 'This is for testing');
+
+        cy.clickSubmit();
+
+        cy.verifySuccessfulSubmissionHeader('Task has been dismissed');
+
+        cy.visit(`/tasks/${businessKey}`);
       });
     });
 
-    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
-
-    cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
-
-    cy.wait('@claim').then(({ response }) => {
-      expect(response.statusCode).to.equal(204);
+    cy.getActivityLogs().then((activities) => {
+      expect(activities).to.contain(expectedActivity);
     });
-
-    cy.wait(2000);
-
-    cy.contains('Dismiss').click();
-
-    cy.get('.formio-component-reason .govuk-radios__label').each((reason, index) => {
-      cy.wrap(reason)
-        .should('contain.text', reasons[index]).and('be.visible');
-    });
-
-    cy.clickNext();
-
-    cy.verifyMandatoryErrorMessage('reason', 'You must indicate at least one reason for dismissing the task');
-
-    cy.selectRadioButton('reason', 'Other');
-
-    cy.typeValueInTextField('otherReason', 'other reason for testing');
-
-    cy.clickNext();
-
-    cy.waitForNoErrors();
-
-    cy.typeValueInTextArea('addANote', 'This is for testing');
-
-    cy.clickSubmit();
-
-    cy.verifySuccessfulSubmissionHeader('Task has been dismissed');
   });
 
   it('Should verify all the action buttons not available when task loaded from Complete tab', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -439,7 +439,7 @@ Cypress.Commands.add('collapseTaskDetails', () => {
 Cypress.Commands.add('navigateToTaskDetailsPage', (task) => {
   const processInstanceId = task.map((item) => item.processInstanceId);
   expect(processInstanceId.length).to.not.equal(0);
-  cy.intercept('GET', `/camunda/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
+  cy.intercept('GET', `/camunda/engine-rest/task?processInstanceId=${processInstanceId[0]}`).as('tasksDetails');
   cy.getBusinessKeyByProcessInstanceId(processInstanceId[0]).then((businessKey) => {
     cy.visit(`/tasks/${businessKey}`);
     cy.wait('@tasksDetails').then(({ response }) => {
@@ -1083,6 +1083,17 @@ Cypress.Commands.add('backToTaskList', (element, tabName) => {
   cy.wait(1000);
   cy.contains('Back to task list').click();
   cy.get('.govuk-tabs__list-item--selected').should('contain.text', tabName).and('be.visible');
+});
+
+Cypress.Commands.add('getActivityLogs', () => {
+  let activityLog = [];
+  cy.get('p.govuk-body:not(.govuk-tag--positiveTarget)').each((item) => {
+    cy.wrap(item).invoke('text').then((activity) => {
+      activityLog.push(activity);
+    });
+  }).then(() => {
+    return activityLog;
+  });
 });
 
 Cypress.Commands.add('getAllRuleMatches', () => {


### PR DESCRIPTION
## Description
Update Automation tests to check the Assessment Complete and Dismissed outcome and notes in the activity log. 
Following scenarios are covered in the tests,
GIVEN a task is dismissed
WHEN the reason and notes are submitted
THEN "Task dismissed", the reason and notes are displayed in the activity log

Scenario: Assessment complete
GIVEN a task assessment is complete
WHEN the reason and notes are submitted
THEN "Assessment complete", the reason and notes are displayed in the activity log

## To Test
npm run cypress:runner
run the following tests from spec `task-details.spec.js`

`Should complete assessment of a task with a reason as take no further action`
`Should dismiss a task with a reason`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
