### PR TITLE
COP 9617: Render risk indicators for rule matches

### DIFF
--- a/src/govuk/Table.jsx
+++ b/src/govuk/Table.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const Table = ({ headings, rows }) => {
+  let tableHeadings = headings
+    ? (
+      <tr className="govuk-table__row">
+        {
+          headings.map((heading, index) => (
+            <th key={index} className="govuk-table__header">{heading}</th>
+          ))
+        }
+      </tr>
+    )
+    : null;
+
+  let tableRows = rows
+    ? rows.map((row, index) => (
+      <tr key={index} className="govuk-table__row">
+        <th className="govuk-table__header">{row.shift()}</th>
+        {
+          row.map((rowItem, itemIndex) => (
+            <td key={itemIndex} className="govuk-table__cell">{rowItem}</td>
+          ))
+        }
+      </tr>
+    ))
+    : null;
+
+  return (
+    <table className="govuk-table">
+      {
+        tableHeadings
+          ? <thead className="govuk-table__head">{tableHeadings}</thead>
+          : null
+      }
+      {
+        tableRows
+          ? <tbody className="govuk-table__body">{tableRows}</tbody>
+          : null
+      }
+    </table>
+  );
+};
+
+export default Table;

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -159,14 +159,24 @@ const renderRulesSection = (version) => {
                 <div className="govuk-grid-row">
                   <div className="govuk-grid-column-full">
                     <h4 className="govuk-heading-s">Risk indicators ({firstRule.childSets.length})</h4>
-                    <Table
-                      headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
-                      rows={translateRiskIndicators(firstRule.childSets)}
-                    />
+                    {
+                      firstRule.childSets.length > 0
+                        ? (
+                          <Table
+                            headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
+                            rows={translateRiskIndicators(firstRule.childSets)}
+                          />
+                        )
+                        : null
+                    }
                   </div>
                 </div>
               )
-              : null
+              : (
+                <div className="govuk-grid-column-full">
+                  <h4 className="govuk-heading-s">Risk indicators (0)</h4>
+                </div>
+              )
           }
         </div>
 
