### PR TITLE
COP-9661: Add test for Multi-select modes persist selection on page refresh

### DIFF
--- a/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
@@ -180,6 +180,22 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
         cy.contains('Clear all filters').click();
       });
     });
+
+    // COP-9661 Multi-select modes persist selection on page refresh
+    filterOptions.forEach((mode) => {
+      cy.applyModesFilter(mode, 'new').then((actualTargets) => {
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.new).be.equal(actualTargets);
+        });
+        cy.reload();
+        cy.contains('Clear all filters').click();
+        cy.wait(2000);
+        cy.getTaskCount(mode, null).then((response) => {
+          expect(response.new).be.equal(actualTargets);
+        });
+        cy.contains('Clear all filters').click();
+      });
+    });
   });
 
   it('Should apply filter tasks by roro-unaccompanied mode & has selectors on New tasks', () => {


### PR DESCRIPTION
## Description
Add test for following scenario,
1.) Tick box for RoRo unacc filter
2.) Click on apply filters
3.) Refresh page
4.) Click on clear filters
5.) Tab counts & results are updated

## To Test
npm run cypress:runner
run test `Should retain applied filter after page reload & navigating between pages` from spec `filter-tasks-by-pre-arrival-mode.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
