### PR TITLE
COP-9210: Add Pre arrival modes filter tests to adapt checkboxes

### DIFF
--- a/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
@@ -239,6 +239,65 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     });
   });
 
+  it('Should apply more than one pre-arrival filter modes on newly created tasks', () => {
+    let actualTotalTargets = 0;
+
+    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+      actualTotalTargets = numberOfTasks.new;
+    });
+
+    const filters = [
+      'RORO_UNACCOMPANIED_FREIGHT',
+      'RORO_ACCOMPANIED_FREIGHT',
+    ];
+
+    // COP-9210 Apply more than one pre-arrival filter, compare the expected number of targets
+    cy.applyModesFilter(filters, 'new').then((actualTargets) => {
+      cy.getTaskCount(filters, null).then((response) => {
+        expect(response.new).be.equal(actualTargets);
+      });
+    });
+
+    // clear the filter
+    cy.contains('Clear all filters').click();
+
+    cy.wait(1000);
+
+    // COP-9210 check the status of  pre-arrival filter modes, after clear filter
+    cy.get('.cop-filters-container').within(() => {
+      cy.get('.govuk-checkboxes li').each((element) => {
+        cy.wrap(element).should('not.be.checked');
+      });
+    });
+
+    // compare total number of expected and actual targets
+    cy.get('a[href="#new"]').invoke('text').then((totalTargets) => {
+      totalTargets = parseInt(totalTargets.match(/\d+/)[0], 10);
+      expect(totalTargets).be.equal(actualTotalTargets);
+    });
+  });
+
+  it('Should select pre-arrival filter modes but not apply on newly created tasks', () => {
+    let actualTotalTargets = 0;
+
+    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+      actualTotalTargets = numberOfTasks.new;
+    });
+
+    // COP-9210 select pre-arrival filter modes, but don't click on apply
+    cy.get('.cop-filters-container').within(() => {
+      cy.get('.govuk-checkboxes li input').each((element) => {
+        cy.wrap(element).check();
+      });
+    });
+
+    // compare total number of expected and actual targets
+    cy.get('a[href="#new"]').invoke('text').then((totalTargets) => {
+      totalTargets = parseInt(totalTargets.match(/\d+/)[0], 10);
+      expect(totalTargets).be.equal(actualTotalTargets);
+    });
+  });
+
   after(() => {
     cy.deleteAutomationTestData();
     cy.contains('Sign out').click();

--- a/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
@@ -27,7 +27,8 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.get('.cop-filters-header .govuk-link').should('have.text', 'Clear all filters');
       cy.get('.govuk-checkboxes li').each((element) => {
         cy.wrap(element).invoke('text').then((value) => {
-          expect(filterNames).to.include(value);
+          let expectedFilterName = value.slice(0, value.indexOf('('));
+          expect(filterNames).to.contains(expectedFilterName);
         });
       });
     });

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -152,8 +152,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('a[href="#inProgress"]').click();
 
-    cy.waitForTaskManagementPageToLoad();
-
     cy.get('@taskName').then((value) => {
       const nextPage = 'a[data-test="next"]';
       if (Cypress.$(nextPage).length > 0) {


### PR DESCRIPTION
## Description
Add / update tests to verify the following scenarios,
As well as testing the AC of this ticket

please check these as they have been updated with the new API

Counts

go to /tasks
task counts in tabs should reflect the number of tasks for the status
pagination should work 
Filters

click on some filters : they should be selected but not applied
click reset : filters should become unselected
click on some filters
click apply : tasks and counts should update based on the filters
click on some other filters
click apply : tasks and counts should update based on the filters
click reset : filters should become unselected, tasks and counts should update to 'all'

## To Test
npm run cypress:runner

run all the tests from spec `filter-tasks-by-pre-arrival-mode.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
