### PR TITLE
Cop 9796 enabled filtering counts

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -76,6 +76,13 @@ const filters = [
   },
 ];
 
+const TabStatusMapping = {
+  new: 'NEW',
+  inProgress: 'IN_PROGRESS',
+  issued: 'ISSUED',
+  complete: 'COMPLETE',
+};
+
 const TasksTab = ({ taskStatus, filtersToApply, setError, targetTaskCount = 0 }) => {
   dayjs.extend(relativeTime);
   dayjs.extend(utc);
@@ -380,32 +387,38 @@ const TaskListPage = () => {
     }
   };
 
-  const getFiltersAndSelectorsCount = async () => {
+  const getFiltersAndSelectorsCount = async (tabId = 'new') => {
     setFiltersAndSelectorsCount();
     if (camundaClientV1) {
       try {
         const filtersSelectorsCount = await camundaClientV1.post('/targeting-tasks/status-counts', [
           {
+            taskStatuses: [TabStatusMapping[tabId]],
             movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
             hasSelectors: null,
           },
           {
+            taskStatuses: [TabStatusMapping[tabId]],
             movementModes: ['RORO_ACCOMPANIED_FREIGHT'],
             hasSelectors: null,
           },
           {
+            taskStatuses: [TabStatusMapping[tabId]],
             movementModes: ['RORO_TOURIST'],
             hasSelectors: null,
           },
           {
+            taskStatuses: [TabStatusMapping[tabId]],
             movementModes: [],
             hasSelectors: true,
           },
           {
+            taskStatuses: [TabStatusMapping[tabId]],
             movementModes: [],
             hasSelectors: false,
           },
           {
+            taskStatuses: [TabStatusMapping[tabId]],
             movementModes: [],
             hasSelectors: null,
           },
@@ -595,9 +608,8 @@ const TaskListPage = () => {
                                 className={`govuk-!-padding-right-1 govuk-label govuk-${filterSet.filterClassPrefix}__label`}
                                 htmlFor={option.optionName}
                               >
-                                {option.optionLabel}
+                                {option.optionLabel} ({showFilterAndSelectorCount(parentIndex, index)})
                               </label>
-                              <span className="govuk-!-margin-top-2 inline-block">({showFilterAndSelectorCount(parentIndex, index)})</span>
                             </li>
                           );
                         })}
@@ -623,7 +635,10 @@ const TaskListPage = () => {
             <Tabs
               title="Title"
               id="tasks"
-              onTabClick={() => { history.push(); }}
+              onTabClick={(e) => {
+                history.push();
+                getFiltersAndSelectorsCount(e.id);
+              }}
               items={[
                 {
                   id: TASK_STATUS_NEW,

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -377,17 +377,17 @@ const TaskListPage = () => {
   const defaultMovementModes = [
     {
       taskStatuses: [],
-      movementModes: [],
+      movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
       hasSelectors: null,
     },
     {
       taskStatuses: [],
-      movementModes: [],
+      movementModes: ['RORO_ACCOMPANIED_FREIGHT'],
       hasSelectors: null,
     },
     {
       taskStatuses: [],
-      movementModes: [],
+      movementModes: ['RORO_TOURIST'],
       hasSelectors: null,
     },
   ];
@@ -413,7 +413,7 @@ const TaskListPage = () => {
   const getAppliedFilters = () => {
     const taskId = localStorage.getItem('taskId') !== 'null' ? localStorage.getItem('taskId') : 'new';
     if (localStorage.getItem('filterMovementMode')) {
-      const movementModes = defaultMovementModes.map((mode) => ({ taskStatuses: [TabStatusMapping[taskId]], movementModes: movementModesSelected, hasSelectors: mode.hasSelectors }));
+      const movementModes = defaultMovementModes.map((mode) => ({ taskStatuses: [TabStatusMapping[taskId]], movementModes: mode.movementModes, hasSelectors: mode.hasSelectors }));
       const selectors = defaultHasSelectors.map((selector) => ({ taskStatuses: [TabStatusMapping[taskId]], movementModes: movementModesSelected, hasSelectors: selector.hasSelectors }));
       return movementModes.concat(selectors);
     }
@@ -593,14 +593,15 @@ const TaskListPage = () => {
   };
 
   const renderSelectedFiltersCount = (filter, filterType) => {
-    const found = filtersAndSelectorsCount.find((f) => {
+    let totalCount;
+    const found = filtersAndSelectorsCount.find((f, index) => {
       if (filterType === 'radio' && ['true', 'false', 'any'].includes(filter)) {
-        const type = filter === 'any' ? null : JSON.parse(filter);
-        return f.filterParams.hasSelectors === type;
+        if (filter !== 'any') return f.filterParams.hasSelectors === JSON.parse(filter);
+        totalCount = (filtersAndSelectorsCount.length - 1) === index && f;
       }
       return f.filterParams.movementModes[0] === filter;
     });
-    return found?.statusCounts?.total;
+    return totalCount ? totalCount?.statusCounts?.total : found?.statusCounts?.total;
   };
 
   const showFilterAndSelectorCount = (parentIndex, index, filter, filterType) => {

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -28,6 +28,94 @@ describe('TaskListPage', () => {
       new: 76,
     },
   };
+
+  const countsFiltersAndSelectorsResponse = [
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 6,
+        new: 6,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_ACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 21,
+        new: 21,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_TOURIST'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 21,
+        new: 21,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: [],
+        hasSelectors: true,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 38,
+        new: 38,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: [],
+        hasSelectors: false,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 10,
+        new: 10,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: [],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 48,
+        new: 48,
+      },
+    },
+  ];
+
   let tabData = {};
 
   const setTabAndTaskValues = (value, taskStatus = 'new') => {
@@ -457,5 +545,20 @@ describe('TaskListPage', () => {
     await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
 
     expect(screen.queryAllByText('Unknown')).toHaveLength(1);
+  });
+
+  it('should render counts for filters and selectors', async () => {
+    mockAxios
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, countsFiltersAndSelectorsResponse)
+      .onPost('/targeting-tasks/pages')
+      .reply(200, []);
+
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'NEW')));
+    expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
+    expect(screen.getByText('RoRo unaccompanied freight (6)')).toBeInTheDocument();
+    expect(screen.getByText('RoRo accompanied freight (21)')).toBeInTheDocument();
+    expect(screen.getByText('RoRo Tourist (21)')).toBeInTheDocument();
+    expect(screen.getByText('New (6)')).toBeInTheDocument();
   });
 });

--- a/src/routes/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/__tests__/TaskListPageFilters.test.jsx
@@ -114,6 +114,180 @@ describe('TaskListFilters', () => {
     },
   ];
 
+  const countsRoroUnaccompaniedFrieghtSelected = [
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 12,
+        new: 12,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_ACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 20,
+        new: 20,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_TOURIST'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 38,
+        new: 38,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
+        hasSelectors: true,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 12,
+        new: 12,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
+        hasSelectors: false,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 0,
+        new: 0,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 12,
+        new: 12,
+      },
+    },
+  ];
+
+  const countsRoroUnaccompaniedAndAccompaniedFrieghtWithPresentSelectorSelected = [
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 12,
+        new: 12,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_ACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 20,
+        new: 20,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_TOURIST'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 38,
+        new: 38,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT', 'RORO_ACCOMPANIED_FREIGHT'],
+        hasSelectors: true,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 27,
+        new: 27,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT', 'RORO_ACCOMPANIED_FREIGHT'],
+        hasSelectors: false,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 5,
+        new: 5,
+      },
+    },
+    {
+      filterParams: {
+        taskStatuses: ['NEW'],
+        movementModes: ['RORO_UNACCOMPANIED_FREIGHT', 'RORO_ACCOMPANIED_FREIGHT'],
+        hasSelectors: null,
+      },
+      statusCounts: {
+        inProgress: 0,
+        issued: 0,
+        complete: 0,
+        total: 32,
+        new: 32,
+      },
+    },
+  ];
+
   it('should display filter options based on filter config (filters.js)', () => {
     // Titles & Actions
     expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -200,5 +374,51 @@ describe('TaskListFilters', () => {
     expect(screen.getByText('Present (0)')).toBeInTheDocument();
     expect(screen.getByText('Not present (0)')).toBeInTheDocument();
     expect(screen.getByText('Any (0)')).toBeInTheDocument();
+  });
+
+  it('should render counts for filter Roro unaccompanied freight selected for NEW TAB state', async () => {
+    localStorage.setItem('hasSelector', 'null');
+    localStorage.setItem('filterMovementMode', 'RORO_UNACCOMPANIED_FREIGHT');
+    expect(localStorage.getItem('hasSelector')).toBe('null');
+    expect(localStorage.getItem('filterMovementMode')).toBe('RORO_UNACCOMPANIED_FREIGHT');
+    mockAxios
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, countsRoroUnaccompaniedFrieghtSelected)
+      .onPost('/targeting-tasks/pages')
+      .reply(200, []);
+
+    fireEvent.click(screen.getByText('Apply filters'));
+
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'NEW')));
+    expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
+    expect(screen.getAllByText('RoRo unaccompanied freight (12)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('RoRo accompanied freight (20)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('RoRo Tourist (38)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Present (12)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Not present (0)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Any (12)')[0]).toBeInTheDocument();
+  });
+
+  it('Filters counts for Roro unaccompanied & Roro accompanied freight with Present selector', async () => {
+    localStorage.setItem('hasSelector', 'true');
+    localStorage.setItem('filterMovementMode', 'RORO_UNACCOMPANIED_FREIGHT,RORO_ACCOMPANIED_FREIGHT');
+    expect(localStorage.getItem('hasSelector')).toBe('true');
+    expect(localStorage.getItem('filterMovementMode')).toBe('RORO_UNACCOMPANIED_FREIGHT,RORO_ACCOMPANIED_FREIGHT');
+    mockAxios
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, countsRoroUnaccompaniedAndAccompaniedFrieghtWithPresentSelectorSelected)
+      .onPost('/targeting-tasks/pages')
+      .reply(200, []);
+
+    fireEvent.click(screen.getByText('Apply filters'));
+
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'NEW')));
+    expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
+    expect(screen.getAllByText('RoRo unaccompanied freight (12)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('RoRo accompanied freight (20)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('RoRo Tourist (38)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Present (27)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Not present (5)')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Any (32)')[0]).toBeInTheDocument();
   });
 });

