### PR TITLE
Add appropriate padding to grid columns in task details

### DIFF
--- a/src/routes/__assets__/TaskDetailsPage.scss
+++ b/src/routes/__assets__/TaskDetailsPage.scss
@@ -178,6 +178,8 @@
         .govuk-task-details-grid-column {
             display: grid;
             grid-template-columns: 50% 50%;
+            column-gap: 0.5em;
+            padding-right: 5px;
             &.bottom-border {
                 margin-bottom: 10px;
                 border-bottom: 1px solid #b1b4b6;

--- a/src/routes/__assets__/TaskDetailsPage.scss
+++ b/src/routes/__assets__/TaskDetailsPage.scss
@@ -178,7 +178,7 @@
         .govuk-task-details-grid-column {
             display: grid;
             grid-template-columns: 50% 50%;
-            column-gap: 0.5em;
+            column-gap: 0.5em; // em unit used here for appropriate scaling between monitor sizes.
             padding-right: 5px;
             &.bottom-border {
                 margin-bottom: 10px;


### PR DESCRIPTION
## Description
This PR fixes a bug where the spacing between columns in task details would almost allow neighboring columns to meet.
**JIRA Ticket**: https://support.cop.homeoffice.gov.uk/browse/COP-9720

## To Test
- Pull and run against dev.
- In a separate browser tab, load up Cerserus-Service (dev env).
- Locate the task titled **CHARLES-2022-01-05-4** or **CHARLES-2022-01-05-3** or **CHARLES-2022-01-05-2** and click on view details.
- Compare the **Booking and check-in** columns (See attached screenshots for guidance).

> **Bug**
![Grid column padding bug](https://user-images.githubusercontent.com/19333750/148255263-922200ca-ec1e-4955-bd9a-8c0638b21882.png)

> **Fixed**
![Grid column padding fixed](https://user-images.githubusercontent.com/19333750/148255320-3b66fe04-75a6-4b25-92af-0804a095ae69.png)



## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
