### PR TITLE
Cop 9825 bring back selector matches

### DIFF
--- a/src/routes/__tests__/TaskVersions.test.jsx
+++ b/src/routes/__tests__/TaskVersions.test.jsx
@@ -14,7 +14,7 @@ describe('TaskVersions', () => {
       taskVersionDifferencesCounts={[]}
       movementMode="RORO Unaccompanied Freight"
     />);
-    expect(screen.queryByText(/Category/)).toBeInTheDocument();
+    expect(screen.queryByText('Category')).toBeInTheDocument();
   });
 
   it('should render No rule matches', () => {


### PR DESCRIPTION
## Description
COP-9825: Bring back selector matches

## To Test
Select any task with selector on a task list page to see the selector details on a task details page.

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [*] All reviewer comments resolved/answered? \*
