### PR TITLE
COP-9550: Update automation tests to inline with latest API and UI changes

### DIFF
--- a/cypress/fixtures/accompanied-task-2-passengers-details.json
+++ b/cypress/fixtures/accompanied-task-2-passengers-details.json
@@ -5,15 +5,7 @@
     "Make": "BMW",
     "Model": "520D",
     "Country of registration": "GB",
-    "Trailer registration number": "IR-6457",
-    "Colour": "Red",
-    "Net weight": "0kg",
-    "Gross weight": "2889kg",
-    "Trailer type": "",
-    "Trailer country of registration": "GB",
-    "Empty or loaded": "L",
-    "Trailer length": "36m",
-    "Trailer height": "3.6m"
+    "Colour": "Red"
   },
   "account": {
     "Full name": "Product of France Wines",
@@ -39,22 +31,26 @@
     "Travel document number": "566746DL",
     "Travel document expiry": "29/10/2023"
   },
-  "passengers": {
-    "Name": "Fred Flintstone",
-    "Date of birth": "15/07/1991",
-    "Gender": "F",
-    "Nationality": "DE",
-    "Travel document type": "Passport",
-    "Travel document number": "875786876",
-    "Travel document expiry": "22/03/2022",
-    "Name": "Barney Rubble",
-    "Date of birth": "12/07/1991",
-    "Gender": "M",
-    "Nationality": "GB",
-    "Travel document type": "OBJDOCPAS",
-    "Travel document number": "244746NL",
-    "Travel document expiry": "01/02/2021"
-  },
+  "passengers": [
+    {
+      "Name": "Fred Flintstone",
+      "Date of birth": "15/07/1991",
+      "Gender": "F",
+      "Nationality": "DE",
+      "Travel document type": "OBJDOCPAS",
+      "Travel document number": "875786876",
+      "Travel document expiry": "22/03/2022"
+      },
+      {
+      "Name": "Barney Rubble",
+      "Date of birth": "12/07/1991",
+      "Gender": "M",
+      "Nationality": "GB",
+      "Travel document type": "OBJDOCPAS",
+      "Travel document number": "244746NL",
+      "Travel document expiry": "01/02/2021"
+    }
+  ],
   "goods": {
     "Description": "Wine",
     "Is cargo hazardous?": "No",

--- a/cypress/fixtures/accompanied-task-details.json
+++ b/cypress/fixtures/accompanied-task-details.json
@@ -5,15 +5,7 @@
     "Make": "",
     "Model": "",
     "Country of registration": "DK",
-    "Colour": "",
-    "Net weight": "3455kg",
-    "Gross weight": "43623kg",
-    "Trailer registration number": "",
-    "Trailer type": "",
-    "Trailer country of registration": "",
-    "Empty or loaded": "Empty",
-    "Trailer length": "36m",
-    "Trailer height": "3.6m"
+    "Colour": ""
   },
   "account": {
     "Full name": "DPE logistics",

--- a/cypress/fixtures/task-details-versions.json
+++ b/cypress/fixtures/task-details-versions.json
@@ -3,19 +3,11 @@
     {
       "vehicle": {
         "Colour": "Red",
-        "Net weight": "4000kg",
-        "Gross weight": "43680kg",
         "Vehicle registration": "GB09KLT-2000",
         "Type": "",
         "Make": "LandRover",
         "Model": "",
-        "Country of registration": "DE",
-        "Trailer registration number": "NL-234-392",
-        "Trailer type": "TR",
-        "Trailer country of registration": "NL",
-        "Empty or loaded": "Loaded",
-        "Trailer length": "46m",
-        "Trailer height": "4.6m"
+        "Country of registration": "DE"
       },
       "account": {
         "Full name": "Testing Printers Ltd",
@@ -217,19 +209,11 @@
     {
       "vehicle": {
         "Colour": "",
-        "Net weight": "3455kg",
-        "Gross weight": "43623kg",
         "Vehicle registration": "GB09KLT-10684",
         "Type": "",
         "Make": "",
         "Model": "Discovery",
-        "Country of registration": "GB",
-        "Trailer registration number": "NL-234-392",
-        "Trailer type": "TR",
-        "Trailer country of registration": "",
-        "Empty or loaded": "Empty",
-        "Trailer length": "36m",
-        "Trailer height": "3.6m"
+        "Country of registration": "GB"
       },
       "account": {
         "Full name": "Univeral Printers Ltd",

--- a/cypress/fixtures/task-version-differences.json
+++ b/cypress/fixtures/task-version-differences.json
@@ -5,8 +5,6 @@
       "Make": "LandRover",
       "Country of registration": "DE",
       "Colour": "Red",
-      "Net weight": "4000kg",
-      "Gross weight": "43680kg",
       "Trailer country of registration": "NL",
       "Empty or loaded": "Loaded",
       "Trailer length": "46m",

--- a/cypress/fixtures/tourist-task-details.json
+++ b/cypress/fixtures/tourist-task-details.json
@@ -5,15 +5,7 @@
     "Make": "AUDI",
     "Model": "V9",
     "Country of registration": "GB",
-    "Colour": "WHITE",
-    "Net weight": "0kg",
-    "Gross weight": "2889kg",
-    "Trailer registration number": "IR-6457",
-    "Trailer type": "",
-    "Trailer country of registration": "GB",
-    "Empty or loaded": "L",
-    "Trailer length": "",
-    "Trailer height": ""
+    "Colour": "WHITE"
   },
   "driver": {
     "Name": "Isiaih Ford",
@@ -24,22 +16,26 @@
     "Travel document number": "566746DL",
     "Travel document expiry": "29/10/2023"
   },
-  "passengers": {
-    "Name": "Fred Flintstone",
-    "Date of birth": "22/11/1991",
-    "Gender": "F",
-    "Nationality": "DE",
-    "Travel document type": "OBJDOCPAS",
-    "Travel document number": "875786876",
-    "Travel document expiry": "22/03/2022",
-    "Name": "Barney Rubble",
-    "Date of birth": "01/03/1989",
-    "Gender": "M",
-    "Nationality": "GB",
-    "Travel document type": "OBJDOCPAS",
-    "Travel document number": "244746NL",
-    "Travel document expiry": "01/02/2021"
-  },
+  "passengers": [
+    {
+      "Name": "Fred Flintstone",
+      "Date of birth": "22/11/1991",
+      "Gender": "F",
+      "Nationality": "DE",
+      "Travel document type": "OBJDOCPAS",
+      "Travel document number": "875786876",
+      "Travel document expiry": "22/03/2022"
+    },
+    {
+      "Name": "Barney Rubble",
+      "Date of birth": "01/03/1989",
+      "Gender": "M",
+      "Nationality": "GB",
+      "Travel document type": "OBJDOCPAS",
+      "Travel document number": "244746NL",
+      "Travel document expiry": "01/02/2021"
+    }
+  ],
   "Booking-and-check-in": {
     "Reference": "AB555412781",
     "Ticket number": "1234567",

--- a/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
@@ -13,6 +13,11 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   });
 
   it('Should view filter tasks by pre-arrival modes', () => {
+    let filterNames = [
+      'RoRo unaccompanied freight',
+      'RoRo accompanied freight',
+      'RoRo Tourist',
+    ];
     cy.get('a[href="#new"]').invoke('text').as('total-tasks').then((totalTargets) => {
       cy.log('Total number of Targets', parseInt(totalTargets.match(/\d+/)[0], 10));
     });
@@ -22,7 +27,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.get('.cop-filters-header .govuk-link').should('have.text', 'Clear all filters');
       cy.get('.govuk-checkboxes li').each((element) => {
         cy.wrap(element).invoke('text').then((value) => {
-          expect(filterOptions).to.include(value);
+          expect(filterNames).to.include(value);
         });
       });
     });
@@ -33,7 +38,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
     // COP-5715 Apply each pre-arrival filter, compare the expected number of targets
     filterOptions.forEach((mode) => {
-      cy.applyFilter(mode, 'new').then((actualTargets) => {
+      cy.applyModesFilter(mode, 'new').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
         cy.getTaskCount(mode, null).then((response) => {
@@ -62,7 +67,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
     // COP-5715 Apply each pre-arrival filter, compare the expected number of targets
     filterOptions.forEach((mode) => {
-      cy.applyFilter(mode, 'inProgress').then((actualTargets) => {
+      cy.applyModesFilter(mode, 'inProgress').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
         cy.getTaskCount(mode, null).then((response) => {
@@ -91,7 +96,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
     // COP-5715 Apply each pre-arrival filter, compare the expected number of targets
     filterOptions.forEach((mode) => {
-      cy.applyFilter(mode, 'issued').then((actualTargets) => {
+      cy.applyModesFilter(mode, 'issued').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
         cy.getTaskCount(mode, null).then((response) => {
@@ -120,7 +125,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
     // COP-5715 Apply each pre-arrival filter, compare the expected number of targets
     filterOptions.forEach((mode) => {
-      cy.applyFilter(mode, 'complete').then((actualTargets) => {
+      cy.applyModesFilter(mode, 'complete').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
         cy.getTaskCount(mode, null).then((response) => {
@@ -145,8 +150,8 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   it('Should retain applied filter after page reload & navigating between pages', () => {
     // COP-5715 switch between the tabs, filter should be retained
     filterOptions.forEach((mode) => {
-      cy.applyFilter(mode, 'new').then((actualTargets) => {
-        cy.getTaskCount(mode, 'New').then((response) => {
+      cy.applyModesFilter(mode, 'new').then((actualTargets) => {
+        cy.getTaskCount(mode, null).then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -161,7 +166,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
     // COP-5715 reload the page after filter applied on the page, filter should be retained
     filterOptions.forEach((mode) => {
-      cy.applyFilter(mode, 'new').then((actualTargets) => {
+      cy.applyModesFilter(mode, 'new').then((actualTargets) => {
         cy.getTaskCount(mode, null).then((response) => {
           expect(response.new).be.equal(actualTargets);
         });

--- a/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
@@ -2,19 +2,17 @@
 /// <reference path="../support/index.d.ts" />
 
 describe('Filter tasks by pre-arrival mode on task management Page', () => {
+  const filterOptions = [
+    'RORO_UNACCOMPANIED_FREIGHT',
+    'RORO_ACCOMPANIED_FREIGHT',
+    'RORO_TOURIST',
+  ];
   beforeEach(() => {
     cy.login(Cypress.env('userName'));
-    cy.intercept('GET', '/camunda/variable-instance?variableName=taskSummaryBasedOnTIS&processInstanceIdIn=**').as('tasks');
     cy.navigation('Tasks');
   });
 
   it('Should view filter tasks by pre-arrival modes', () => {
-    const filterOptions = [
-      'RoRo unaccompanied freight',
-      'RoRo accompanied freight',
-      'RoRo tourist',
-    ];
-
     cy.get('a[href="#new"]').invoke('text').as('total-tasks').then((totalTargets) => {
       cy.log('Total number of Targets', parseInt(totalTargets.match(/\d+/)[0], 10));
     });
@@ -22,7 +20,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     cy.get('.cop-filters-container').within(() => {
       cy.get('h2.govuk-heading-s').should('have.text', 'Filters');
       cy.get('.cop-filters-header .govuk-link').should('have.text', 'Clear all filters');
-      cy.get('.govuk-radios__item [name="Mode"]').next().each((element) => {
+      cy.get('.govuk-checkboxes li').each((element) => {
         cy.wrap(element).invoke('text').then((value) => {
           expect(filterOptions).to.include(value);
         });
@@ -31,12 +29,6 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   });
 
   it('Should apply filter tasks by pre-arrival modes on newly created tasks', () => {
-    const filterOptions = [
-      'roro-unaccompanied-freight',
-      'roro-accompanied-freight',
-      'roro-tourist',
-    ];
-
     let actualTotalTargets = 0;
 
     // COP-5715 Apply each pre-arrival filter, compare the expected number of targets
@@ -44,9 +36,10 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyFilter(mode, 'new').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getNumberOfTasksByMode(mode, 'New').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.new).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
       });
     });
 
@@ -63,12 +56,6 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   });
 
   it('Should apply filter tasks by pre-arrival modes on In Progress tasks', () => {
-    const filterOptions = [
-      'roro-unaccompanied-freight',
-      'roro-accompanied-freight',
-      'roro-tourist',
-    ];
-
     let actualTotalTargets = 0;
 
     cy.get('a[href="#inProgress"]').click();
@@ -78,9 +65,10 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyFilter(mode, 'inProgress').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getNumberOfTasksByMode(mode, 'In Progress').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.inProgress).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
       });
     });
 
@@ -97,12 +85,6 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   });
 
   it('Should apply filter tasks by pre-arrival modes on Issued tasks', () => {
-    const filterOptions = [
-      'roro-unaccompanied-freight',
-      'roro-accompanied-freight',
-      'roro-tourist',
-    ];
-
     let actualTotalTargets = 0;
 
     cy.get('a[href="#issued"]').click();
@@ -112,9 +94,10 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyFilter(mode, 'issued').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getNumberOfTasksByMode(mode, 'Issued').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.issued).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
       });
     });
 
@@ -131,12 +114,6 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   });
 
   it('Should apply filter tasks by pre-arrival modes on Completed tasks', () => {
-    const filterOptions = [
-      'roro-unaccompanied-freight',
-      'roro-accompanied-freight',
-      'roro-tourist',
-    ];
-
     let actualTotalTargets = 0;
 
     cy.get('a[href="#complete"]').click();
@@ -146,9 +123,10 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyFilter(mode, 'complete').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getNumberOfTasksByMode(mode, 'Completed').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.complete).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
       });
     });
 
@@ -165,55 +143,52 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   });
 
   it('Should retain applied filter after page reload & navigating between pages', () => {
-    const filterOptions = [
-      'roro-unaccompanied-freight',
-      'roro-accompanied-freight',
-      'roro-tourist',
-    ];
-
     // COP-5715 switch between the tabs, filter should be retained
     filterOptions.forEach((mode) => {
       cy.applyFilter(mode, 'new').then((actualTargets) => {
-        cy.getNumberOfTasksByMode(mode, 'New').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, 'New').then((response) => {
+          expect(response.new).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
         cy.get('a[href="#complete"]').click();
         cy.get('a[href="#new"]').click();
-        cy.getNumberOfTasksByMode(mode, 'New').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.new).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
       });
     });
 
     // COP-5715 reload the page after filter applied on the page, filter should be retained
     filterOptions.forEach((mode) => {
       cy.applyFilter(mode, 'new').then((actualTargets) => {
-        cy.getNumberOfTasksByMode(mode, 'New').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.new).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
         cy.reload();
         cy.wait(2000);
-        cy.getNumberOfTasksByMode(mode, 'New').then((expectedTargets) => {
-          expect(expectedTargets).be.equal(actualTargets);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.new).be.equal(actualTargets);
         });
+        cy.contains('Clear all filters').click();
       });
     });
   });
 
   it('Should apply filter tasks by roro-unaccompanied mode & has selectors on New tasks', () => {
-    const filterOptions = [
-      'roro-unaccompanied-freight',
-      'has-selector',
-    ];
-
-    cy.getNumberOfTasksWithoutFilter('New').as('expectedTargets');
+    let expectedTargets;
+    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+      expectedTargets = numberOfTasks.new;
+    });
 
     // COP-9191 Apply each pre-arrival filter, compare the expected number of targets
 
-    cy.applyFilter(filterOptions, 'new').then((actualTargets) => {
-      cy.log('actual targets', actualTargets);
-      cy.getNumberOfTasksByModeAndSelectors(filterOptions[0], filterOptions[1], 'New').then((expectedTargets) => {
-        expect(expectedTargets).be.equal(actualTargets);
+    cy.applyModesFilter('RORO_UNACCOMPANIED_FREIGHT', 'new').then(() => {
+      cy.applySelectorFilter('true', 'new').then((actualTargets) => {
+        cy.getTaskCount('RORO_UNACCOMPANIED_FREIGHT', 'true').then((FilterExpectedTargets) => {
+          expect(FilterExpectedTargets.new).be.equal(actualTargets);
+        });
       });
     });
 
@@ -225,28 +200,25 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     // compare total number of expected and actual targets
     cy.get('a[href="#new"]').invoke('text').then((totalTargets) => {
       totalTargets = parseInt(totalTargets.match(/\d+/)[0], 10);
-      cy.get('@expectedTargets').then((expectedTargets) => {
-        expect(expectedTargets).be.equal(totalTargets);
-      });
+      expect(expectedTargets).be.equal(totalTargets);
     });
   });
 
   it('Should apply filter tasks by roro-accompanied mode & has no selectors on In Progress tasks', () => {
-    const filterOptions = [
-      'roro-accompanied-freight',
-      'has-no-selector',
-    ];
-
+    let expectedTargets;
     cy.get('a[href="#inProgress"]').click();
 
-    cy.getNumberOfTasksWithoutFilter('In Progress').as('expectedTargets');
+    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+      expectedTargets = numberOfTasks.inProgress;
+    });
 
     // COP-9191 Apply each pre-arrival filter, compare the expected number of targets
 
-    cy.applyFilter(filterOptions, 'inProgress').then((actualTargets) => {
-      cy.log('actual targets', actualTargets);
-      cy.getNumberOfTasksByModeAndSelectors(filterOptions[0], filterOptions[1], 'In Progress').then((expectedTargets) => {
-        expect(expectedTargets).be.equal(actualTargets);
+    cy.applyModesFilter('RORO_UNACCOMPANIED_FREIGHT', 'inProgress').then(() => {
+      cy.applySelectorFilter('false', 'inProgress').then((actualTargets) => {
+        cy.getTaskCount('RORO_UNACCOMPANIED_FREIGHT', 'false').then((FilterExpectedTargets) => {
+          expect(FilterExpectedTargets.inProgress).be.equal(actualTargets);
+        });
       });
     });
 
@@ -258,9 +230,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     // compare total number of expected and actual targets
     cy.get('a[href="#inProgress"]').invoke('text').then((totalTargets) => {
       totalTargets = parseInt(totalTargets.match(/\d+/)[0], 10);
-      cy.get('@expectedTargets').then((expectedTargets) => {
-        expect(expectedTargets).be.equal(totalTargets);
-      });
+      expect(expectedTargets).be.equal(totalTargets);
     });
   });
 

--- a/cypress/integration/cerberus/formapi-404.spec.js
+++ b/cypress/integration/cerberus/formapi-404.spec.js
@@ -14,7 +14,7 @@ describe('Cerberus-UI handles the exception if Form API server is unresponsive',
   });
 
   it('should show an error when Form API does not respond', () => {
-    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
 
     cy.intercept('GET', `https://${formApiUrl}/form/name/*`, {
       statusCode: 404,
@@ -26,7 +26,7 @@ describe('Cerberus-UI handles the exception if Form API server is unresponsive',
       cy.navigateToTaskDetailsPage(tasks);
     });
 
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+    cy.get('p.govuk-body').eq(0).should('contain.text', 'Task not assigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
 

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -8,7 +8,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
   });
 
   it('Should submit a target successfully from a RoRo-accompanied task and it should be moved to target issued tab', () => {
-    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
 
     cy.fixture('target-information.json').as('inputData');
 
@@ -25,7 +25,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       });
     });
 
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+    cy.get('p.govuk-body').eq(0).should('contain.text', 'Task not assigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
 
@@ -49,7 +49,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.verifyElementText('model', targetData.vehicle.Model);
       cy.verifyElementText('colour', targetData.vehicle.Colour);
       cy.verifyElementText('registrationNumber', targetData.vehicle['Vehicle registration']);
-      cy.verifyElementText('regNumber', targetData.vehicle['Trailer registration number']);
+      cy.verifyElementText('regNumber', 'IR-6457');
       cy.verifyMultiSelectDropdown('threatIndicators', ['Paid by cash', 'Empty trailer for round trip', 'Empty vehicle']);
       cy.removeOptionFromMultiSelectDropdown('threatIndicators', ['Paid by cash']);
       cy.verifyMultiSelectDropdown('threatIndicators', ['Empty trailer for round trip', 'Empty vehicle']);
@@ -134,8 +134,6 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.get('a[href="#issued"]').click();
 
-    cy.waitForTaskManagementPageToLoad();
-
     cy.get('@taskName').then((value) => {
       cy.log('Task Name to be searched', value);
       const nextPage = 'a[data-test="next"]';
@@ -152,7 +150,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
   });
 
   it('Should submit a target successfully from a RoRo-Unaccompanied task and it should be moved to target issued tab', () => {
-    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
 
     cy.fixture('RoRo-Unaccompanied-RBT-SBT.json').then((task) => {
       date.setDate(date.getDate() + 6);
@@ -167,7 +165,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       });
     });
 
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+    cy.get('p.govuk-body').eq(0).should('contain.text', 'Task not assigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
 
@@ -236,8 +234,6 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.get('a[href="#issued"]').click();
 
-    cy.waitForTaskManagementPageToLoad();
-
     cy.get('@taskName').then((value) => {
       cy.log('Task Name to be searched', value);
       const nextPage = 'a[data-test="next"]';
@@ -254,7 +250,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
   });
 
   it('Should submit a target successfully from a RoRo-Tourist task and it should be moved to target issued tab', () => {
-    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
 
     cy.fixture('RoRo-Tourist-2-passengers.json').then((task) => {
       date.setDate(date.getDate() + 6);
@@ -271,7 +267,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       });
     });
 
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+    cy.get('p.govuk-body').eq(0).should('contain.text', 'Task not assigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
 
@@ -372,8 +368,6 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
     cy.get('a[href="#issued"]').click();
 
-    cy.waitForTaskManagementPageToLoad();
-
     cy.get('@taskName').then((value) => {
       cy.log('Task Name to be searched', value);
       const nextPage = 'a[data-test="next"]';
@@ -392,9 +386,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
   it('Should verify all the action buttons not available when task loaded from Issued tab', () => {
     cy.get('a[href="#issued"]').click();
 
-    cy.get('.title-container').eq(0).within(() => {
-      cy.get('a').click();
-    });
+    cy.get('.govuk-task-list-card a').eq(0).click();
 
     cy.get('.task-actions--buttons button').should('not.exist');
 

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -426,7 +426,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it.skip('Vehicle and Trailer - Unknown values in Task List & Task Summary', () => {
+  it('Vehicle and Trailer - Unknown values in Task List & Task Summary', () => {
     cy.fixture('taskInfo-unknown/RoRo-Acc-VehWithTrail-expected.json').as('expTestData');
     cy.fixture('taskInfo-unknown/RoRo-Acc-VehWithTrail.json')
       .then((task) => {
@@ -466,7 +466,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it.skip('Vehicle - Unknown values in Task List and Task summary', () => {
+  it('Vehicle - Unknown values in Task List and Task summary', () => {
     cy.fixture('taskInfo-unknown/RoRo-Acc-VehOnly-expected.json').as('expTestData');
     cy.fixture('/taskInfo-unknown/RoRo-Acc-VehOnly.json')
       .then((task) => {
@@ -505,7 +505,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it.skip('Should display correct values for PERFDRIVER Driver, Booking, Vehicle, tasklist, task summary', () => {
+  it('Should display correct values for PERFDRIVER Driver, Booking, Vehicle, tasklist, task summary', () => {
     cy.fixture('/taskInfo-known/RoRo-Acc-TaskDetails-expected.json').as('expTestData');
     cy.fixture('/taskInfo-known/RoRo-Acc-TaskDetails-known.json')
       .then((task) => {
@@ -581,7 +581,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it.skip('Setting drivers when no driver or multiple drivers exist', () => {
+  it('Setting drivers when no driver or multiple drivers exist', () => {
     let jsonFolder = '/drivers/';
     let expDriverForPayload = [
       ['driverAndMultiplePass.json', 'Joanne Flower'],

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -9,16 +9,15 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   });
 
   it('Should navigate to task details page', () => {
-    cy.get('.task-heading a').eq(1).invoke('text').then((text) => {
-      cy.contains(text).click();
+    cy.get('h4.task-heading').eq(1).invoke('text').then((text) => {
+      cy.get('.govuk-task-list-card a').eq(1).click();
       cy.get('.govuk-caption-xl').should('have.text', text);
     });
     cy.wait(2000);
     cy.get('.govuk-accordion__open-all').click();
     let headers = [];
-    cy.get('h2.govuk-heading-m').each((element) => {
+    cy.get('.govuk-task-details-grid .title-heading').each((element) => {
       cy.wrap(element).invoke('text').then((value) => {
-        cy.log(value);
         headers.push(value);
       });
     }).then(() => {
@@ -28,7 +27,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   it('Should add notes for the selected tasks', () => {
     const taskNotes = 'Add notes for testing & check it stored';
-    cy.intercept('POST', '/camunda/process-definition/key/noteSubmissionWrapper/submit-form').as('notes');
+    cy.intercept('POST', '/camunda/engine-rest/process-definition/key/noteSubmissionWrapper/submit-form').as('notes');
     cy.fixture('tasks.json').then((task) => {
       let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
@@ -40,9 +39,9 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       });
     });
 
-    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
 
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+    cy.get('p.govuk-body').eq(0).should('contain.text', 'Task not assigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
 
@@ -67,7 +66,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       cy.contains('Add notes for testing & check it stored').should('have.text', taskNotes);
     });
 
-    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim').click();
+    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim task').click();
 
     cy.wait(2000);
   });
@@ -88,7 +87,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       cy.navigateToTaskDetailsPage(tasks);
     });
 
-    cy.get('.govuk-heading-xl').should('have.text', 'Task details');
+    cy.get('.govuk-heading-xl').should('have.text', 'Overview');
 
     cy.get('.formio-component-note textarea').should('not.exist');
   });
@@ -121,7 +120,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       'Dismiss',
     ];
 
-    cy.intercept('POST', '/camunda/task/*/claim').as('claim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
     cy.fixture('tasks.json').then((task) => {
       let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
@@ -133,7 +132,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       });
     });
 
-    cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+    cy.get('p.govuk-body').eq(0).should('contain.text', 'Task not assigned');
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
 
@@ -207,13 +206,13 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   });
 
   it('Should Unclaim a task Successfully from task details page', () => {
-    cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/unclaim').as('unclaim');
 
     cy.getTasksAssignedToMe().then((tasks) => {
       cy.navigateToTaskDetailsPage(tasks);
     });
 
-    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim').click();
+    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim task').click();
 
     cy.wait('@unclaim').then(({ response }) => {
       expect(response.statusCode).to.equal(204);
@@ -302,7 +301,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
         });
 
         cy.intercept('POST', '/camunda/engine-rest/task/*/claim').as('claim');
-        cy.get('p.govuk-body').eq(0).should('contain.text', 'Unassigned');
+        cy.get('p.govuk-body').eq(0).should('contain.text', 'Task not assigned');
 
         cy.get('button.link-button').should('be.visible').and('have.text', 'Claim').click();
 
@@ -349,9 +348,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   it('Should verify all the action buttons not available when task loaded from Complete tab', () => {
     cy.get('a[href="#complete"]').click();
 
-    cy.get('.title-container').eq(0).within(() => {
-      cy.get('a').click();
-    });
+    cy.get('.govuk-task-list-card a').eq(0).click();
 
     cy.get('.task-actions--buttons button').should('not.exist');
 
@@ -362,7 +359,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   it('Should Unclaim a task Successfully from at the end of pages In Progress tab & verify it moved to New tab', () => {
     cy.clock();
-    cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/unclaim').as('unclaim');
 
     cy.getTasksAssignedToMe().then((tasks) => {
       cy.navigateToTaskDetailsPage(tasks);
@@ -370,7 +367,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('.govuk-caption-xl').invoke('text').as('taskName');
 
-    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim').click();
+    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim task').click();
 
     cy.wait('@unclaim').then(({ response }) => {
       expect(response.statusCode).to.equal(204);
@@ -397,7 +394,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   });
 
   it('Should Unclaim a task Successfully from In Progress tab and verify it moved to New tab', () => {
-    cy.intercept('POST', '/camunda/task/*/unclaim').as('unclaim');
+    cy.intercept('POST', '/camunda/engine-rest/task/*/unclaim').as('unclaim');
 
     cy.getTasksAssignedToMe().then((tasks) => {
       cy.navigateToTaskDetailsPage(tasks);
@@ -405,7 +402,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('.govuk-caption-xl').invoke('text').as('taskName');
 
-    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim').click();
+    cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim task').click();
 
     cy.wait('@unclaim').then(({ response }) => {
       expect(response.statusCode).to.equal(204);
@@ -429,7 +426,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it('Vehicle and Trailer - Unknown values in Task List & Task Summary', () => {
+  it.skip('Vehicle and Trailer - Unknown values in Task List & Task Summary', () => {
     cy.fixture('taskInfo-unknown/RoRo-Acc-VehWithTrail-expected.json').as('expTestData');
     cy.fixture('taskInfo-unknown/RoRo-Acc-VehWithTrail.json')
       .then((task) => {
@@ -469,7 +466,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it('Vehicle - Unknown values in Task List and Task summary', () => {
+  it.skip('Vehicle - Unknown values in Task List and Task summary', () => {
     cy.fixture('taskInfo-unknown/RoRo-Acc-VehOnly-expected.json').as('expTestData');
     cy.fixture('/taskInfo-unknown/RoRo-Acc-VehOnly.json')
       .then((task) => {
@@ -508,7 +505,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it('Should display correct values for PERFDRIVER Driver, Booking, Vehicle, tasklist, task summary', () => {
+  it.skip('Should display correct values for PERFDRIVER Driver, Booking, Vehicle, tasklist, task summary', () => {
     cy.fixture('/taskInfo-known/RoRo-Acc-TaskDetails-expected.json').as('expTestData');
     cy.fixture('/taskInfo-known/RoRo-Acc-TaskDetails-known.json')
       .then((task) => {
@@ -552,6 +549,8 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       });
     });
 
+    cy.intercept('POST', '/camunda/v1/targeting-tasks/pages').as('tasks');
+
     cy.getTasksAssignedToSpecificUser('boothi.palanisamy@digital.homeoffice.gov.uk').then((tasks) => {
       cy.navigateToTaskDetailsPage(tasks);
     });
@@ -564,7 +563,9 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('a[href="#inProgress"]').click();
 
-    cy.waitForTaskManagementPageToLoad();
+    cy.wait('@tasks').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
 
     cy.get('@taskName').then((text) => {
       const nextPage = 'a[data-test="next"]';
@@ -580,7 +581,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
     });
   });
 
-  it('Setting drivers when no driver or multiple drivers exist', () => {
+  it.skip('Setting drivers when no driver or multiple drivers exist', () => {
     let jsonFolder = '/drivers/';
     let expDriverForPayload = [
       ['driverAndMultiplePass.json', 'Joanne Flower'],
@@ -601,7 +602,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
             .then((response) => {
               cy.wait(4000);
               cy.checkTaskDisplayed(`${response.businessKey}`);
-              cy.get('h2:contains(Driver)')
+              cy.get('h3:contains(Driver)')
                 .parent('div')
                 .within(() => {
                   cy.get('dt')

--- a/cypress/integration/cerberus/task-risk-score-verify.spec.js
+++ b/cypress/integration/cerberus/task-risk-score-verify.spec.js
@@ -8,6 +8,7 @@ describe('View total Risk score from Targeting Indicators in the task list Page'
     cy.getBusinessKey('-RORO-Accompanied-Freight-target-indicators-same-version_').then((businessKeys) => {
       expect(businessKeys.length).to.not.equal(0);
       cy.verifyTaskListInfo(`${businessKeys[0]}`).then((taskListDetails) => {
+        console.log(taskListDetails);
         expect('Risk Score: 50').to.deep.equal(taskListDetails.riskScore);
       });
     });
@@ -38,7 +39,7 @@ describe('View total Risk score from Targeting Indicators in the task list Page'
     cy.getBusinessKey('-RORO-Unaccompanied-Freight-RoRo-UNACC-SBT_').then((businessKeys) => {
       expect(businessKeys.length).to.not.equal(0);
       cy.verifyTaskListInfo(`${businessKeys[0]}`).then((taskListDetails) => {
-        expect('Risk Score:').to.deep.equal(taskListDetails.riskScore);
+        expect('Risk Score: 0').to.deep.equal(taskListDetails.riskScore);
       });
     });
   });

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -23,8 +23,6 @@ describe('Task Details of different tasks on task details Page', () => {
       });
     });
 
-    cy.visit('/tasks/AUTOTEST-24-12-2021-RORO-Unaccompanied-Freight-VERSION-DETAILS_454991:CMID=TEST');
-
     cy.wait(2000);
     cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'true');
     cy.expandTaskDetails(0);
@@ -732,12 +730,21 @@ describe('Task Details of different tasks on task details Page', () => {
       });
     });
 
+    const nextPage = 'a[data-test="next"]';
     cy.visit('/tasks');
-    cy.findTaskInAllThePages(businessKey, null, null).then(() => {
-      cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-        cy.wrap(element).find('.govuk-tag--updatedTarget').should('not.exist');
+    if (Cypress.$(nextPage).length > 0) {
+      cy.findTaskInAllThePages(businessKey, null, null).then(() => {
+        cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
+          cy.wrap(element).find('.govuk-tag--updatedTarget').should('not.exist');
+        });
       });
-    });
+    } else {
+      cy.findTaskInSinglePage(businessKey, null, null).then(() => {
+        cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
+          cy.wrap(element).find('.govuk-tag--updatedTarget').should('not.exist');
+        });
+      });
+    }
   });
 
   // COP-6905 Scenario-3

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -408,12 +408,7 @@ describe('Task Details of different tasks on task details Page', () => {
       cy.wrap(version).invoke('attr', 'aria-expanded').should('equal', expectedDefaultExpandStatus[index]);
     });
 
-    cy.visit('/tasks');
-    cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-      cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
-        expect(taskUpdated).to.be.equal('Updated');
-      });
-    });
+    cy.verifyTaskHasMultipleVersion(businessKey);
   });
 
   it('Should verify task details on each version retained', () => {
@@ -522,20 +517,14 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.postTasksInParallel(tasks).then((response) => {
       cy.wait(15000);
       cy.checkTaskDisplayed(`${response.businessKey}`);
-      let encodedBusinessKey = encodeURIComponent(`${response.businessKey}`);
-      cy.getAllProcessInstanceId(encodedBusinessKey).then((res) => {
+      cy.getAllProcessInstanceId(`${response.businessKey}`).then((res) => {
         expect(res.body.length).to.not.equal(0);
         expect(res.body.length).to.equal(1);
       });
     });
     cy.get('.govuk-accordion__section-heading').should('have.length', 3);
 
-    cy.visit('/tasks');
-    cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-      cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
-        expect(taskUpdated).to.be.equal('Updated');
-      });
-    });
+    cy.verifyTaskHasMultipleVersion(businessKey);
   });
 
   it('Should verify single task created for the same target with different versions when Failed Cerberus payloads sent without delay', () => {
@@ -661,12 +650,7 @@ describe('Task Details of different tasks on task details Page', () => {
 
     cy.get('.govuk-accordion__section-heading').should('have.length', 3);
 
-    cy.visit('/tasks');
-    cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-      cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
-        expect(taskUpdated).to.be.equal('Updated');
-      });
-    });
+    cy.verifyTaskHasMultipleVersion(businessKey);
   });
 
   // COP-8934 two versions have passenger details and one version doesn't have passenger details
@@ -749,8 +733,10 @@ describe('Task Details of different tasks on task details Page', () => {
     });
 
     cy.visit('/tasks');
-    cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-      cy.wrap(element).find('.govuk-tag--updatedTarget').should('not.exist');
+    cy.findTaskInAllThePages(businessKey, null, null).then(() => {
+      cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
+        cy.wrap(element).find('.govuk-tag--updatedTarget').should('not.exist');
+      });
     });
   });
 

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -23,56 +23,64 @@ describe('Task Details of different tasks on task details Page', () => {
       });
     });
 
+    cy.visit('/tasks/AUTOTEST-24-12-2021-RORO-Unaccompanied-Freight-VERSION-DETAILS_454991:CMID=TEST');
+
     cy.wait(2000);
     cy.get('.govuk-accordion__section-button').invoke('attr', 'aria-expanded').should('equal', 'true');
     cy.expandTaskDetails(0);
 
     cy.fixture('unaccompanied-task-details.json').then((expectedDetails) => {
-      cy.contains('h2', 'Account details').next().within(() => {
+      cy.contains('h3', 'Account details').next().within(() => {
         cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.account);
+          console.log(expectedDetails.account);
+          console.log('actual', details);
+          expect(expectedDetails.account).to.deep.equal(details);
         });
       });
 
-      cy.contains('h2', 'Haulier details').next().within(() => {
+      cy.contains('h3', 'Haulier details').next().within(() => {
         cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.haulier);
+          expect(expectedDetails.haulier).to.deep.equal(details);
         });
       });
 
-      cy.contains('h2', 'Driver').next().within(() => {
+      cy.contains('h3', 'Driver').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.driver);
         });
       });
 
-      cy.contains('h2', 'Goods').next().within(() => {
+      cy.contains('h3', 'Goods').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.goods);
         });
       });
 
-      cy.contains('h2', 'Booking and check-in').next().within(() => {
+      cy.contains('h3', 'Booking and check-in').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
         });
       });
 
-      cy.contains('h2', 'Targeting indicators').nextAll().within(() => {
-        cy.get('.govuk-summary-list__key').eq(1).invoke('text').then((numberOfIndicators) => {
-          expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
-        });
-        cy.get('.govuk-summary-list__value').eq(1).invoke('text').then((totalScore) => {
-          expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+      cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+        cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+          cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+            expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
+          });
+          cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+            expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+          });
         });
 
-        cy.getTaskDetails().then((details) => {
-          delete details.Indicator;
-          expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+        cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+          cy.getTargetIndicatorDetails().then((details) => {
+            delete details.Indicator;
+            expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+          });
         });
       });
 
-      cy.contains('h2', '2 selector matches').then((locator) => {
+      cy.contains('h3', '2 selector matches').then((locator) => {
         cy.getAllSelectorMatches(locator).then((actualSelectorMatches) => {
           expect(actualSelectorMatches).to.deep.equal(expectedDetails.selector_matches);
         });
@@ -115,53 +123,57 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.expandTaskDetails(0);
 
     cy.fixture('accompanied-task-details.json').then((expectedDetails) => {
-      cy.contains('h2', 'Vehicle details').next().within(() => {
-        cy.getTaskDetails().then((details) => {
+      cy.contains('h3', 'Vehicle').next().within((elements) => {
+        cy.getVehicleDetails(elements).then((details) => {
           expect(details).to.deep.equal(expectedDetails.vehicle);
         });
       });
 
-      cy.contains('h2', 'Account details').next().within(() => {
+      cy.contains('h3', 'Account details').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.account);
         });
       });
 
-      cy.contains('h2', 'Haulier details').next().within(() => {
+      cy.contains('h3', 'Haulier details').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.haulier);
         });
       });
 
-      cy.contains('h2', 'Driver').next().within(() => {
+      cy.contains('h3', 'Driver').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.driver);
         });
       });
 
-      cy.contains('h2', 'Goods').next().within(() => {
+      cy.contains('h3', 'Goods').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.goods);
         });
       });
 
-      cy.contains('h2', 'Booking and check-in').next().within(() => {
+      cy.contains('h3', 'Booking and check-in').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
         });
       });
 
-      cy.contains('h2', 'Targeting indicators').nextAll().within(() => {
-        cy.get('.govuk-summary-list__key').eq(1).invoke('text').then((numberOfIndicators) => {
-          expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
-        });
-        cy.get('.govuk-summary-list__value').eq(1).invoke('text').then((totalScore) => {
-          expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+      cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+        cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+          cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+            expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
+          });
+          cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+            expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+          });
         });
 
-        cy.getTaskDetails().then((details) => {
-          delete details.Indicator;
-          expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+        cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+          cy.getTargetIndicatorDetails().then((details) => {
+            delete details.Indicator;
+            expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+          });
         });
       });
     });
@@ -186,25 +198,32 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.expandTaskDetails(0);
 
     cy.fixture('tourist-task-details.json').then((expectedDetails) => {
-      cy.contains('h2', 'Vehicle details').next().within(() => {
-        cy.getTaskDetails().then((details) => {
+      cy.contains('h3', 'Vehicle').next().within((elements) => {
+        cy.getVehicleDetails(elements).then((details) => {
           expect(details).to.deep.equal(expectedDetails.vehicle);
         });
       });
 
-      cy.contains('h2', 'Driver').next().within(() => {
+      cy.contains('h3', 'Driver').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.driver);
         });
       });
 
-      cy.contains('h2', 'Passengers').next().within(() => {
-        cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.passengers);
+      cy.contains('h3', 'Occupants').nextAll().within(() => {
+        cy.contains('h3', 'Passengers').next().within(() => {
+          cy.getTaskDetails().then((details) => {
+            expect(details).to.deep.equal(expectedDetails.passengers[0]);
+          });
+        });
+        cy.get('.govuk-hidden-passengers').within(() => {
+          cy.getTaskDetails().then((details) => {
+            expect(details).to.deep.equal(expectedDetails.passengers[1]);
+          });
         });
       });
 
-      cy.contains('h2', 'Booking and check-in').next().within(() => {
+      cy.contains('h3', 'Booking and check-in').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
         });
@@ -233,59 +252,70 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.expandTaskDetails(0);
 
     cy.fixture('accompanied-task-2-passengers-details.json').then((expectedDetails) => {
-      cy.contains('h2', 'Vehicle details').next().within(() => {
-        cy.getTaskDetails().then((details) => {
+      cy.contains('h3', 'Vehicle').next().within((elements) => {
+        cy.getVehicleDetails(elements).then((details) => {
           expect(details).to.deep.equal(expectedDetails.vehicle);
         });
       });
 
-      cy.contains('h2', 'Account details').next().within(() => {
+      cy.contains('h3', 'Account details').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.account);
         });
       });
 
-      cy.contains('h2', 'Haulier details').next().within(() => {
+      cy.contains('h3', 'Haulier details').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.haulier);
         });
       });
 
-      cy.contains('h2', 'Driver').next().within(() => {
+      cy.contains('h3', 'Driver').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.driver);
         });
       });
 
-      cy.contains('h2', 'Passengers').next().within(() => {
-        cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.passengers);
+      cy.contains('h3', 'Occupants').nextAll().within(() => {
+        cy.contains('h3', 'Passengers').next().within(() => {
+          cy.getTaskDetails().then((details) => {
+            expect(details).to.deep.equal(expectedDetails.passengers[0]);
+          });
+        });
+        cy.get('.govuk-hidden-passengers').within(() => {
+          cy.getTaskDetails().then((details) => {
+            expect(details).to.deep.equal(expectedDetails.passengers[1]);
+          });
         });
       });
 
-      cy.contains('h2', 'Goods').next().within(() => {
+      cy.contains('h3', 'Goods').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails.goods);
         });
       });
 
-      cy.contains('h2', 'Booking and check-in').next().within(() => {
+      cy.contains('h3', 'Booking and check-in').next().within(() => {
         cy.getTaskDetails().then((details) => {
           expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
         });
       });
 
-      cy.contains('h2', 'Targeting indicators').nextAll().within(() => {
-        cy.get('.govuk-summary-list__key').eq(1).invoke('text').then((numberOfIndicators) => {
-          expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
-        });
-        cy.get('.govuk-summary-list__value').eq(1).invoke('text').then((totalScore) => {
-          expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+      cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+        cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+          cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+            expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
+          });
+          cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+            expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+          });
         });
 
-        cy.getTaskDetails().then((details) => {
-          delete details.Indicator;
-          expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+        cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+          cy.getTargetIndicatorDetails().then((details) => {
+            delete details.Indicator;
+            expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+          });
         });
       });
 
@@ -335,8 +365,7 @@ describe('Task Details of different tasks on task details Page', () => {
       cy.postTasks(task, null).then((response) => {
         cy.wait(15000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
-        let encodedBusinessKey = encodeURIComponent(`${response.businessKey}`);
-        cy.getAllProcessInstanceId(encodedBusinessKey).then((res) => {
+        cy.getAllProcessInstanceId(`${response.businessKey}`).then((res) => {
           expect(res.body.length).to.not.equal(0);
           expect(res.body.length).to.equal(1);
         });
@@ -565,7 +594,6 @@ describe('Task Details of different tasks on task details Page', () => {
     const businessKey = `AUTOTEST-${dateNowFormatted}-RORO-Accompanied-Freight-passenger-info_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
     let departureDateTime;
     let arrivalDataTime;
-    let bookingDateTime;
     const dateFormat = 'D MMM YYYY [at] HH:mm';
 
     date.setDate(date.getDate() + 8);
@@ -607,7 +635,6 @@ describe('Task Details of different tasks on task details Page', () => {
       departureDateTime = Cypress.dayjs(departureDateTime).utc().format(dateFormat);
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualDepartureTimestamp = Cypress.dayjs().add(13, 'day').valueOf();
       task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime = Cypress.dayjs().format('YYYY-MM-DDThh:mm:ss');
-      bookingDateTime = Cypress.dayjs(task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime).utc().format(dateFormat);
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, null).then((response) => {
         cy.wait(15000);
@@ -620,10 +647,10 @@ describe('Task Details of different tasks on task details Page', () => {
         // COP-9368 Latest departure date/time should be displayed in UI for tasks with multiple versions
         let expectedTaskSummary = {
           'Ferry': 'DFDS voyage of DOVER SEAWAYS',
-          'Departure': `DOV, ${departureDateTime}`,
-          'Arrival': `CAL, ${arrivalDataTime}`,
-          'Account': `Univeral Printers Ltd, booked on ${bookingDateTime}`,
-          'Haulier': 'Matthesons',
+          'Departure': `${departureDateTime}   DOV`,
+          'Arrival': `CAL      ${arrivalDataTime}`,
+          'vehicle': 'Vehicle with TrailerGB09KLT-10685 with NL-234-392 driven by Bobby Brownshoes',
+          'Account': 'Arrival 8 days before travel',
         };
 
         cy.checkTaskSummaryDetails().then((taskSummary) => {
@@ -703,17 +730,21 @@ describe('Task Details of different tasks on task details Page', () => {
       },
     };
 
-    cy.contains('h2', 'Targeting indicators').nextAll().within(() => {
-      cy.get('.govuk-summary-list__key').eq(1).invoke('text').then((numberOfIndicators) => {
-        expect(numberOfIndicators).to.be.equal(expectedDetails['Total Indicators']);
-      });
-      cy.get('.govuk-summary-list__value').eq(1).invoke('text').then((totalScore) => {
-        expect(totalScore).to.be.equal(expectedDetails['Total Score']);
+    cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+      cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+        cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+          expect(numberOfIndicators).to.be.equal(expectedDetails['Total Indicators']);
+        });
+        cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+          expect(totalScore).to.be.equal(expectedDetails['Total Score']);
+        });
       });
 
-      cy.getTaskDetails().then((details) => {
-        delete details.Indicator;
-        expect(details).to.deep.equal(expectedDetails.indicators);
+      cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+        cy.getTargetIndicatorDetails().then((details) => {
+          delete details.Indicator;
+          expect(details).to.deep.equal(expectedDetails.indicators);
+        });
       });
     });
 
@@ -783,17 +814,21 @@ describe('Task Details of different tasks on task details Page', () => {
       },
     };
 
-    cy.contains('h2', 'Targeting indicators').nextAll().within(() => {
-      cy.get('.govuk-summary-list__key').eq(1).invoke('text').then((numberOfIndicators) => {
-        expect(numberOfIndicators).to.be.equal(expectedDetails['Total Indicators']);
-      });
-      cy.get('.govuk-summary-list__value').eq(1).invoke('text').then((totalScore) => {
-        expect(totalScore).to.be.equal(expectedDetails['Total Score']);
+    cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+      cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+        cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+          expect(numberOfIndicators).to.be.equal(expectedDetails['Total Indicators']);
+        });
+        cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+          expect(totalScore).to.be.equal(expectedDetails['Total Score']);
+        });
       });
 
-      cy.getTaskDetails().then((details) => {
-        delete details.Indicator;
-        expect(details).to.deep.equal(expectedDetails.indicators);
+      cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+        cy.getTargetIndicatorDetails().then((details) => {
+          delete details.Indicator;
+          expect(details).to.deep.equal(expectedDetails.indicators);
+        });
       });
     });
 
@@ -848,17 +883,21 @@ describe('Task Details of different tasks on task details Page', () => {
       },
     };
 
-    cy.contains('h2', 'Targeting indicators').nextAll().within(() => {
-      cy.get('.govuk-summary-list__key').eq(1).invoke('text').then((numberOfIndicators) => {
-        expect(numberOfIndicators).to.be.equal(expectedDetails['Total Indicators']);
-      });
-      cy.get('.govuk-summary-list__value').eq(1).invoke('text').then((totalScore) => {
-        expect(totalScore).to.be.equal(expectedDetails['Total Score']);
+    cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+      cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+        cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+          expect(numberOfIndicators).to.be.equal(expectedDetails['Total Indicators']);
+        });
+        cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+          expect(totalScore).to.be.equal(expectedDetails['Total Score']);
+        });
       });
 
-      cy.getTaskDetails().then((details) => {
-        delete details.Indicator;
-        expect(details).to.deep.equal(expectedDetails.indicators);
+      cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+        cy.getTargetIndicatorDetails().then((details) => {
+          delete details.Indicator;
+          expect(details).to.deep.equal(expectedDetails.indicators);
+        });
       });
     });
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1127,12 +1127,23 @@ Cypress.Commands.add('getAllSelectorMatches', (locator) => {
 });
 
 Cypress.Commands.add('verifyTaskHasMultipleVersion', (businessKey) => {
+  const nextPage = 'a[data-test="next"]';
   cy.visit('/tasks');
-  cy.findTaskInAllThePages(businessKey, null, null).then(() => {
-    cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-      cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
-        expect(taskUpdated).to.be.equal('Updated');
+  if (Cypress.$(nextPage).length > 0) {
+    cy.findTaskInAllThePages(businessKey, null, null).then(() => {
+      cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
+        cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
+          expect(taskUpdated).to.be.equal('Updated');
+        });
       });
     });
-  });
+  } else {
+    cy.findTaskInSinglePage(businessKey, null, null).then(() => {
+      cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
+        cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
+          expect(taskUpdated).to.be.equal('Updated');
+        });
+      });
+    });
+  }
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -717,15 +717,11 @@ Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
   cy.visit('/tasks');
   if (Cypress.$(nextPage).length > 0) {
     cy.findTaskInAllThePages(businessKey, null, null).then(() => {
-      getTaskSummary(businessKey).then((taskSummary) => {
-        return taskSummary;
-      });
+      return getTaskSummary(businessKey);
     });
   } else {
     cy.findTaskInSinglePage(businessKey, null, null).then(() => {
-      getTaskSummary(businessKey).then((taskSummary) => {
-        return taskSummary;
-      });
+      return getTaskSummary(businessKey);
     });
   }
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1120,3 +1120,14 @@ Cypress.Commands.add('getAllSelectorMatches', (locator) => {
       return actualSelectorMatches;
     });
 });
+
+Cypress.Commands.add('verifyTaskHasMultipleVersion', (businessKey) => {
+  cy.visit('/tasks');
+  cy.findTaskInAllThePages(businessKey, null, null).then(() => {
+    cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
+      cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
+        expect(taskUpdated).to.be.equal('Updated');
+      });
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -599,120 +599,135 @@ Cypress.Commands.add('verifyTaskSummary', (taskSummary) => {
   cy.get('.card').should('contain.text', taskSummary);
 });
 
-Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
+function getTaskSummary(businessKey) {
   let taskSummary = {};
+  cy.get('.govuk-task-list-card').contains(businessKey).parents('.card-container').within((element) => {
+    cy.wrap(element).find('h3.task-heading').invoke('text').then((mode) => {
+      taskSummary.mode = mode;
+    });
+    cy.wrap(element).find('.task-risk-statement').invoke('text').then((rules) => {
+      taskSummary.rules = rules;
+    });
+
+    cy.wrap(element).find('.content-line-one').then(($voyage) => {
+      let value = $voyage.text();
+      taskSummary.voyage = (value.split(',')[0].trim());
+      taskSummary.arrival = (value.split(',')[1].trim());
+    });
+
+    cy.wrap(element).find('.content-line-two').then(($dateTime) => {
+      let value = $dateTime.text();
+      let departure = (value.split('-')[0].trim());
+      let arrival = (value.split('-')[1].trim());
+      taskSummary.departurePort = departure.slice(-3).trim();
+      taskSummary.departureDateTime = departure.slice(0, departure.length - 3).trim();
+      taskSummary.arrivalPort = arrival.slice(0, 3).trim();
+      taskSummary.arrivalDateTime = arrival.slice(3, arrival.length).trim();
+    });
+
+    cy.wrap(element).contains('Driver details').next().then((driverDetails) => {
+      cy.wrap(driverDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.driverFirstName = info;
+          } else if (index === 1) {
+            taskSummary.driverLastName = info;
+          } else {
+            taskSummary.driverNumberOfTrips = info;
+          }
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Vehicle details').next().then((vehicleDetails) => {
+      cy.wrap(vehicleDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.vehicleRegistration = info;
+          } else if (index === 1) {
+            taskSummary.vehicleMake = info;
+          } else if (index === 2) {
+            taskSummary.vehicleModel = info;
+          } else {
+            taskSummary.vehicleNumberOfTrips = info;
+          }
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Account details').next().then((accountDetails) => {
+      cy.wrap(accountDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.bookedDateTime = info;
+          } else {
+            taskSummary.bookedDetails = info;
+          }
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Haulier details').next().then((haulierDetails) => {
+      cy.wrap(haulierDetails).find('li').each((details) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          taskSummary.haulier = info;
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Goods description').next().then((goodsDetails) => {
+      cy.wrap(goodsDetails).find('li').each((details) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          taskSummary.goods = info;
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Passenger details').next().then((passengerDetails) => {
+      cy.wrap(passengerDetails).find('li').each((details) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          taskSummary.passengerDetails = info;
+        });
+      });
+    });
+
+    cy.wrap(element).contains('Trailer details').next().then((trailerDetails) => {
+      cy.wrap(trailerDetails).find('li').each((details, index) => {
+        cy.wrap(details).invoke('text').then((info) => {
+          if (index === 0) {
+            taskSummary.trailerRegitration = info;
+          } else {
+            taskSummary.trailerTrips = info;
+          }
+        });
+      });
+    });
+
+    cy.wrap(element).find('.task-labels-item strong').invoke('text').then((riskScore) => {
+      taskSummary.riskScore = riskScore;
+    });
+  })
+    .then(() => {
+      return taskSummary;
+    });
+}
+
+Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
+  const nextPage = 'a[data-test="next"]';
   cy.visit('/tasks');
-  cy.findTaskInAllThePages(businessKey, null, null).then(() => {
-    cy.get('.govuk-task-list-card').contains(businessKey).parents('.card-container').within((element) => {
-      cy.wrap(element).find('h3.task-heading').invoke('text').then((mode) => {
-        taskSummary.mode = mode;
-      });
-      cy.wrap(element).find('.task-risk-statement').invoke('text').then((rules) => {
-        taskSummary.rules = rules;
-      });
-
-      cy.wrap(element).find('.content-line-one').then(($voyage) => {
-        let value = $voyage.text();
-        taskSummary.voyage = (value.split(',')[0].trim());
-        taskSummary.arrival = (value.split(',')[1].trim());
-      });
-
-      cy.wrap(element).find('.content-line-two').then(($dateTime) => {
-        let value = $dateTime.text();
-        let departure = (value.split('-')[0].trim());
-        let arrival = (value.split('-')[1].trim());
-        taskSummary.departurePort = departure.slice(-3).trim();
-        taskSummary.departureDateTime = departure.slice(0, departure.length - 3).trim();
-        taskSummary.arrivalPort = arrival.slice(0, 3).trim();
-        taskSummary.arrivalDateTime = arrival.slice(3, arrival.length).trim();
-      });
-
-      cy.wrap(element).contains('Driver details').next().then((driverDetails) => {
-        cy.wrap(driverDetails).find('li').each((details, index) => {
-          cy.wrap(details).invoke('text').then((info) => {
-            if (index === 0) {
-              taskSummary.driverFirstName = info;
-            } else if (index === 1) {
-              taskSummary.driverLastName = info;
-            } else {
-              taskSummary.driverNumberOfTrips = info;
-            }
-          });
-        });
-      });
-
-      cy.wrap(element).contains('Vehicle details').next().then((vehicleDetails) => {
-        cy.wrap(vehicleDetails).find('li').each((details, index) => {
-          cy.wrap(details).invoke('text').then((info) => {
-            if (index === 0) {
-              taskSummary.vehicleRegistration = info;
-            } else if (index === 1) {
-              taskSummary.vehicleMake = info;
-            } else if (index === 2) {
-              taskSummary.vehicleModel = info;
-            } else {
-              taskSummary.vehicleNumberOfTrips = info;
-            }
-          });
-        });
-      });
-
-      cy.wrap(element).contains('Account details').next().then((accountDetails) => {
-        cy.wrap(accountDetails).find('li').each((details, index) => {
-          cy.wrap(details).invoke('text').then((info) => {
-            if (index === 0) {
-              taskSummary.bookedDateTime = info;
-            } else {
-              taskSummary.bookedDetails = info;
-            }
-          });
-        });
-      });
-
-      cy.wrap(element).contains('Haulier details').next().then((haulierDetails) => {
-        cy.wrap(haulierDetails).find('li').each((details) => {
-          cy.wrap(details).invoke('text').then((info) => {
-            taskSummary.haulier = info;
-          });
-        });
-      });
-
-      cy.wrap(element).contains('Goods description').next().then((goodsDetails) => {
-        cy.wrap(goodsDetails).find('li').each((details) => {
-          cy.wrap(details).invoke('text').then((info) => {
-            taskSummary.goods = info;
-          });
-        });
-      });
-
-      cy.wrap(element).contains('Passenger details').next().then((passengerDetails) => {
-        cy.wrap(passengerDetails).find('li').each((details) => {
-          cy.wrap(details).invoke('text').then((info) => {
-            taskSummary.passengerDetails = info;
-          });
-        });
-      });
-
-      cy.wrap(element).contains('Trailer details').next().then((trailerDetails) => {
-        cy.wrap(trailerDetails).find('li').each((details, index) => {
-          cy.wrap(details).invoke('text').then((info) => {
-            if (index === 0) {
-              taskSummary.trailerRegitration = info;
-            } else {
-              taskSummary.trailerTrips = info;
-            }
-          });
-        });
-      });
-
-      cy.wrap(element).find('.task-labels-item strong').invoke('text').then((riskScore) => {
-        taskSummary.riskScore = riskScore;
-      });
-    })
-      .then(() => {
+  if (Cypress.$(nextPage).length > 0) {
+    cy.findTaskInAllThePages(businessKey, null, null).then(() => {
+      getTaskSummary(businessKey).then((taskSummary) => {
         return taskSummary;
       });
-  });
+    });
+  } else {
+    cy.findTaskInSinglePage(businessKey, null, null).then(() => {
+      getTaskSummary(businessKey).then((taskSummary) => {
+        return taskSummary;
+      });
+    });
+  }
 });
 
 Cypress.Commands.add('verifyTaskDetailSection', (expData, versionInRow, sectionname) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -602,123 +602,117 @@ Cypress.Commands.add('verifyTaskSummary', (taskSummary) => {
 Cypress.Commands.add('verifyTaskListInfo', (businessKey) => {
   let taskSummary = {};
   cy.visit('/tasks');
-  cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-    cy.wrap(element).find('h3.task-heading').invoke('text').then((mode) => {
-      taskSummary.mode = mode;
-    });
-    cy.wrap(element).find('.task-risk-statement').invoke('text').then((rules) => {
-      taskSummary.rules = rules;
-    });
-
-    cy.wrap(element).find('.content-line-one li').each((section, index) => {
-      cy.wrap(section).invoke('text').then((info) => {
-        if (index === 0) {
-          taskSummary.voyage = info;
-        } else {
-          taskSummary.arrival = info;
-        }
+  cy.findTaskInAllThePages(businessKey, null, null).then(() => {
+    cy.get('.govuk-task-list-card').contains(businessKey).parents('.card-container').within((element) => {
+      cy.wrap(element).find('h3.task-heading').invoke('text').then((mode) => {
+        taskSummary.mode = mode;
       });
-    });
-
-    cy.wrap(element).find('.content-line-two li').each((section, index) => {
-      cy.wrap(section).invoke('text').then((info) => {
-        if (index === 0) {
-          taskSummary.departurePort = info;
-        } else if (index === 1) {
-          taskSummary.departureDateTime = info;
-        } else if (index === 2) {
-          taskSummary.arrivalPort = info;
-        } else {
-          taskSummary.arrivalDateTime = info;
-        }
+      cy.wrap(element).find('.task-risk-statement').invoke('text').then((rules) => {
+        taskSummary.rules = rules;
       });
-    });
 
-    cy.wrap(element).contains('Driver details').next().then((driverDetails) => {
-      cy.wrap(driverDetails).find('li').each((details, index) => {
-        cy.wrap(details).invoke('text').then((info) => {
-          if (index === 0) {
-            taskSummary.driverFirstName = info;
-          } else if (index === 1) {
-            taskSummary.driverLastName = info;
-          } else {
-            taskSummary.driverNumberOfTrips = info;
-          }
+      cy.wrap(element).find('.content-line-one').then(($voyage) => {
+        let value = $voyage.text();
+        taskSummary.voyage = (value.split(',')[0].trim());
+        taskSummary.arrival = (value.split(',')[1].trim());
+      });
+
+      cy.wrap(element).find('.content-line-two').then(($dateTime) => {
+        let value = $dateTime.text();
+        let departure = (value.split('-')[0].trim());
+        let arrival = (value.split('-')[1].trim());
+        taskSummary.departurePort = departure.slice(-3).trim();
+        taskSummary.departureDateTime = departure.slice(0, departure.length - 3).trim();
+        taskSummary.arrivalPort = arrival.slice(0, 3).trim();
+        taskSummary.arrivalDateTime = arrival.slice(3, arrival.length).trim();
+      });
+
+      cy.wrap(element).contains('Driver details').next().then((driverDetails) => {
+        cy.wrap(driverDetails).find('li').each((details, index) => {
+          cy.wrap(details).invoke('text').then((info) => {
+            if (index === 0) {
+              taskSummary.driverFirstName = info;
+            } else if (index === 1) {
+              taskSummary.driverLastName = info;
+            } else {
+              taskSummary.driverNumberOfTrips = info;
+            }
+          });
         });
       });
-    });
 
-    cy.wrap(element).contains('Vehicle details').next().then((vehicleDetails) => {
-      cy.wrap(vehicleDetails).find('li').each((details, index) => {
-        cy.wrap(details).invoke('text').then((info) => {
-          if (index === 0) {
-            taskSummary.vehicleRegistration = info;
-          } else if (index === 1) {
-            taskSummary.vehicleMake = info;
-          } else if (index === 2) {
-            taskSummary.vehicleModel = info;
-          } else {
-            taskSummary.vehicleNumberOfTrips = info;
-          }
+      cy.wrap(element).contains('Vehicle details').next().then((vehicleDetails) => {
+        cy.wrap(vehicleDetails).find('li').each((details, index) => {
+          cy.wrap(details).invoke('text').then((info) => {
+            if (index === 0) {
+              taskSummary.vehicleRegistration = info;
+            } else if (index === 1) {
+              taskSummary.vehicleMake = info;
+            } else if (index === 2) {
+              taskSummary.vehicleModel = info;
+            } else {
+              taskSummary.vehicleNumberOfTrips = info;
+            }
+          });
         });
       });
-    });
 
-    cy.wrap(element).contains('Account details').next().then((accountDetails) => {
-      cy.wrap(accountDetails).find('li').each((details, index) => {
-        cy.wrap(details).invoke('text').then((info) => {
-          if (index === 0) {
-            taskSummary.bookedDateTime = info;
-          } else {
-            taskSummary.bookedDetails = info;
-          }
+      cy.wrap(element).contains('Account details').next().then((accountDetails) => {
+        cy.wrap(accountDetails).find('li').each((details, index) => {
+          cy.wrap(details).invoke('text').then((info) => {
+            if (index === 0) {
+              taskSummary.bookedDateTime = info;
+            } else {
+              taskSummary.bookedDetails = info;
+            }
+          });
         });
       });
-    });
 
-    cy.wrap(element).contains('Haulier details').next().then((haulierDetails) => {
-      cy.wrap(haulierDetails).find('li').each((details) => {
-        cy.wrap(details).invoke('text').then((info) => {
-          taskSummary.haulier = info;
+      cy.wrap(element).contains('Haulier details').next().then((haulierDetails) => {
+        cy.wrap(haulierDetails).find('li').each((details) => {
+          cy.wrap(details).invoke('text').then((info) => {
+            taskSummary.haulier = info;
+          });
         });
       });
-    });
 
-    cy.wrap(element).contains('Goods description').next().then((goodsDetails) => {
-      cy.wrap(goodsDetails).find('li').each((details) => {
-        cy.wrap(details).invoke('text').then((info) => {
-          taskSummary.goods = info;
+      cy.wrap(element).contains('Goods description').next().then((goodsDetails) => {
+        cy.wrap(goodsDetails).find('li').each((details) => {
+          cy.wrap(details).invoke('text').then((info) => {
+            taskSummary.goods = info;
+          });
         });
       });
-    });
 
-    cy.wrap(element).contains('Passenger details').next().then((passengerDetails) => {
-      cy.wrap(passengerDetails).find('li').each((details) => {
-        cy.wrap(details).invoke('text').then((info) => {
-          taskSummary.passengerDetails = info;
+      cy.wrap(element).contains('Passenger details').next().then((passengerDetails) => {
+        cy.wrap(passengerDetails).find('li').each((details) => {
+          cy.wrap(details).invoke('text').then((info) => {
+            taskSummary.passengerDetails = info;
+          });
         });
       });
-    });
 
-    cy.wrap(element).contains('Trailer details').next().then((trailerDetails) => {
-      cy.wrap(trailerDetails).find('li').each((details, index) => {
-        cy.wrap(details).invoke('text').then((info) => {
-          if (index === 0) {
-            taskSummary.trailerRegitration = info;
-          } else {
-            taskSummary.trailerTrips = info;
-          }
+      cy.wrap(element).contains('Trailer details').next().then((trailerDetails) => {
+        cy.wrap(trailerDetails).find('li').each((details, index) => {
+          cy.wrap(details).invoke('text').then((info) => {
+            if (index === 0) {
+              taskSummary.trailerRegitration = info;
+            } else {
+              taskSummary.trailerTrips = info;
+            }
+          });
         });
       });
-    });
 
-    cy.wrap(element).find('.task-labels-item strong').invoke('text').then((riskScore) => {
-      taskSummary.riskScore = riskScore;
-    });
-  })
-    .then(() => {
-      return taskSummary;
-    });
+      cy.wrap(element).find('.task-labels-item strong').invoke('text').then((riskScore) => {
+        taskSummary.riskScore = riskScore;
+      });
+    })
+      .then(() => {
+        return taskSummary;
+      });
+  });
 });
 
 Cypress.Commands.add('verifyTaskDetailSection', (expData, versionInRow, sectionname) => {
@@ -1024,7 +1018,7 @@ Cypress.Commands.add('applySelectorFilter', (filterOptions, taskType) => {
 });
 
 Cypress.Commands.add('verifyBookingDateTime', (expectedBookingDateTime) => {
-  cy.contains('h2', 'Booking and check-in').next().within(() => {
+  cy.contains('h3', 'Booking and check-in').next().within(() => {
     cy.getTaskDetails().then((details) => {
       const bookingDateTime = Object.fromEntries(Object.entries(details).filter(([key]) => key.includes('Date and time')));
       expect(bookingDateTime['Date and time']).to.be.equal(expectedBookingDateTime);


### PR DESCRIPTION
## Description
Update automation tests to inline with latest API and UI changes

## To Test
npm run cypress:test:report -- -b electron

note: some of the tests still failing due to `selector` section not available on task details page

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