--- a/src/routes/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/__tests__/TaskListPageFilters.test.jsx
@@ -33,34 +33,34 @@ describe('TaskListFilters', () => {
 
     // Check boxes
     expect(screen.getAllByRole('checkbox').length).toBe(3);
-    expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo accompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo unaccompanied freight (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo accompanied freight (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist (0)')).not.toBeChecked();
 
     // Radio buttons
     expect(screen.getAllByRole('radio').length).toBe(3);
-    expect(screen.getByLabelText('Not present')).not.toBeChecked();
-    expect(screen.getByLabelText('Present')).not.toBeChecked();
-    expect(screen.getByLabelText('Any')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('Present (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('Any (0)')).not.toBeChecked();
   });
 
   it('should allow user to select a single radio button in each group', () => {
     // group one select
-    fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
+    fireEvent.click(screen.getByLabelText('RoRo accompanied freight (0)'));
     // group two select first 'has', then 'has no'
-    fireEvent.click(screen.getByLabelText('Present'));
-    fireEvent.click(screen.getByLabelText('Not present'));
+    fireEvent.click(screen.getByLabelText('Present (0)'));
+    fireEvent.click(screen.getByLabelText('Not present (0)'));
 
-    expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo accompanied freight')).toBeChecked();
-    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
-    expect(screen.getByLabelText('Not present')).toBeChecked();
-    expect(screen.getByLabelText('Present')).not.toBeChecked(); // this is reset to 'not' when 'has no' is selected
+    expect(screen.getByLabelText('RoRo unaccompanied freight (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo accompanied freight (0)')).toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present (0)')).toBeChecked();
+    expect(screen.getByLabelText('Present (0)')).not.toBeChecked(); // this is reset to 'not' when 'has no' is selected
   });
 
   it('should store selection to localstorage when apply filters button is clicked', () => {
-    fireEvent.click(screen.getByLabelText('RoRo accompanied freight'));
-    fireEvent.click(screen.getByLabelText('Present'));
+    fireEvent.click(screen.getByLabelText('RoRo accompanied freight (0)'));
+    fireEvent.click(screen.getByLabelText('Present (0)'));
     fireEvent.click(screen.getByText('Apply filters'));
 
     expect(localStorage.getItem('hasSelector')).toBe('true');
@@ -75,11 +75,11 @@ describe('TaskListFilters', () => {
 
     fireEvent.click(screen.getByText('Clear all filters'));
 
-    expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo accompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
-    expect(screen.getByLabelText('Not present')).not.toBeChecked();
-    expect(screen.getByLabelText('Present')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo unaccompanied freight (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo accompanied freight (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('Present (0)')).not.toBeChecked();
     expect(localStorage.getItem('hasSelector')).toBeFalsy();
     expect(localStorage.getItem('filterMovementMode')).toBeFalsy();
   });
@@ -87,10 +87,10 @@ describe('TaskListFilters', () => {
   it('should persist filters when they exist in local storage', () => {
     localStorage.setItem('filterMovementMode', 'RORO_ACCOMPANIED_FREIGHT');
 
-    expect(screen.getByLabelText('RoRo unaccompanied freight')).not.toBeChecked();
-    expect(screen.getByLabelText('RoRo Tourist')).not.toBeChecked();
-    expect(screen.getByLabelText('Not present')).not.toBeChecked();
-    expect(screen.getByLabelText('Present')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo unaccompanied freight (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('RoRo Tourist (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('Not present (0)')).not.toBeChecked();
+    expect(screen.getByLabelText('Present (0)')).not.toBeChecked();
     expect(localStorage.getItem('filterMovementMode')).toBe('RORO_ACCOMPANIED_FREIGHT');
   });
 });


### PR DESCRIPTION
## Description
COP-9796: Filters and selectors are showing counts based on selection criteria

## To Test
1. Select any tab(New, In progress, Issued, Complete) on tasklist page.
2. Select various filters & selectors, click on Apply filters button to see the rendered counts for each filter and selector from the API
3. Clicking on Clear all filters link would reset the count for the selected tab

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [*] All reviewer comments resolved/answered? \*
