### PR TITLE
CB 1766: Add more tests for TaskNotes component

### DIFF
--- a/src/routes/__fixtures__/operationsHistoryResponse_PROPERTY_CHANGED.fixture.json
+++ b/src/routes/__fixtures__/operationsHistoryResponse_PROPERTY_CHANGED.fixture.json
@@ -1,0 +1,10 @@
+[
+  {
+    "operationType": "Complete",
+    "property": "delete",
+    "orgValue": "false",
+    "newValue": "true",
+    "timestamp": "2022-01-05T16:16:31.693+0000",
+    "userId": "testuser@email.com"
+  }
+]

--- a/src/routes/__fixtures__/operationsHistoryResponse_USER_CLAIM.fixture.json
+++ b/src/routes/__fixtures__/operationsHistoryResponse_USER_CLAIM.fixture.json
@@ -1,0 +1,10 @@
+[
+  {
+    "operationType": "Assign",
+    "property": "assignee",
+    "orgValue": null,
+    "newValue": "testuser@email.com",
+    "timestamp": "2021-04-06T15:30:42.420+0000",
+    "userId": "testuser@email.com"
+  }
+]

--- a/src/routes/__fixtures__/operationsHistoryResponse_USER_UNCLAIM.fixture.json
+++ b/src/routes/__fixtures__/operationsHistoryResponse_USER_UNCLAIM.fixture.json
@@ -1,0 +1,10 @@
+[
+  {
+    "operationType": "Assign",
+    "property": "assignee",
+    "orgValue": null,
+    "newValue": null,
+    "timestamp": "2021-04-06T15:30:42.420+0000",
+    "userId": "testuser@email.com"
+  }
+]

--- a/src/routes/__tests__/TaskNotes.test.jsx
+++ b/src/routes/__tests__/TaskNotes.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { render, screen, waitFor } from '@testing-library/react';
+import '../../__mocks__/keycloakMock';
+
+import TaskNotes from '../TaskDetails/TaskNotes';
+
+import variableInstanceStatusNew from '../__fixtures__/variableInstanceStatusNew.fixture.json';
+import noteFormFixture from '../__fixtures__/noteFormResponse.fixture.json';
+
+// mock useParams
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn().mockReturnValue({ businessKey: 'BUSINESS_KEY' }),
+}));
+
+describe('TaskNotes', () => {
+  const mockAxios = new MockAdapter(axios);
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => { });
+    mockAxios.reset();
+  });
+
+  const operationsHistoryFixture = [{
+    operationType: 'Claim',
+    property: 'assignee',
+    orgValue: null,
+    timestamp: '2021-04-06T15:30:42.420+0000',
+    userId: 'testuser@email.com',
+  }];
+  const taskHistoryFixture = [{
+    assignee: 'testuser@email.com',
+    startTime: '2021-04-20T10:50:25.869+0000',
+    name: 'Investigate Error',
+  }];
+
+  const mockTaskNotesAxiosCalls = ({
+    variableInstanceResponse,
+  }) => {
+    mockAxios
+      .onGet('/history/variable-instance', { params: { processInstanceIdIn: '123', deserializeValues: false } })
+      .reply(200, variableInstanceResponse)
+      .onGet('/history/user-operation', { params: { processInstanceId: '123', deserializeValues: false } })
+      .reply(200, operationsHistoryFixture)
+      .onGet('/history/task', { params: { processInstanceId: '123', deserializeValues: false } })
+      .reply(200, taskHistoryFixture)
+      .onGet('/form/name/noteCerberus')
+      .reply(200, noteFormFixture);
+  };
+
+  it('Should render task notes form when displayFrom=true', async () => {
+    mockTaskNotesAxiosCalls({
+      variableInstanceResponse: variableInstanceStatusNew,
+    });
+
+    await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
+
+    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+  });
+});

--- a/src/routes/__tests__/TaskNotes.test.jsx
+++ b/src/routes/__tests__/TaskNotes.test.jsx
@@ -24,14 +24,26 @@ describe('TaskNotes', () => {
     mockAxios.reset();
   });
 
