### PR TITLE
COP-9661 Handle localStorage returning null as string for hasSelectors

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -409,8 +409,11 @@ const TaskListPage = () => {
     // Clear localStorage
     localStorage.removeItem('filterMovementMode');
     localStorage.removeItem('hasSelector');
-    // Clear checked options
-    if (hasSelectors) {
+    /* Clear checked options :
+     * when hasSelectors was not selected, it stores 'null' as a string in the
+     * localStorage so needs to be excluded in the if condition
+    */
+    if (hasSelectors && hasSelectors !== 'null') {
       document.getElementById(hasSelectors).checked = false;
       setHasSelectors(null);
     }


### PR DESCRIPTION
## Description
Bug discovered whereby filters were not clearing when 'clear filter' clicked after a page refresh (see test scenario below)

- discovered localStorage returned 'null' as string which was causing the issue
- updated IF condition to handle that

## To Test

- select a mode filter
- click apply
- refresh page
- click clear filter
- > tasks should reset back to 'all' (default setting)

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
