### PR TITLE
Add padding to vehicle icons in task list & details page

### DIFF
--- a/src/routes/TaskDetails/TaskSummary.jsx
+++ b/src/routes/TaskDetails/TaskSummary.jsx
@@ -19,37 +19,41 @@ const TaskSummary = ({ movementMode, taskSummaryData }) => {
           <div className="govuk-grid-column-one-half">
             <div className="summary-data-list">
               <i className={`icon-position--left align-middle ${getMovementModeIcon(movementMode, roroData.vehicle, roroData.passengers)}`} />
-              <ul>
-                <li>
-                  <span className="govuk-caption-m">
-                    {roroData.vehicle?.registrationNumber && 'Vehicle'}
-                    {(roroData.vehicle?.registrationNumber && roroData.vehicle?.trailer?.regNumber) && ' with '}
-                    {roroData?.vehicle?.trailer?.regNumber && 'Trailer'}
-                  </span>
-                  <h3 className="govuk-heading-s">
-                    {roroData.vehicle && roroData.vehicle.registrationNumber}
-                    {(roroData.vehicle?.registrationNumber && roroData.vehicle?.trailer?.regNumber) && <span className="govuk-!-font-weight-regular"> with </span>}
-                    {roroData.vehicle?.trailer?.regNumber && roroData.vehicle.trailer.regNumber}
-                    {roroData.driver?.name && <span className="govuk-!-font-weight-regular"> driven by </span>}
-                    {roroData.driver?.name && roroData.driver.name}
-                  </h3>
-                </li>
-              </ul>
+              <div className="first-half">
+                <ul>
+                  <li>
+                    <span className="govuk-caption-m">
+                      {roroData.vehicle?.registrationNumber && 'Vehicle'}
+                      {(roroData.vehicle?.registrationNumber && roroData.vehicle?.trailer?.regNumber) && ' with '}
+                      {roroData?.vehicle?.trailer?.regNumber && 'Trailer'}
+                    </span>
+                    <h3 className="govuk-heading-s">
+                      {roroData.vehicle && roroData.vehicle.registrationNumber}
+                      {(roroData.vehicle?.registrationNumber && roroData.vehicle?.trailer?.regNumber) && <span className="govuk-!-font-weight-regular"> with </span>}
+                      {roroData.vehicle?.trailer?.regNumber && roroData.vehicle.trailer.regNumber}
+                      {roroData.driver?.name && <span className="govuk-!-font-weight-regular"> driven by </span>}
+                      {roroData.driver?.name && roroData.driver.name}
+                    </h3>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
           <div className="govuk-grid-column-one-half align-right">
             <div className="summary-data-list">
               <i className="c-icon-ship align-middle" />
-              <ul>
-                <li><span>{roroData.vessel?.company && `${roroData.vessel?.company} voyage of `}{roroData.vessel.name}</span></li>
-                <li>
-                  <span>{!roroData.departureTime ? 'unknown' : dayjs.utc(roroData.departureTime).format(LONG_DATE_FORMAT)}{' '}
-                    <span className="dot" />  <span className="font__bold">{roroData.departureLocation && `${roroData.departureLocation} `}</span>{' - '}
-                  </span> <span className="font__bold">{roroData.arrivalLocation && `${roroData.arrivalLocation} `} </span>{'  '}
-                  <span className="dot" />  {!roroData.eta ? 'unknown' : dayjs.utc(roroData.eta).format(LONG_DATE_FORMAT)}
-                </li>
-                <li><span>Arrival {!roroData.eta ? 'unknown' : (dayjs.utc(roroData.eta).fromNow())}</span></li>
-              </ul>
+              <div className="second-half">
+                <ul>
+                  <li><span>{roroData.vessel?.company && `${roroData.vessel?.company} voyage of `}{roroData.vessel.name}</span></li>
+                  <li>
+                    <span>{!roroData.departureTime ? 'unknown' : dayjs.utc(roroData.departureTime).format(LONG_DATE_FORMAT)}{' '}
+                      <span className="dot" />  <span className="font__bold">{roroData.departureLocation && `${roroData.departureLocation} `}</span>{' - '}
+                    </span> <span className="font__bold">{roroData.arrivalLocation && `${roroData.arrivalLocation} `} </span>{'  '}
+                    <span className="dot" />  {!roroData.eta ? 'unknown' : dayjs.utc(roroData.eta).format(LONG_DATE_FORMAT)}
+                  </li>
+                  <li><span>Arrival {!roroData.eta ? 'unknown' : (dayjs.utc(roroData.eta).fromNow())}</span></li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>

--- a/src/routes/TaskLists/TaskListMode.jsx
+++ b/src/routes/TaskLists/TaskListMode.jsx
@@ -62,8 +62,8 @@ const renderRoRoTouristModeSection = (roroData, movementModeIcon, passengers) =>
   return (
     <div className="govuk-grid-column-one-quarter govuk-!-padding-left-8">
       <i className={`icon-position--left ${movementModeIcon}`} />
-      <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0">{getMovementModeTypeText(movementModeIcon)}</p>
-      <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold">{getMovementModeTypeContent(roroData, movementModeIcon, passengers)}</p>
+      <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0 govuk-!-padding-left-1">{getMovementModeTypeText(movementModeIcon)}</p>
+      <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-padding-left-1">{getMovementModeTypeContent(roroData, movementModeIcon, passengers)}</p>
     </div>
   );
 };
