### PR TITLE
COP-9557: Add test to verify 'Property delete changed from false to true' removed from activity log

### DIFF
--- a/cypress/fixtures/taskInfo-known/RoRo-Acc-TaskDetails-expected.json
+++ b/cypress/fixtures/taskInfo-known/RoRo-Acc-TaskDetails-expected.json
@@ -1,7 +1,6 @@
 {
   "taskListDetails": {
-    "mode": "Pre-Arrival",
-    "rules": "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
+    "rules": "Class A Drugs and 0 other rules",
     "voyage": "Brittany Ferries voyage of BARFLEUR",
     "arrival": "arrival a year after travel",
     "departurePort": "DOV",
@@ -19,17 +18,17 @@
     "bookedDetails": "Booked 2 days before travel",
     "haulier": "Matthesons",
     "goods": "Printed Paper",
-    "passengerDetails": "1 passenger",
+    "passengerDetails": "2 passengers",
     "trailerRegitration": "NL-234-392",
     "trailerTrips": "0 trips",
     "riskScore": "Risk Score: 80"
   },
   "taskSummary": {
     "Ferry": "Brittany Ferries voyage of BARFLEUR",
-    "Departure": "DOV, 4 Aug 2020 at 13:05",
-    "Arrival": "CAL, 4 Aug 2020 at 13:35",
-    "Account": "Univeral Printers Ltd, booked on 2 Aug 2020 at 09:15",
-    "Haulier": "Matthesons"
+    "Departure": "4 Aug 2020 at 13:05   DOV",
+    "Arrival": "CAL      4 Aug 2020 at 13:35",
+    "Account": "Arrival a year after travel",
+    "vehicle": "Vehicle with TrailerCOP1 with NL-234-392 driven by Ben Bailey"
   },
   "versions": [
     {
@@ -39,17 +38,7 @@
         "Make": "Model-xyz",
         "Model": "Make-123",
         "Country of registration": "GB",
-        "Colour": "Colour-White",
-        "Net weight": "3455kg",
-        "Gross weight": "43623kg",
-        "Trailer registration number": "NL-234-392",
-        "Trailer type": "TR",
-        "Trailer country of registration": "",
-        "Empty or loaded": "Loaded",
-        "Trailer length": "36m",
-        "Trailer height": "3.6m",
-        "Gross weight": "43623kg",
-        "Net weight": "3455kg"
+        "Colour": "Colour-White"
       },
       "account": {
         "Full name": "Univeral Printers Ltd",

--- a/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehOnly-expected.json
+++ b/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehOnly-expected.json
@@ -1,7 +1,6 @@
 {
   "taskListDetails": {
-    "mode": "Pre-Arrival",
-    "rules": "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
+    "rules": "Class A Drugs and 0 other rules",
     "voyage": "Brittany Ferries voyage of BARFLEUR",
     "arrival": "arrival a year after travel",
     "departurePort": "unknown",
@@ -16,14 +15,14 @@
     "goods": "Unknown",
     "passengerDetails": "None",
     "trailerRegitration": "0 trips",
-    "riskScore": "Risk Score:"
+    "riskScore": "Risk Score: 0"
   },
   "taskSummary": {
     "Ferry": "Brittany Ferries voyage of BARFLEUR",
     "Departure": "4 Aug 2020 at 13:05",
     "Arrival": "4 Aug 2020 at 13:35",
-    "Account": "unknown, booked on 2 Aug 2020 at 09:15",
-    "Haulier": "unknown"
+    "Account": "Arrival a year after travel",
+    "vehicle": ""
   }
 }
 

--- a/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehWithTrail-expected.json
+++ b/cypress/fixtures/taskInfo-unknown/RoRo-Acc-VehWithTrail-expected.json
@@ -1,7 +1,6 @@
 {
   "taskListDetails": {
-    "mode": "Pre-Arrival",
-    "rules": "Scenario 1 Rule, Tier 1, Class A Drugs and 0 other rules",
+    "rules": "Class A Drugs and 0 other rules",
     "voyage": "Brittany Ferries voyage of BARFLEUR",
     "arrival": "arrival a year after travel",
     "departurePort": "unknown",
@@ -17,13 +16,13 @@
     "passengerDetails": "None",
     "trailerRegitration": "NL-234-392",
     "trailerTrips": "0 trips",
-    "riskScore": "Risk Score:"
+    "riskScore": "Risk Score: 0"
   },
   "taskSummary": {
     "Ferry": "Brittany Ferries voyage of BARFLEUR",
     "Departure": "4 Aug 2020 at 13:05",
     "Arrival": "4 Aug 2020 at 13:35",
-    "Account": "unknown, booked on 2 Aug 2020 at 09:15",
-    "Haulier": "unknown"
+    "Account": "Arrival a year after travel",
+    "vehicle": "TrailerNL-234-392"
   }
 }

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -294,8 +294,6 @@ describe('Issue target from cerberus UI using target sheet information form', ()
         cy.verifyElementText('model', targetData.vehicle.Model);
         cy.verifyElementText('colour', targetData.vehicle.Colour);
         cy.verifyElementText('registrationNumber', targetData.vehicle['Vehicle registration']);
-        cy.verifyElementText('regNumber', targetData.vehicle['Trailer registration number']);
-
         cy.get('.formio-component-driver').within(() => {
           cy.verifyElementText('firstName', driverFirstName.split(' ')[0]);
           cy.verifyElementText('lastName', driverFirstName.split(' ')[1]);

--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -11,7 +11,9 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
   it('Should navigate to task details page', () => {
     cy.get('h4.task-heading').eq(1).invoke('text').then((text) => {
       cy.get('.govuk-task-list-card a').eq(1).click();
-      cy.get('.govuk-caption-xl').should('have.text', text);
+      cy.get('.govuk-caption-xl').invoke('text').then((taskTitle) => {
+        expect(text).to.contain(taskTitle);
+      });
     });
     cy.wait(2000);
     cy.get('.govuk-accordion__open-all').click();
@@ -73,6 +75,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
   it('Should add Notes for the tasks assigned to others', () => {
     const notesText = 'adding notes on someone else task';
+    cy.intercept('POST', '/camunda/engine-rest/process-definition/key/noteSubmissionWrapper/submit-form').as('submitNotes');
     cy.fixture('tasks.json').then((task) => {
       let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
@@ -96,7 +99,10 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('button[name="data[submit]"]').click();
 
-    cy.wait(2000);
+    cy.wait('@submitNotes').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
     cy.getActivityLogs().then((activities) => {
       expect(activities).to.contain(notesText);
     });
@@ -271,7 +277,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
         cy.clickNext();
 
-        cy.typeValueInTextArea('note', 'This is for testing');
+        cy.typeValueInTextArea('addANote', 'This is for testing');
 
         cy.clickSubmit();
 
@@ -283,6 +289,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.getActivityLogs().then((activities) => {
       expect(activities).to.contain(expectedActivity);
+      expect(activities).not.to.contain('Property delete changed from false to true');
     });
   });
 
@@ -338,7 +345,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
         cy.waitForNoErrors();
 
-        cy.typeValueInTextArea('note', 'This is for testing');
+        cy.typeValueInTextArea('addANote', 'This is for testing');
 
         cy.clickSubmit();
 
@@ -350,6 +357,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.getActivityLogs().then((activities) => {
       expect(activities).to.contain(expectedActivity);
+      expect(activities).not.to.contain('Property delete changed from false to true');
     });
   });
 
@@ -464,8 +472,8 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
           });
       });
 
-    cy.get('.card .govuk-caption-m').should('contain.text', 'Vehicle with Trailer');
-    cy.get('.card .govuk-heading-m').should('contain.text', 'NL-234-392');
+    cy.get('.card .govuk-caption-m').should('contain.text', 'Trailer');
+    cy.get('.card .govuk-heading-s').should('contain.text', 'NL-234-392');
 
     cy.get('@expTestData').then((expTestData) => {
       cy.checkTaskSummaryDetails().then((taskSummary) => {
@@ -504,8 +512,6 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
           });
       });
 
-    cy.get('.card .govuk-caption-m').should('contain.text', 'Vehicle');
-
     cy.get('@expTestData').then((expTestData) => {
       cy.checkTaskSummaryDetails().then((taskSummary) => {
         expect(taskSummary).to.deep.equal(expTestData.taskSummary);
@@ -536,7 +542,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       });
 
     cy.get('.card .govuk-caption-m').should('contain.text', 'Vehicle with Trailer');
-    cy.get('.card .govuk-heading-m').should('contain.text', 'NL-234-392');
+    cy.get('.card .govuk-heading-s').should('contain.text', 'NL-234-392');
 
     cy.get('@expTestData').then((expTestData) => {
       cy.checkTaskSummaryDetails().then((taskSummary) => {
@@ -610,14 +616,11 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
             .then((response) => {
               cy.wait(4000);
               cy.checkTaskDisplayed(`${response.businessKey}`);
-              cy.get('h3:contains(Driver)')
-                .parent('div')
-                .within(() => {
-                  cy.get('dt')
-                    .contains('Name')
-                    .next()
-                    .should('have.text', expDriver);
+              cy.contains('h3', 'Driver').next().within(() => {
+                cy.getTaskDetails().then((details) => {
+                  expect(details.Name).to.be.equal(expDriver);
                 });
+              });
             });
         });
     });


### PR DESCRIPTION
## Description
Add test to verify 'Property delete changed from false to true' removed from activity log
Fix failing tests due to the latest changes.

## To Test
npm run cypress:runner
run all tests from spec `task-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
