### PR TITLE
COP-4762: Add tests to verify empty task list fallback message on task management page

### DIFF
--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -96,24 +96,12 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
     }
   });
 
-  it('Should verify tasks are sorted in arrival time on task management page', () => {
-    let arrivalDate;
-    cy.get('.task-list--item-2 .content-line-two').each((item, index) => {
-      let dates;
-      cy.wrap(item).invoke('text').then((element) => {
-        if (element !== 'unknown') {
-          dates = element.split('-')[1];
-          dates = dates.slice(5, dates.length).split('at')[0];
-          const d = new Date(dates);
-          if (index === 0) {
-            arrivalDate = d.getTime();
-          } else {
-            expect(arrivalDate).to.be.lte(d.getTime());
-            arrivalDate = d.getTime();
-          }
-        }
-      });
-    });
+  it('Should verify tasks are sorted in arrival time for new and InProgress tabs on task management page', () => {
+    cy.get('a[href="#new"]').click();
+    cy.verifyTasksSortedOnArrivalDateTime();
+
+    cy.get('a[href="#inProgress"]').click();
+    cy.verifyTasksSortedOnArrivalDateTime();
   });
 
   it('Should Claim and Unclaim a task Successfully from task management page', () => {
@@ -383,6 +371,22 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
           expect(taskFound).to.equal(true);
         });
       }
+    });
+  });
+
+  it('Should check empty task list fallback message on task management page', () => {
+    cy.get('.govuk-checkboxes [value="RORO_UNACCOMPANIED_FREIGHT"]')
+      .click({ force: true });
+
+    cy.get('.govuk-radios__item [value="false"]')
+      .click({ force: true });
+
+    cy.contains('Apply filters').click();
+
+    cy.get('.govuk-tabs__list li a').each((navigationItem) => {
+      cy.wrap(navigationItem).click();
+
+      cy.get('.govuk-tabs__panel p').should('contain.text', 'No more tasks available');
     });
   });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1158,3 +1158,23 @@ Cypress.Commands.add('verifyTaskHasMultipleVersion', (businessKey) => {
     }
   });
 });
+
+Cypress.Commands.add('verifyTasksSortedOnArrivalDateTime', () => {
+  let arrivalDate;
+  cy.get('.task-list--item-2 .content-line-two').each((item, index) => {
+    let dates;
+    cy.wrap(item).invoke('text').then((element) => {
+      if (element !== 'unknown') {
+        dates = element.split('-')[1];
+        dates = dates.slice(5, dates.length).split('at')[0];
+        const d = new Date(dates);
+        if (index === 0) {
+          arrivalDate = d.getTime();
+        } else {
+          expect(arrivalDate).to.be.lte(d.getTime());
+          arrivalDate = d.getTime();
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Description
Add tests to verify empty task list fallback message on task management page

## To Test
npm run cypress:runner
execute test `Should check empty task list fallback message on task management page` from spec `task-management.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
