### PR TITLE
COP-9557 Remove "Property delete changed from false to true"

### DIFF
--- a/src/routes/TaskDetails/TaskNotes.jsx
+++ b/src/routes/TaskDetails/TaskNotes.jsx
@@ -63,7 +63,11 @@ const TaskNotes = ({ displayForm, businessKey, processInstanceId }) => {
         if ([OPERATION_TYPE_CLAIM, OPERATION_TYPE_ASSIGN].includes(operation.operationType)) {
           return operation.newValue ? 'User has claimed the task' : 'User has unclaimed the task';
         }
-        return `Property ${operation.property} changed from ${operation.orgValue || 'none'} to ${operation.newValue || 'none'}`;
+        /*
+         * Line below left as commented out in the event that line affected other parts of the system
+         */
+        // return `Property ${operation.property} changed from ${operation.orgValue || 'none'} to ${operation.newValue || 'none'}`;
+        return null;
       };
       return {
         id: uuidv4(),
@@ -114,21 +118,23 @@ const TaskNotes = ({ displayForm, businessKey, processInstanceId }) => {
       <h3 className="govuk-heading-m task-details-notes-heading">Task activity</h3>
 
       {activityLog.map((activity) => {
-        return (
-          <div key={activity.id}>
-            <div className="activity-body-container">
-              <p className="govuk-body-s govuk-!-margin-bottom-2">
-                <span className="govuk-!-font-weight-bold">
-                  {new Date(activity.date).toLocaleDateString()}
-                </span>
-              &nbsp;at <span className="govuk-!-font-weight-bold">{new Date(activity.date).toLocaleTimeString()}</span>
-                {activity.user && <>&nbsp;by <a href={`mailto:${activity.user}`}>{activity.user}</a></>}
-              </p>
-              <p className="govuk-body">{hyperlinkify(activity.note)}</p>
+        if (activity.note !== null) {
+          return (
+            <div key={activity.id}>
+              <div className="activity-body-container">
+                <p className="govuk-body-s govuk-!-margin-bottom-2">
+                  <span className="govuk-!-font-weight-bold">
+                    {new Date(activity.date).toLocaleDateString()}
+                  </span>
+                &nbsp;at <span className="govuk-!-font-weight-bold">{new Date(activity.date).toLocaleTimeString()}</span>
+                  {activity.user && <>&nbsp;by <a href={`mailto:${activity.user}`}>{activity.user}</a></>}
+                </p>
+                <p className="govuk-body">{hyperlinkify(activity.note)}</p>
+              </div>
+              <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
             </div>
-            <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-          </div>
-        );
+          );
+        }
       })}
     </div>
   );

--- a/src/routes/__fixtures__/variableInstanceStatusComplete.fixture.json
+++ b/src/routes/__fixtures__/variableInstanceStatusComplete.fixture.json
@@ -91,7 +91,7 @@
   },
   {
     "type": "Json",
-    "value": "[{\"note\":\"Target received\",\"timeStamp\":1619171257457,\"userId\":\"Cerberus - Rules Based Targetting\"}]",
+    "value": "[{\"note\":null,\"timeStamp\":1619171257457,\"userId\":\"test.user@digital.homeoffice.gov.uk\"}, {\"note\":\"Target received\",\"timeStamp\":1619171257457,\"userId\":\"Cerberus - Rules Based Targetting\"}]",
     "name": "notes"
   },
   {

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -28,6 +28,13 @@ describe('TaskDetailsPage', () => {
     orgValue: null,
     timestamp: '2021-04-06T15:30:42.420+0000',
     userId: 'testuser@email.com',
+  },
+  {
+    operationType: 'Complete',
+    property: 'assignee',
+    orgValue: null,
+    timestamp: '2021-04-06T15:30:42.420+0000',
+    userId: 'testuser@email.com',
   }];
   const taskHistoryFixture = [{
     assignee: 'testuser@email.com',
@@ -480,5 +487,25 @@ describe('TaskDetailsPage', () => {
     await waitFor(() => render(<TaskDetailsPage />));
 
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+  });
+
+  it('should not render any note that has value null', async () => {
+    mockTaskDetailsAxiosCalls({
+      processInstanceResponse: [{ id: '123' }],
+      taskResponse: [{
+        processInstanceId: '123',
+        assignee: null,
+        id: 'task123',
+        taskDefinitionKey: 'developTarget',
+      }],
+      variableInstanceResponse: variableInstanceStatusComplete,
+      operationsHistoryResponse: operationsHistoryFixture,
+      taskHistoryResponse: taskHistoryFixture,
+      noteFormResponse: noteFormFixure,
+    });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('test.user@digital.homeoffice.gov.uk')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description
This PR removes the unwanted "Property delete changed from false to true" note that is displayed for a completed task.
**JIRA Ticket**: https://support.cop.homeoffice.gov.uk/browse/COP-9557

## To Test
- Pull and run against dev.
- Go to the completed tab and view the details of this task: **CERB-CERB-RORO-Tourist:CMID=TEST-MRUOCCO-1**.
- In another tab, load up the cerberus dev, navigate to the completed tab and load up the task mentioned above.
- Compare the displayed task notes between the local dev environment and cerberus dev environment.
- Compare notes of all other completed tasks.

> Local Dev Env
![COP-9557 - Local Dev](https://user-images.githubusercontent.com/19333750/148371911-0d893947-38a0-47fa-85dc-46390642af8d.png)



> Cerberus Dev Env
![COP-9557 - Cerberus Dev](https://user-images.githubusercontent.com/19333750/148371934-8a51c9c8-ea69-48f9-9344-b15726dde05e.png)





## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
