### PR TITLE
Remove hover state for task list items

### DIFF
--- a/src/routes/__assets__/TaskListPage.scss
+++ b/src/routes/__assets__/TaskListPage.scss
@@ -13,10 +13,6 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
     background: #ffffff;
 }
 
-.govuk-task-list-card:hover {
-    box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 1.0);
-}
-
 .heading-container {
     display: flex;
     justify-content: flex-start;


### PR DESCRIPTION
## Description
This PR removes the extra shadow applied to task list cards when the mouse hovers over the task list card.

## To Test
- Pull and run aginst dev
- Confirm that hovering over each task list card does not activate the hover shadow (images for comparison attached below)

> With hover shadow
![image](https://user-images.githubusercontent.com/19333750/148557324-737780a7-bf9a-4fa0-9dd6-17809f1286c6.png)


> Without hover shadow
![image](https://user-images.githubusercontent.com/19333750/148557378-b3c1b400-be63-48fd-8090-841195455d31.png)


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