@@ -72,8 +72,8 @@ const renderRoroModeSection = (roroData, movementModeIcon) => {
   return (
     <div className="govuk-grid-column-one-quarter govuk-!-padding-left-8">
       <i className={`icon-position--left ${movementModeIcon}`} />
-      <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0">{!roroData.vehicle.make ? '\xa0' : roroData.vehicle.make} {roroData.vehicle.model}</p>
-      <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold">{!roroData.vehicle.registrationNumber ? '\xa0' : roroData.vehicle.registrationNumber.toUpperCase()}</p>
+      <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0 govuk-!-padding-left-1">{!roroData.vehicle.make ? '\xa0' : roroData.vehicle.make} {roroData.vehicle.model}</p>
+      <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-padding-left-1">{!roroData.vehicle.registrationNumber ? '\xa0' : roroData.vehicle.registrationNumber.toUpperCase()}</p>
     </div>
   );
 };
@@ -82,8 +82,8 @@ const renderRoroVoyageSection = (roroData) => {
   return (
     <div className="govuk-grid-column-three-quarters govuk-!-padding-right-7 align-right">
       <i className="c-icon-ship" />
-      <p className="content-line-one">{roroData.vessel.company && `${roroData.vessel.company} voyage of `}{roroData.vessel.name}{', '}arrival {!roroData.eta ? 'unknown' : dayjs.utc(roroData.eta).fromNow()}</p>
-      <p className="govuk-body-s content-line-two">
+      <p className="content-line-one govuk-!-padding-right-2">{roroData.vessel.company && `${roroData.vessel.company} voyage of `}{roroData.vessel.name}{', '}arrival {!roroData.eta ? 'unknown' : dayjs.utc(roroData.eta).fromNow()}</p>
+      <p className="govuk-body-s content-line-two govuk-!-padding-right-2">
         {!roroData.departureTime ? 'unknown' : dayjs.utc(roroData.departureTime).format(constants.LONG_DATE_FORMAT)}{' '}
         <span className="dot" />
         <span className="govuk-!-font-weight-bold"> {roroData.departureLocation || 'unknown'}</span>{' '}-{' '}

--- a/src/routes/__assets__/TaskDetailsPage.scss
+++ b/src/routes/__assets__/TaskDetailsPage.scss
@@ -268,6 +268,8 @@
         margin: auto 0 auto 0;
         padding-bottom: 2.5em;
     }
+    .c-icon-group::before,
+    .c-icon-person::before,
     .c-icon-trailer::before,
     .c-icon-van::before,
     .c-icon-car::before,
@@ -276,6 +278,12 @@
     }
     .c-icon-ship::before {
         left: 5px;
+    }
+    .second-half {
+        padding-right: 10px;
+    }
+    .first-half {
+        padding-left: 10px;
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds a cosmetic padding to the RoRo vehicle icons & the RoRo freight movement icon.

## To Test
- Pull & run against dev
- On Task List Page, confirm that there is a visible separation between the icon on the left side of the task summary and the text to the right of it.
- On Task List page, confirm that there is a visible separation between the icon on the right side of the task summary and the text to the left of it.
- On Task Details Page, confirm that there is a visible separation between the icon on the left side of the task summary and the text to the right of it.
- On Task Details page, confirm that there is a visible separation between the icon on the right side of the task summary and the text to the left of it.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
