### PR TITLE
Cop 9782 - Single foot passenger logic fix

### DIFF
--- a/src/routes/TaskDetails/TaskSummary.jsx
+++ b/src/routes/TaskDetails/TaskSummary.jsx
@@ -4,13 +4,14 @@ import utc from 'dayjs/plugin/utc';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { LONG_DATE_FORMAT } from '../../constants';
 import getMovementModeIcon from '../../utils/getVehicleModeIcon';
+import modify from '../../utils/roroDataUtil';
 
 import '../__assets__/TaskDetailsPage.scss';
 
 const TaskSummary = ({ movementMode, taskSummaryData }) => {
   dayjs.extend(utc);
   dayjs.extend(relativeTime);
-  const roroData = taskSummaryData.roro.details;
+  const roroData = modify({ ...taskSummaryData.roro.details });
 
   return (
     <section className="card">

--- a/src/routes/TaskLists/TaskListMode.jsx
+++ b/src/routes/TaskLists/TaskListMode.jsx
@@ -35,13 +35,8 @@ const getMovementModeTypeContent = (roroData, movementModeIcon, passengers) => {
   }
 };
 
-const createCoTravellers = (coTravellers, movementModeIcon) => {
-  let remainingCoTravellers;
-  if (movementModeIcon === constants.RORO_TOURIST_GROUP_ICON) {
-    remainingCoTravellers = coTravellers.splice(1);
-  } else {
-    remainingCoTravellers = coTravellers;
-  }
+const createCoTravellers = (coTravellers) => {
+  let remainingCoTravellers = coTravellers.splice(1); // Return remainder of array (passenger at index 0 is primary traveller)
   const maxToDisplay = 4;
   const remaining = remainingCoTravellers.length > maxToDisplay ? remainingCoTravellers.length - maxToDisplay : 0;
   const coTravellersJsx = remainingCoTravellers.map((coTraveller, index) => {
@@ -94,7 +89,7 @@ const renderRoroVoyageSection = (roroData) => {
   );
 };
 
-const renderRoRoTouristSingleAndGroupCardBody = (roroData, passengers, movementModeIcon) => {
+const renderRoRoTouristSingleAndGroupCardBody = (roroData) => {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-item">
@@ -103,7 +98,7 @@ const renderRoRoTouristSingleAndGroupCardBody = (roroData, passengers, movementM
             Primary traveller
           </h3>
           <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
-            <li className="govuk-!-font-weight-bold">{passengers[0]?.firstName} {passengers[0]?.lastName}</li>
+            <li className="govuk-!-font-weight-bold">{roroData?.passengers[0]?.name}</li>
           </ul>
         </div>
       </div>
@@ -113,7 +108,7 @@ const renderRoRoTouristSingleAndGroupCardBody = (roroData, passengers, movementM
             Document
           </h3>
           <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
-            {passengers[0]?.docNumber ? (<li className="govuk-!-font-weight-bold">{passengers[0].docNumber}</li>)
+            {roroData.passengers[0]?.docNumber ? (<li className="govuk-!-font-weight-bold">{roroData.passengers[0].docNumber}</li>)
               : (<li className="govuk-!-font-weight-bold">Unknown</li>)}
           </ul>
         </div>
@@ -137,7 +132,7 @@ const renderRoRoTouristSingleAndGroupCardBody = (roroData, passengers, movementM
           Co-travellers
         </h3>
         <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
-          {passengers.length > 1 ? createCoTravellers([...passengers], movementModeIcon) : <li className="govuk-!-font-weight-bold">None</li>}
+          {roroData?.passengers.length > 1 ? createCoTravellers([...roroData.passengers]) : <li className="govuk-!-font-weight-bold">None</li>}
         </ul>
       </div>
     </div>
@@ -168,17 +163,6 @@ const renderRoRoTouristCard = (roroData, movementMode, movementModeIcon) => {
                   {roroData?.driver ? (
                     <>
                       <li className="govuk-!-font-weight-bold">
-                        {roroData.driver.firstName && roroData.driver.firstName}{' '}{roroData.driver.lastName && roroData.driver.lastName}
-                      </li>
-                      {roroData.driver.gender && <br />}
-                      <li>
-                        {roroData.driver.gender === 'M' && 'Male'}
-                        {roroData.driver.gender === 'F' && 'Female'}
-                      </li>
-                    </>
-                  ) : (
-                    <>
-                      <li className="govuk-!-font-weight-bold">
                         {(roroData.passengers && roroData.passengers.length > 0) && roroData.passengers[0].name}
                       </li>
                       {(roroData.passengers && roroData.passengers.length > 0) && <br />}
@@ -187,6 +171,8 @@ const renderRoRoTouristCard = (roroData, movementMode, movementModeIcon) => {
                         {roroData.passengers && roroData.passengers[0].gender === 'F' && 'Female'}
                       </li>
                     </>
+                  ) : (
+                    <li className="govuk-!-font-weight-bold">Unknown</li>
                   )}
                 </ul>
               </div>
@@ -230,7 +216,7 @@ const renderRoRoTouristCard = (roroData, movementMode, movementModeIcon) => {
               </h3>
               <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
                 {roroData.passengers ? (
-                  createCoTravellers(roroData.passengers)
+                  createCoTravellers([...roroData.passengers])
                 ) : (<li className="govuk-!-font-weight-bold">None</li>)}
               </ul>
             </div>
@@ -238,7 +224,8 @@ const renderRoRoTouristCard = (roroData, movementMode, movementModeIcon) => {
         </section>
       </>
     );
-  } if (movementModeIcon === constants.RORO_TOURIST_INDIVIDUAL_ICON) {
+  }
+  if (movementModeIcon === constants.RORO_TOURIST_INDIVIDUAL_ICON) {
     return (
       <>
         <section className="task-list--item-2">
@@ -250,11 +237,12 @@ const renderRoRoTouristCard = (roroData, movementMode, movementModeIcon) => {
           </div>
         </section>
         <section className="task-list--item-3">
-          {renderRoRoTouristSingleAndGroupCardBody(roroData, passengers, movementModeIcon)}
+          {renderRoRoTouristSingleAndGroupCardBody(roroData)}
         </section>
       </>
     );
-  } if (movementModeIcon === constants.RORO_TOURIST_GROUP_ICON) {
+  }
+  if (movementModeIcon === constants.RORO_TOURIST_GROUP_ICON) {
     return (
       <>
         <section className="task-list--item-2">
@@ -266,7 +254,7 @@ const renderRoRoTouristCard = (roroData, movementMode, movementModeIcon) => {
           </div>
         </section>
         <section className="task-list--item-3">
-          {renderRoRoTouristSingleAndGroupCardBody(roroData, passengers, movementModeIcon)}
+          {renderRoRoTouristSingleAndGroupCardBody(roroData)}
         </section>
       </>
     );

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -16,6 +16,7 @@ import useAxiosInstance from '../../utils/axiosInstance';
 import { useKeycloak } from '../../utils/keycloak';
 import { calculateTaskListTotalRiskScore } from '../../utils/rickScoreCalculator';
 import getMovementModeIcon from '../../utils/getVehicleModeIcon';
+import modify from '../../utils/roroDataUtil';
 // Components/Pages
 import ClaimButton from '../../components/ClaimTaskButton';
 import ErrorSummary from '../../govuk/ErrorSummary';
@@ -211,7 +212,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError, targetTaskCount = 0 })
       )}
 
       {!isLoading && targetTasks.length > 0 && targetTasks.map((target) => {
-        const roroData = target.summary.roro.details;
+        const roroData = modify({ ...target.summary.roro.details });
         const movementModeIcon = getMovementModeIcon(target.movementMode, roroData.vehicle, roroData.passengers);
         return (
           <div className="govuk-task-list-card" key={target.summary.parentBusinessKey.businessKey}>

--- a/src/utils/__fixtures__/roroData.fixture.js
+++ b/src/utils/__fixtures__/roroData.fixture.js
@@ -1,0 +1,65 @@
+const testRoroData = {
+  movementStatus: 'Pre-Arrival',
+  bookingDateTime: '2020-08-02T09:15:00,2020-08-03T13:05:00',
+  vessel: {
+    name: 'DOVER SEAWAYS',
+    company: 'DFDS',
+  },
+  eta: '2021-12-02T10:36:53Z',
+  departureTime: '2020-08-03T13:05:00Z',
+  arrivalLocation: 'CAL',
+  departureLocation: 'DOV',
+  vehicle: {
+    colour: '',
+    model: '',
+    make: '',
+    registrationNumber: '',
+    type: '',
+  },
+  load: {
+    manifestedLoad: 'Printed Paper',
+    manifestedWeight: '',
+    countryOfDestination: '',
+  },
+  account: {
+    name: 'Univeral Printers Ltd',
+    number: 'PO000359675',
+  },
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+  ],
+  haulier: {
+    name: 'Matthesons',
+    address: {
+      line1: '',
+      line2: '',
+      line3: null,
+      city: '',
+      postCode: '',
+      country: '',
+    },
+  },
+};
+
+export default testRoroData;

--- a/src/utils/__fixtures__/roroDataDriverPassengers.fixture.js
+++ b/src/utils/__fixtures__/roroDataDriverPassengers.fixture.js
@@ -1,0 +1,119 @@
+const roroDataDriver1Pax = {
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+  ],
+};
+
+const roroDataDriver2Pax = {
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+    {
+      name: 'Sponge Bob',
+      dob: '27/10/1970',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26elrt61742c7a2c44f7e47ff0b4a747',
+      firstName: 'Sponge',
+      lastName: 'Bob',
+      middleName: '',
+    },
+  ],
+};
+
+const roroDataBlankDriver2Pax = {
+  driver: {
+    name: '',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: '',
+    lastName: '',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+    {
+      name: 'Sponge Bob',
+      dob: '27/10/1970',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26elrt61742c7a2c44f7e47ff0b4a747',
+      firstName: 'Sponge',
+      lastName: 'Bob',
+      middleName: '',
+    },
+  ],
+};
+
+const roroDataDriverNoPax = {
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [],
+};
+
+export { roroDataDriver1Pax, roroDataDriver2Pax, roroDataBlankDriver2Pax, roroDataDriverNoPax };

--- a/src/utils/__tests__/passengersGenerator.test.jsx
+++ b/src/utils/__tests__/passengersGenerator.test.jsx
@@ -1,0 +1,25 @@
+import generateTotalPassengers from '../passengersGenerator';
+
+import { roroDataDriver1Pax, roroDataDriver2Pax, roroDataBlankDriver2Pax, roroDataDriverNoPax } from '../__fixtures__/roroDataDriverPassengers.fixture';
+
+describe('Passengers Generator', () => {
+  it('should generate a new list of 2 passengers from given', () => {
+    const totalPassengers = generateTotalPassengers(roroDataDriver1Pax.driver, roroDataDriver1Pax.passengers);
+    expect(totalPassengers.length).toEqual(2);
+  });
+
+  it('should generate a new list of 3 passengers from given', () => {
+    const totalPassengers = generateTotalPassengers(roroDataDriver2Pax.driver, roroDataDriver2Pax.passengers);
+    expect(totalPassengers.length).toEqual(3);
+  });
+
+  it('should generate a new list of 2 passengers when driver name is blank', () => {
+    const totalPassengers = generateTotalPassengers(roroDataBlankDriver2Pax.driver, roroDataBlankDriver2Pax.passengers);
+    expect(totalPassengers.length).toEqual(2);
+  });
+
+  it('should generate a new list of a single passenger when passengers array is empty', () => {
+    const totalPassengers = generateTotalPassengers(roroDataDriverNoPax.driver, roroDataDriverNoPax.passengers);
+    expect(totalPassengers.length).toEqual(1);
+  });
+});

--- a/src/utils/__tests__/roroDataUtil.test.jsx
+++ b/src/utils/__tests__/roroDataUtil.test.jsx
@@ -1,0 +1,10 @@
+import modify from '../roroDataUtil';
+
+import testRoroData from '../__fixtures__/roroData.fixture';
+
+describe('RoRoData Util', () => {
+  it('should return a modified roroData object with a list of 2 passengers', () => {
+    const modifiedRoroData = modify({ ...testRoroData });
+    expect(modifiedRoroData.passengers.length).toEqual(2);
+  });
+});

--- a/src/utils/passengersGenerator.jsx
+++ b/src/utils/passengersGenerator.jsx
@@ -6,6 +6,8 @@ const hasPassengers = (passengers) => {
   return passengers && passengers?.length > 0;
 };
 
+// Driver if available, will now be included in the passengers list
+// therefore making person at index 0 the primary traveller.
 const generateTotalPassengers = (driver, passengers) => {
   let newPassengersArray = [];
   if (isDriverPresent(driver)) {

--- a/src/utils/passengersGenerator.jsx
+++ b/src/utils/passengersGenerator.jsx
@@ -9,16 +9,16 @@ const hasPassengers = (passengers) => {
 // Driver if available, will now be included in the passengers list
 // therefore making person at index 0 the primary traveller.
 const generateTotalPassengers = (driver, passengers) => {
-  let newPassengersArray = [];
+  let totalPassengers = [];
   if (isDriverPresent(driver)) {
-    newPassengersArray.push(driver);
+    totalPassengers.push(driver);
   }
   if (hasPassengers(passengers)) {
     passengers.map((passenger) => {
-      newPassengersArray.push(passenger);
+      totalPassengers.push(passenger);
     });
   }
-  return newPassengersArray;
+  return totalPassengers;
 };
 
 export default generateTotalPassengers;

--- a/src/utils/passengersGenerator.jsx
+++ b/src/utils/passengersGenerator.jsx
@@ -1,0 +1,22 @@
+const isDriverPresent = (driver) => {
+  return driver?.name && driver?.name !== '' && driver?.name !== null;
+};
+
+const hasPassengers = (passengers) => {
+  return passengers && passengers?.length > 0;
+};
+
+const generateTotalPassengers = (driver, passengers) => {
+  let newPassengersArray = [];
+  if (isDriverPresent(driver)) {
+    newPassengersArray.push(driver);
+  }
+  if (hasPassengers(passengers)) {
+    passengers.map((passenger) => {
+      newPassengersArray.push(passenger);
+    });
+  }
+  return newPassengersArray;
+};
+
+export default generateTotalPassengers;

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -1,5 +1,6 @@
 import generateTotalPassengers from './passengersGenerator';
 
+// Passengers data within roroData will be overwritten the new passeners count.
 const modify = (roroData) => {
   const modifiedPassengers = generateTotalPassengers(roroData.driver, roroData.passengers);
   roroData.passengers = modifiedPassengers;

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -1,0 +1,9 @@
+import generateTotalPassengers from './passengersGenerator';
+
+const modify = (roroData) => {
+  const modifiedPassengers = generateTotalPassengers(roroData.driver, roroData.passengers);
+  roroData.passengers = modifiedPassengers;
+  return roroData;
+};
+
+export default modify;

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -2,8 +2,7 @@ import generateTotalPassengers from './passengersGenerator';
 
 // Passengers data within roroData will be overwritten the new passeners count.
 const modify = (roroData) => {
-  const modifiedPassengers = generateTotalPassengers(roroData.driver, roroData.passengers);
-  roroData.passengers = modifiedPassengers;
+  roroData.passengers = generateTotalPassengers(roroData.driver, roroData.passengers);
   return roroData;
 };
 


### PR DESCRIPTION
## Description
This PR fixes a bug where the driver object in `roroData` was being ignored in the total count of RoRo passengers being returned for the following.

RoRo Tourist: 
- Car
- Foot Passenger
- Group Passengers.

This PR also adds the driver if present, to the passengers array.

## To Test
- Pull and Run against dev
- Load up cerberus dev in a separate browser tab.
- Locate the task: `CHARLES-2022-01-05-3` on the task list page
- Compare the count of foot passengers between that shown on task list page and that shown on task details page.


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