@@ -215,13 +225,23 @@ const renderRulesSection = (version) => {
                       ? (
                         <div className="govuk-grid-column-full">
                           <h4 className="govuk-heading-s">Risk indicators ({rule.childSets.length})</h4>
-                          <Table
-                            headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
-                            rows={translateRiskIndicators(rule.childSets)}
-                          />
+                          {
+                            rule.childSets.length > 0
+                              ? (
+                                <Table
+                                  headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
+                                  rows={translateRiskIndicators(rule.childSets)}
+                                />
+                              )
+                              : null
+                          }
                         </div>
                       )
-                      : null
+                      : (
+                        <div className="govuk-grid-column-full">
+                          <h4 className="govuk-heading-s">Risk indicators (0)</h4>
+                        </div>
+                      )
                     }
                 </div>
               </details>

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -16,12 +16,23 @@ import { RORO_TOURIST, LONG_DATE_FORMAT, RORO_TOURIST_CAR_ICON,
 import getMovementModeIcon from '../../utils/getVehicleModeIcon';
 import { modifyRoRoPassengersTaskDetails } from '../../utils/roroDataUtil';
 import capitalizeFirstLetter from '../../utils/stringConversion';
+import Table from '../../govuk/Table';
 
 let threatLevel;
 
 const isLatest = (index) => {
   return index === 0 ? '(latest)' : '';
 };
+
+const translateRiskIndicators = (riskIndicators) => riskIndicators.map((riskIndicator) => {
+  let result = [4];
+  result[0] = riskIndicator.contents.find((item) => item.propName === 'entity').content;
+  result[1] = riskIndicator.contents.find((item) => item.propName === 'attribute').content;
+  result[2] = riskIndicator.contents.find((item) => item.propName === 'operator').content;
+  result[3] = riskIndicator.contents.find((item) => item.propName === 'indicatorValue').content;
+
+  return result;
+});
 
 const renderFieldSetContents = (contents) => contents.map(({ fieldName, content, type }) => {
   if (!type.includes('HIDDEN')) {
@@ -142,6 +153,21 @@ const renderRulesSection = (version) => {
               <p>{firstRule.contents.find((item) => item.propName === 'agencyCode').content}</p>
             </div>
           </div>
+          {
+            firstRule.hasChildSet
+              ? (
+                <div className="govuk-grid-row">
+                  <div className="govuk-grid-column-full">
+                    <h4 className="govuk-heading-s">Risk indicators ({firstRule.childSets.length})</h4>
+                    <Table
+                      headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
+                      rows={translateRiskIndicators(firstRule.childSets)}
+                    />
+                  </div>
+                </div>
+              )
+              : null
+          }
         </div>
 
         { otherRules.length > 0 && (
@@ -184,6 +210,19 @@ const renderRulesSection = (version) => {
                     <h4 className="govuk-heading-s">Agency</h4>
                     <p>{rule.contents.find((item) => item.propName === 'agencyCode').content}</p>
                   </div>
+                  {
+                    rule.hasChildSet
+                      ? (
+                        <div className="govuk-grid-column-full">
+                          <h4 className="govuk-heading-s">Risk indicators ({rule.childSets.length})</h4>
+                          <Table
+                            headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
+                            rows={translateRiskIndicators(rule.childSets)}
+                          />
+                        </div>
+                      )
+                      : null
+                    }
                 </div>
               </details>
             </div>

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -173,8 +173,10 @@ const renderRulesSection = (version) => {
                 </div>
               )
               : (
-                <div className="govuk-grid-column-full">
-                  <h4 className="govuk-heading-s">Risk indicators (0)</h4>
+                <div className="govuk-grid-row">
+                  <div className="govuk-grid-column-full">
+                    <h4 className="govuk-heading-s">Risk indicators (0)</h4>
+                  </div>
                 </div>
               )
           }

--- a/src/routes/__fixtures__/taskVersions.js
+++ b/src/routes/__fixtures__/taskVersions.js
@@ -802,7 +802,7 @@ const taskSingleVersion = [
       childSets: [
         {
           fieldSetName: '',
-          hasChildSet: false,
+          hasChildSet: true,
           contents: [
             {
               fieldName: 'Name',
@@ -852,6 +852,80 @@ const taskSingleVersion = [
               content: 293,
               versionLastUpdated: null,
               propName: 'ruleId',
+            },
+          ],
+          childSets: [
+            {
+              fieldSetName: 'Indicator matches',
+              hasChildSet: false,
+              contents: [
+                {
+                  fieldName: 'Entity',
+                  type: 'TEXT_CELL',
+                  content: 'Vehicle',
+                  versionLastUpdated: null,
+                  propName: 'entity',
+                },
+                {
+                  fieldName: 'Attribute',
+                  type: 'TEXT_CELL',
+                  content: 'Vehicle is empty',
+                  versionLastUpdated: null,
+                  propName: 'attribute',
+                },
+                {
+                  fieldName: 'Operator',
+                  type: 'TEXT_CELL',
+                  content: 'equals',
+                  versionLastUpdated: null,
+                  propName: 'operator',
+                },
+                {
+                  fieldName: 'Value',
+                  type: 'BOOLEAN_CELL',
+                  content: 'true',
+                  versionLastUpdated: null,
+                  propName: 'indicatorValue',
+                },
+              ],
+              type: 'STANDARD',
+              propName: 'indicatorMatches',
+            },
+            {
+              fieldSetName: 'Indicator matches',
+              hasChildSet: false,
+              contents: [
+                {
+                  fieldName: 'Entity',
+                  type: 'TEXT_CELL',
+                  content: 'Message',
+                  versionLastUpdated: null,
+                  propName: 'entity',
+                },
+                {
+                  fieldName: 'Attribute',
+                  type: 'TEXT_CELL',
+                  content: 'Mode',
+                  versionLastUpdated: null,
+                  propName: 'attribute',
+                },
+                {
+                  fieldName: 'Operator',
+                  type: 'TEXT_CELL',
+                  content: 'is one of',
+                  versionLastUpdated: null,
+                  propName: 'operator',
+                },
+                {
+                  fieldName: 'Value',
+                  type: 'BOOLEAN_CELL',
+                  content: 'RORO Accompanied Freight,RORO Unaccompanied Freight',
+                  versionLastUpdated: null,
+                  propName: 'indicatorValue',
+                },
+              ],
+              type: 'STANDARD',
+              propName: 'indicatorMatches',
             },
           ],
           type: 'null',
@@ -3307,5 +3381,7 @@ const noVehicleTwoPaxTsBasedOnTISData = {
   },
 };
 
-export { taskSingleVersion, taskNoRulesMatch, taskFootPassengerSingleVersion, taskFootPassengersSingleVersion,
-  taskSummaryBasedOnTISData, noVehicleSinglePaxTsBasedOnTISData, noVehicleTwoPaxTsBasedOnTISData };
+export {
+  taskSingleVersion, taskNoRulesMatch, taskFootPassengerSingleVersion, taskFootPassengersSingleVersion,
+  taskSummaryBasedOnTISData, noVehicleSinglePaxTsBasedOnTISData, noVehicleTwoPaxTsBasedOnTISData,
+};

--- a/src/routes/__tests__/TaskVersions.test.jsx
+++ b/src/routes/__tests__/TaskVersions.test.jsx
@@ -28,6 +28,7 @@ describe('TaskVersions', () => {
     expect(screen.queryByText(/Category/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Tier/)).not.toBeInTheDocument();
   });
+
   it('should render headers for RORO Tourist with vehicle', () => {
     render(<TaskVersions
       taskSummaryBasedOnTIS={taskSummaryBasedOnTISData}
@@ -37,7 +38,7 @@ describe('TaskVersions', () => {
     />);
 
     expect(screen.queryByText('Targeting indicators')).toBeInTheDocument();
-    expect(screen.queryAllByText('Vehicle')).toHaveLength(2);
+    expect(screen.queryAllByText('Vehicle')).toHaveLength(3);
     expect(screen.queryByText('Booking and check-in')).toBeInTheDocument();
     expect(screen.queryByText('Occupants')).toBeInTheDocument();
     expect(screen.queryByText('Passengers')).toBeInTheDocument();
@@ -89,5 +90,23 @@ describe('TaskVersions', () => {
     expect(screen.queryByText('Goods')).not.toBeInTheDocument();
     expect(screen.queryByText('Haulier details')).not.toBeInTheDocument();
     expect(screen.queryByText('Account details')).not.toBeInTheDocument();
+  });
+
+  it('should render rule matches with risk indicators', () => {
+    render(<TaskVersions
+      taskSummaryBasedOnTIS={taskSummaryBasedOnTISData}
+      taskVersions={taskSingleVersion}
+      taskVersionDifferencesCounts={[0]}
+      movementMode="RORO Tourist"
+    />);
+    expect(screen.queryByText('Rules matched')).toBeInTheDocument();
+    expect(screen.queryByText('Paid by Cash')).toBeInTheDocument();
+    expect(screen.queryByText('Risk indicators (2)')).toBeInTheDocument();
+    expect(screen.queryByText('Vehicle is empty')).toBeInTheDocument();
+    expect(screen.queryByText('Mode')).toBeInTheDocument();
+
+    expect(screen.queryByText('Other rule matches (1)')).toBeInTheDocument();
+    expect(screen.queryByText('Paid by cash1')).toBeInTheDocument();
+    expect(screen.queryByText('Risk indicators (0)')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description
- Added new `Table` component
- Render risk indicators table at the bottom of each rule match, if they exist. The title of this field should be `Risk indicators (X)`
- If not, only render `Risk indicators (0)`
- Created a very simple test for this
- Updated a fixture for the test

## To Test (Before process-models!527 is merged)
- Run the UI, click on a task and scroll down to the `Rules matched` section. By default, each should have a `Risk indicators (0)` title.
- Add a line after TaskVersions:119, updating `firstRule.childSets` with some input data and toggle `firstRule.hasChildSets` to `true`. If done correctly, this should render the table with the correct data.

## To Test (After process-models!527 is merged)
- Run the UI, click on a task and the risk indicators' data should be displayed in the `Risk indicators (X)` field.

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [x] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