-  const variableInstanceResponse_EMPTY = [{
+  const variableInstanceResponseEmpty = [{
     type: 'Json',
-    value: "[]",
-    name: "notes",
-  }]
+    value: '[]',
+    name: 'notes',
+  }];
+
+  const variableInstanceFixture = [{
+    type: 'Json',
+    value: '[{"note":"Task received","timeStamp":1641378056264,"userId":"testuser@email.com"}]',
+    name: 'notes',
+  }];
+
+  const taskHistoryFixture = [{
+    name: 'Develop the task',
+    assignee: 'testuser@email.com',
+    startTime: '2022-01-05T10:20:56.318+0000',
+  }];
 
   const mockTaskNotesAxiosCalls = ({
-    variableInstanceResponse = variableInstanceResponse_EMPTY,
+    variableInstanceResponse = variableInstanceResponseEmpty,
     operationsHistoryResponse = [],
     taskHistoryResponse = [],
   }) => {
@@ -50,7 +62,6 @@ describe('TaskNotes', () => {
     mockTaskNotesAxiosCalls({});
 
     await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
-
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
     expect(screen.queryByText('Task activity')).toBeInTheDocument();
   });
@@ -59,38 +70,52 @@ describe('TaskNotes', () => {
     mockTaskNotesAxiosCalls({});
 
     await waitFor(() => render(<TaskNotes displayForm={false} businessKey="ghi" processInstanceId="123" />));
-
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
     expect(screen.queryByText('Task activity')).toBeInTheDocument();
   });
 
-  it('should display user claimed task', async () => {
+  it('should display task received activity', async () => {
+    mockTaskNotesAxiosCalls({
+      variableInstanceResponse: variableInstanceFixture,
+    });
+
+    await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
+    expect(screen.queryByText('Task received')).toBeInTheDocument();
+  });
+
+  it('should display user claimed task activity', async () => {
     mockTaskNotesAxiosCalls({
       operationsHistoryResponse: operationsHistoryResponseClaim,
     });
 
     await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
-
     expect(screen.queryByText('User has claimed the task')).toBeInTheDocument();
   });
 
-  it('should display user unclaimed task', async () => {
+  it('should display user unclaimed task activity', async () => {
     mockTaskNotesAxiosCalls({
       operationsHistoryResponse: operationsHistoryResponseUnclaim,
     });
 
     await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
-
     expect(screen.queryByText('User has unclaimed the task')).toBeInTheDocument();
   });
 
-  it('should display property changed operation', async () => {
+  it('should display property changed activity', async () => {
     mockTaskNotesAxiosCalls({
       operationsHistoryResponse: operationsHistoryResponsePropertyChanged,
     });
 
     await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
-
     expect(screen.queryByText('Property delete changed from false to true')).toBeInTheDocument();
+  });
+
+  it('should display develop the task activity', async () => {
+    mockTaskNotesAxiosCalls({
+      taskHistoryResponse: taskHistoryFixture,
+    });
+
+    await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
+    expect(screen.queryByText('Develop the task')).toBeInTheDocument();
   });
 });

--- a/src/routes/__tests__/TaskNotes.test.jsx
+++ b/src/routes/__tests__/TaskNotes.test.jsx
@@ -24,26 +24,12 @@ describe('TaskNotes', () => {
     mockAxios.reset();
   });
 
-  const variableInstanceResponseEmpty = [{
-    type: 'Json',
-    value: '[]',
-    name: 'notes',
-  }];
-
-  const variableInstanceFixture = [{
-    type: 'Json',
-    value: '[{"note":"Task received","timeStamp":1641378056264,"userId":"testuser@email.com"}]',
-    name: 'notes',
-  }];
-
-  const taskHistoryFixture = [{
-    name: 'Develop the task',
-    assignee: 'testuser@email.com',
-    startTime: '2022-01-05T10:20:56.318+0000',
-  }];
-
   const mockTaskNotesAxiosCalls = ({
-    variableInstanceResponse = variableInstanceResponseEmpty,
+    variableInstanceResponse = [{
+      type: 'Json',
+      value: '[]',
+      name: 'notes',
+    }],
     operationsHistoryResponse = [],
     taskHistoryResponse = [],
   }) => {
@@ -76,7 +62,11 @@ describe('TaskNotes', () => {
 
   it('should display task received activity', async () => {
     mockTaskNotesAxiosCalls({
-      variableInstanceResponse: variableInstanceFixture,
+      variableInstanceResponse: [{
+        type: 'Json',
+        value: '[{"note":"Task received","timeStamp":1641378056264,"userId":"testuser@email.com"}]',
+        name: 'notes',
+      }],
     });
 
     await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));
@@ -112,7 +102,11 @@ describe('TaskNotes', () => {
 
   it('should display develop the task activity', async () => {
     mockTaskNotesAxiosCalls({
-      taskHistoryResponse: taskHistoryFixture,
+      taskHistoryResponse: [{
+        name: 'Develop the task',
+        assignee: 'testuser@email.com',
+        startTime: '2022-01-05T10:20:56.318+0000',
+      }],
     });
 
     await waitFor(() => render(<TaskNotes displayForm businessKey="ghi" processInstanceId="123" />));


### PR DESCRIPTION
## Description
- New tests for TaskNotes
  - Check that the notes form renders/hides when `displayForm` is true/false
  - Check that the `variableInstance` (`history/variable-instance`) data displays correctly in the activity bar
  - Check that the `operationsHistory` (`history/user-operation`) data displays correctly in the activity bar
  - Check that the `taskHistory` (`history/task`) data displays correctly in the activity bar
- Added some fixtures to support these tests

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
