### PR TITLE
COP-9674: Add test to verify No icon displayed if Vehicle node is Empty & non RoRo Tourist task

### DIFF
--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -20,8 +20,26 @@ describe('Create task with different payload from Cerberus', () => {
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
       cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-VEHICLE-NULL`).then((response) => {
         cy.wait(4000);
-        cy.checkTaskDisplayed(`${response.businessKey}`);
+        let businessKey = response.businessKey;
+        cy.checkTaskDisplayed(businessKey);
         cy.checkTaskSummary(null, bookingDateTime);
+        const nextPage = 'a[data-test="next"]';
+        cy.visit('/tasks');
+        cy.get('body').then(($el) => {
+          if ($el.find(nextPage).length > 0) {
+            cy.findTaskInAllThePages(businessKey, null, null).then(() => {
+              cy.get('.govuk-task-list-card').contains(businessKey).parents('.card-container').within(() => {
+                cy.get('.task-list--item-2 .govuk-grid-column-one-quarter').find('[class^=c-icon-]').should('not.exist');
+              });
+            });
+          } else {
+            cy.findTaskInSinglePage(businessKey, null, null).then(() => {
+              cy.get('.govuk-task-list-card').contains(businessKey).parents('.card-container').within(() => {
+                cy.get('.task-list--item-2 .govuk-grid-column-one-quarter').find('[class^=c-icon-]').should('not.exist');
+              });
+            });
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
## Description
Add test to verify the following scenario,

Scenario: NOT RoRo Tourist: no Vehicle (or trailer)
GIVEN a NON RoRo Tourist task
AND it does not have any vehicles or trailers
WHEN the task is displayed in the task list
THEN NO icon is displayed

## To Test
npm run cypress:runner

run test `Should create a task with a payload contains vehicle value as null` from spec `create-tasks.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
