### PR TITLE
COP-9845 - Check icon text matched icon displayed

### DIFF
--- a/src/routes/TaskDetails/TaskSummary.jsx
+++ b/src/routes/TaskDetails/TaskSummary.jsx
@@ -5,7 +5,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { LONG_DATE_FORMAT, RORO_TOURIST, RORO_TOURIST_SINGLE_ICON, RORO_TOURIST_GROUP_ICON } from '../../constants';
 import getMovementModeIcon from '../../utils/getVehicleModeIcon';
 import { modifyRoRoPassengersTaskList, hasVehicle, hasTrailer, hasDriver } from '../../utils/roroDataUtil';
-import { formatTaskIconText } from '../../utils/stringConversion';
+import { formatMovementModeIconText } from '../../utils/stringConversion';
 
 import '../__assets__/TaskDetailsPage.scss';
 
@@ -37,7 +37,7 @@ const getSummaryFirstHalf = (movementMode, roroData) => {
   return (
     <li>
       <span className="govuk-caption-m">
-        {formatTaskIconText(roroData)}
+        {formatMovementModeIconText(roroData, movementMode)}
       </span>
       <h3 className="govuk-heading-s">
         {hasVehicle(roroData.vehicle.registrationNumber) ? roroData.vehicle.registrationNumber : ''}

--- a/src/routes/TaskDetails/TaskSummary.jsx
+++ b/src/routes/TaskDetails/TaskSummary.jsx
@@ -4,7 +4,7 @@ import utc from 'dayjs/plugin/utc';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { LONG_DATE_FORMAT, RORO_TOURIST, RORO_TOURIST_SINGLE_ICON, RORO_TOURIST_GROUP_ICON } from '../../constants';
 import getMovementModeIcon from '../../utils/getVehicleModeIcon';
-import { modifyRoRoPassengersTaskList } from '../../utils/roroDataUtil';
+import { modifyRoRoPassengersTaskList, hasVehicle, hasTrailer, hasDriver } from '../../utils/roroDataUtil';
 
 import '../__assets__/TaskDetailsPage.scss';
 
@@ -36,16 +36,16 @@ const getSummaryFirstHalf = (movementMode, roroData) => {
   return (
     <li>
       <span className="govuk-caption-m">
-        {roroData.vehicle?.registrationNumber && 'Vehicle'}
-        {(roroData.vehicle?.registrationNumber && roroData.vehicle?.trailer?.regNumber) && ' with '}
-        {roroData?.vehicle?.trailer?.regNumber && 'Trailer'}
+        {hasVehicle(roroData.vehicle?.registrationNumber) && 'Vehicle'}
+        {(hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) && ' with '}
+        {hasTrailer(roroData?.vehicle?.trailer?.regNumber) && 'Trailer'}
       </span>
       <h3 className="govuk-heading-s">
-        {roroData.vehicle && roroData.vehicle.registrationNumber}
-        {(roroData.vehicle?.registrationNumber && roroData.vehicle?.trailer?.regNumber) && <span className="govuk-!-font-weight-regular"> with </span>}
-        {roroData.vehicle?.trailer?.regNumber && roroData.vehicle.trailer.regNumber}
-        {roroData.driver?.name && <span className="govuk-!-font-weight-regular"> driven by </span>}
-        {roroData.driver?.name && roroData.driver.name}
+        {hasVehicle(roroData.vehicle.registrationNumber) && roroData.vehicle.registrationNumber}
+        {(hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) && <span className="govuk-!-font-weight-regular"> with </span>}
+        {hasTrailer(roroData.vehicle?.trailer?.regNumber) && roroData.vehicle.trailer.regNumber}
+        {hasDriver(roroData.driver?.name) && <span className="govuk-!-font-weight-regular"> driven by </span>}
+        {hasDriver(roroData.driver?.name) && roroData.driver.name}
       </h3>
     </li>
   );

--- a/src/routes/TaskDetails/TaskSummary.jsx
+++ b/src/routes/TaskDetails/TaskSummary.jsx
@@ -5,6 +5,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { LONG_DATE_FORMAT, RORO_TOURIST, RORO_TOURIST_SINGLE_ICON, RORO_TOURIST_GROUP_ICON } from '../../constants';
 import getMovementModeIcon from '../../utils/getVehicleModeIcon';
 import { modifyRoRoPassengersTaskList, hasVehicle, hasTrailer, hasDriver } from '../../utils/roroDataUtil';
+import { formatTaskIconText } from '../../utils/stringConversion';
 
 import '../__assets__/TaskDetailsPage.scss';
 
@@ -36,16 +37,14 @@ const getSummaryFirstHalf = (movementMode, roroData) => {
   return (
     <li>
       <span className="govuk-caption-m">
-        {hasVehicle(roroData.vehicle?.registrationNumber) && 'Vehicle'}
-        {(hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) && ' with '}
-        {hasTrailer(roroData?.vehicle?.trailer?.regNumber) && 'Trailer'}
+        {formatTaskIconText(roroData)}
       </span>
       <h3 className="govuk-heading-s">
-        {hasVehicle(roroData.vehicle.registrationNumber) && roroData.vehicle.registrationNumber}
-        {(hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) && <span className="govuk-!-font-weight-regular"> with </span>}
-        {hasTrailer(roroData.vehicle?.trailer?.regNumber) && roroData.vehicle.trailer.regNumber}
-        {hasDriver(roroData.driver?.name) && <span className="govuk-!-font-weight-regular"> driven by </span>}
-        {hasDriver(roroData.driver?.name) && roroData.driver.name}
+        {hasVehicle(roroData.vehicle.registrationNumber) ? roroData.vehicle.registrationNumber : ''}
+        {(hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) ? <span className="govuk-!-font-weight-regular"> with </span> : ''}
+        {hasTrailer(roroData.vehicle?.trailer?.regNumber) ? roroData.vehicle.trailer.regNumber : ''}
+        {hasVehicle(roroData.vehicle.registrationNumber) && hasDriver(roroData.driver?.name) ? <span className="govuk-!-font-weight-regular"> driven by </span> : ''}
+        {hasVehicle(roroData.vehicle.registrationNumber) && hasDriver(roroData.driver?.name) ? roroData.driver.name : ''}
       </h3>
     </li>
   );

--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -15,7 +15,7 @@ import { RORO_TOURIST, LONG_DATE_FORMAT, RORO_TOURIST_CAR_ICON,
 // utils
 import getMovementModeIcon from '../../utils/getVehicleModeIcon';
 import { modifyRoRoPassengersTaskDetails } from '../../utils/roroDataUtil';
-import capitalizeFirstLetter from '../../utils/stringConversion';
+import { capitalizeFirstLetter } from '../../utils/stringConversion';
 
 let threatLevel;
 

--- a/src/routes/TaskLists/TaskListMode.jsx
+++ b/src/routes/TaskLists/TaskListMode.jsx
@@ -8,7 +8,6 @@ import * as constants from '../../constants';
 import targetDatetimeDifference from '../../utils/calculateDatetimeDifference';
 import formatGender from '../../utils/genderFormatter';
 import { hasVehicleMake, hasVehicleModel, hasVehicle, hasTrailer } from '../../utils/roroDataUtil';
-import { formatTaskIconText } from '../../utils/stringConversion';
 
 const getMovementModeTypeText = (movementModeIcon) => {
   switch (movementModeIcon) {
@@ -71,9 +70,7 @@ const renderRoroModeSection = (roroData, movementModeIcon) => {
     return (
       <div className="govuk-grid-column-one-quarter govuk-!-padding-left-9">
         <i className={`icon-position--left ${movementModeIcon}`} />
-        <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0 govuk-!-padding-left-1">
-          {formatTaskIconText(roroData)}
-        </p>
+        <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0 govuk-!-padding-left-1">{'\xa0'}</p>
         <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-padding-left-1">
           {hasTrailer(roroData.vehicle?.trailer?.regNumber) ? roroData.vehicle.trailer.regNumber.toUpperCase() : '\xa0'}
         </p>

--- a/src/routes/TaskLists/TaskListMode.jsx
+++ b/src/routes/TaskLists/TaskListMode.jsx
@@ -7,6 +7,8 @@ import * as constants from '../../constants';
 // Utils
 import targetDatetimeDifference from '../../utils/calculateDatetimeDifference';
 import formatGender from '../../utils/genderFormatter';
+import { hasVehicleMake, hasVehicleModel, hasVehicle, hasTrailer } from '../../utils/roroDataUtil';
+import { formatTaskIconText } from '../../utils/stringConversion';
 
 const getMovementModeTypeText = (movementModeIcon) => {
   switch (movementModeIcon) {
@@ -65,11 +67,29 @@ const renderRoRoTouristModeSection = (roroData, movementModeIcon, passengers) =>
 };
 
 const renderRoroModeSection = (roroData, movementModeIcon) => {
+  if (movementModeIcon === constants.RORO_UNACCOMPANIED_ICON) {
+    return (
+      <div className="govuk-grid-column-one-quarter govuk-!-padding-left-9">
+        <i className={`icon-position--left ${movementModeIcon}`} />
+        <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0 govuk-!-padding-left-1">
+          {formatTaskIconText(roroData)}
+        </p>
+        <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-padding-left-1">
+          {hasTrailer(roroData.vehicle?.trailer?.regNumber) ? roroData.vehicle.trailer.regNumber.toUpperCase() : '\xa0'}
+        </p>
+      </div>
+    );
+  }
   return (
     <div className="govuk-grid-column-one-quarter govuk-!-padding-left-9">
       <i className={`icon-position--left ${movementModeIcon}`} />
-      <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0 govuk-!-padding-left-1">{!roroData.vehicle.make ? '\xa0' : roroData.vehicle.make} {roroData.vehicle.model}</p>
-      <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-padding-left-1">{!roroData.vehicle.registrationNumber ? '\xa0' : roroData.vehicle.registrationNumber.toUpperCase()}</p>
+      <p className="govuk-body-s content-line-one govuk-!-margin-bottom-0 govuk-!-padding-left-1">
+        {hasVehicleMake(roroData.vehicle?.make) ? roroData.vehicle.make : '\xa0'}{' '}
+        {hasVehicleModel(roroData.vehicle?.model) ? roroData.vehicle.model : '\xa0'}
+      </p>
+      <p className="govuk-body-s govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-padding-left-1">
+        {hasVehicle(roroData.vehicle?.registrationNumber) ? roroData.vehicle.registrationNumber.toUpperCase() : '\xa0'}
+      </p>
     </div>
   );
 };

--- a/src/utils/__fixtures__/roroData.fixture.js
+++ b/src/utils/__fixtures__/roroData.fixture.js
@@ -62,4 +62,273 @@ const testRoroData = {
   },
 };
 
-export default testRoroData;
+const testRoroDataTouristWithVehicle = {
+  movementStatus: 'Pre-Arrival',
+  bookingDateTime: '2020-08-02T09:15:00,2020-08-03T13:05:00',
+  vessel: {
+    name: 'DOVER SEAWAYS',
+    company: 'DFDS',
+  },
+  eta: '2021-12-02T10:36:53Z',
+  departureTime: '2020-08-03T13:05:00Z',
+  arrivalLocation: 'CAL',
+  departureLocation: 'DOV',
+  vehicle: {
+    colour: '',
+    model: '',
+    make: '',
+    registrationNumber: 'KR-8967L',
+    type: '',
+  },
+  load: {
+    manifestedLoad: 'Printed Paper',
+    manifestedWeight: '',
+    countryOfDestination: '',
+  },
+  account: {
+    name: 'Univeral Printers Ltd',
+    number: 'PO000359675',
+  },
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+  ],
+  haulier: {
+    name: 'Matthesons',
+    address: {
+      line1: '',
+      line2: '',
+      line3: null,
+      city: '',
+      postCode: '',
+      country: '',
+    },
+  },
+};
+
+const testRoroDataAccompaniedFreight = {
+  movementStatus: 'Pre-Arrival',
+  bookingDateTime: '2020-08-02T09:15:00,2020-08-03T13:05:00',
+  vessel: {
+    name: 'DOVER SEAWAYS',
+    company: 'DFDS',
+  },
+  eta: '2021-12-02T10:36:53Z',
+  departureTime: '2020-08-03T13:05:00Z',
+  arrivalLocation: 'CAL',
+  departureLocation: 'DOV',
+  vehicle: {
+    colour: '',
+    model: '',
+    make: '',
+    registrationNumber: 'KR-8967L',
+    type: '',
+    trailer: {
+      regNumber: 'TR-111L',
+    },
+  },
+  load: {
+    manifestedLoad: 'Printed Paper',
+    manifestedWeight: '',
+    countryOfDestination: '',
+  },
+  account: {
+    name: 'Univeral Printers Ltd',
+    number: 'PO000359675',
+  },
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+  ],
+  haulier: {
+    name: 'Matthesons',
+    address: {
+      line1: '',
+      line2: '',
+      line3: null,
+      city: '',
+      postCode: '',
+      country: '',
+    },
+  },
+};
+
+const testRoroDataAccompaniedFreightNoTrailer = {
+  movementStatus: 'Pre-Arrival',
+  bookingDateTime: '2020-08-02T09:15:00,2020-08-03T13:05:00',
+  vessel: {
+    name: 'DOVER SEAWAYS',
+    company: 'DFDS',
+  },
+  eta: '2021-12-02T10:36:53Z',
+  departureTime: '2020-08-03T13:05:00Z',
+  arrivalLocation: 'CAL',
+  departureLocation: 'DOV',
+  vehicle: {
+    colour: '',
+    model: '',
+    make: '',
+    registrationNumber: 'KR-8967L',
+    type: '',
+    trailer: {
+      regNumber: '',
+    },
+  },
+  load: {
+    manifestedLoad: 'Printed Paper',
+    manifestedWeight: '',
+    countryOfDestination: '',
+  },
+  account: {
+    name: 'Univeral Printers Ltd',
+    number: 'PO000359675',
+  },
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+  ],
+  haulier: {
+    name: 'Matthesons',
+    address: {
+      line1: '',
+      line2: '',
+      line3: null,
+      city: '',
+      postCode: '',
+      country: '',
+    },
+  },
+};
+
+const testRoroDataUnaccompaniedFreight = {
+  movementStatus: 'Pre-Arrival',
+  bookingDateTime: '2020-08-02T09:15:00,2020-08-03T13:05:00',
+  vessel: {
+    name: 'DOVER SEAWAYS',
+    company: 'DFDS',
+  },
+  eta: '2021-12-02T10:36:53Z',
+  departureTime: '2020-08-03T13:05:00Z',
+  arrivalLocation: 'CAL',
+  departureLocation: 'DOV',
+  vehicle: {
+    colour: '',
+    model: '',
+    make: '',
+    registrationNumber: '',
+    type: '',
+    trailer: {
+      regNumber: 'TR-111L',
+    },
+  },
+  load: {
+    manifestedLoad: 'Printed Paper',
+    manifestedWeight: '',
+    countryOfDestination: '',
+  },
+  account: {
+    name: 'Univeral Printers Ltd',
+    number: 'PO000359675',
+  },
+  driver: {
+    name: '',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+  ],
+  haulier: {
+    name: 'Matthesons',
+    address: {
+      line1: '',
+      line2: '',
+      line3: null,
+      city: '',
+      postCode: '',
+      country: '',
+    },
+  },
+};
+
+export { testRoroData,
+  testRoroDataTouristWithVehicle,
+  testRoroDataAccompaniedFreight,
+  testRoroDataUnaccompaniedFreight,
+  testRoroDataAccompaniedFreightNoTrailer };

--- a/src/utils/__fixtures__/roroData.fixture.js
+++ b/src/utils/__fixtures__/roroData.fixture.js
@@ -193,6 +193,73 @@ const testRoroDataAccompaniedFreight = {
   },
 };
 
+const testRoroDataAccompaniedFreightNoVehicleNoTrailer = {
+  movementStatus: 'Pre-Arrival',
+  bookingDateTime: '2020-08-02T09:15:00,2020-08-03T13:05:00',
+  vessel: {
+    name: 'DOVER SEAWAYS',
+    company: 'DFDS',
+  },
+  eta: '2021-12-02T10:36:53Z',
+  departureTime: '2020-08-03T13:05:00Z',
+  arrivalLocation: 'CAL',
+  departureLocation: 'DOV',
+  vehicle: {
+    colour: '',
+    model: '',
+    make: '',
+    registrationNumber: '',
+    type: '',
+    trailer: {
+      regNumber: '',
+    },
+  },
+  load: {
+    manifestedLoad: 'Printed Paper',
+    manifestedWeight: '',
+    countryOfDestination: '',
+  },
+  account: {
+    name: 'Univeral Printers Ltd',
+    number: 'PO000359675',
+  },
+  driver: {
+    name: 'Bob Brown',
+    dob: '12/03/1971',
+    gender: 'M',
+    docNumber: '244746NL',
+    docExpiry: '01/02/2021',
+    poleId: 'ROROXML:P=33f544d684db9e59150ae84406709122',
+    firstName: 'Bob',
+    lastName: 'Brown',
+    middleName: '',
+  },
+  passengers: [
+    {
+      name: 'Ben Bailey',
+      dob: '27/10/1969',
+      gender: 'M',
+      docNumber: '',
+      docExpiry: '',
+      poleId: 'ROROXML:P=26ebab61705c7a2c44b5f47ff0b4a58a',
+      firstName: 'Ben',
+      lastName: 'Bailey',
+      middleName: '',
+    },
+  ],
+  haulier: {
+    name: 'Matthesons',
+    address: {
+      line1: '',
+      line2: '',
+      line3: null,
+      city: '',
+      postCode: '',
+      country: '',
+    },
+  },
+};
+
 const testRoroDataAccompaniedFreightNoTrailer = {
   movementStatus: 'Pre-Arrival',
   bookingDateTime: '2020-08-02T09:15:00,2020-08-03T13:05:00',
@@ -331,4 +398,5 @@ export { testRoroData,
   testRoroDataTouristWithVehicle,
   testRoroDataAccompaniedFreight,
   testRoroDataUnaccompaniedFreight,
-  testRoroDataAccompaniedFreightNoTrailer };
+  testRoroDataAccompaniedFreightNoTrailer,
+  testRoroDataAccompaniedFreightNoVehicleNoTrailer };

--- a/src/utils/__tests__/roroDataUtil.test.jsx
+++ b/src/utils/__tests__/roroDataUtil.test.jsx
@@ -1,6 +1,6 @@
 import { modifyRoRoPassengersTaskList, hasCheckinDate, hasEta } from '../roroDataUtil';
 
-import testRoroData from '../__fixtures__/roroData.fixture';
+import { testRoroData } from '../__fixtures__/roroData.fixture';
 
 describe('RoRoData Util', () => {
   it('should return a modified roroData object with a list of 2 passengers', () => {

--- a/src/utils/__tests__/stringConversion.test.js
+++ b/src/utils/__tests__/stringConversion.test.js
@@ -1,0 +1,40 @@
+import { RORO_ACCOMPANIED_FREIGHT, RORO_TOURIST, RORO_UNACCOMPANIED_FREIGHT } from '../../constants';
+import { capitalizeFirstLetter, formatMovementModeIconText } from '../stringConversion';
+import { testRoroDataTouristWithVehicle, testRoroDataAccompaniedFreight, testRoroDataUnaccompaniedFreight,
+  testRoroDataAccompaniedFreightNoTrailer } from '../__fixtures__/roroData.fixture';
+
+describe('String Conversion', () => {
+  it('should capitalise first letter of given', () => {
+    const output = capitalizeFirstLetter('hello');
+    expect(output.charAt(0)).toEqual('H');
+  });
+
+  it('should not capitalize first letter of Integer at first position', () => {
+    const output = capitalizeFirstLetter('9hello');
+    expect(output.charAt(0)).toEqual('9');
+  });
+
+  it('should not capitalize first letter of empty given', () => {
+    const output = capitalizeFirstLetter('');
+    expect(output.charAt(0)).toEqual('');
+  });
+
+  it('should return expected text when movement is tourist (car)', () => {
+    const output = formatMovementModeIconText(testRoroDataTouristWithVehicle, RORO_TOURIST);
+    expect(output).toEqual('Vehicle');
+  });
+  it('should return expected text when is accompanied', () => {
+    const output = formatMovementModeIconText(testRoroDataAccompaniedFreight, RORO_ACCOMPANIED_FREIGHT);
+    expect(output).toEqual('Vehicle with Trailer');
+  });
+
+  it('should return expected text when movement is accompanied without trailer', () => {
+    const output = formatMovementModeIconText(testRoroDataAccompaniedFreightNoTrailer, RORO_ACCOMPANIED_FREIGHT);
+    expect(output).toEqual('Vehicle');
+  });
+
+  it('should return expected text when movement is unaccompanied freight', () => {
+    const output = formatMovementModeIconText(testRoroDataUnaccompaniedFreight, RORO_UNACCOMPANIED_FREIGHT);
+    expect(output).toEqual('Trailer');
+  });
+});

--- a/src/utils/__tests__/stringConversion.test.js
+++ b/src/utils/__tests__/stringConversion.test.js
@@ -1,7 +1,8 @@
 import { RORO_ACCOMPANIED_FREIGHT, RORO_TOURIST, RORO_UNACCOMPANIED_FREIGHT } from '../../constants';
 import { capitalizeFirstLetter, formatMovementModeIconText } from '../stringConversion';
 import { testRoroDataTouristWithVehicle, testRoroDataAccompaniedFreight, testRoroDataUnaccompaniedFreight,
-  testRoroDataAccompaniedFreightNoTrailer } from '../__fixtures__/roroData.fixture';
+  testRoroDataAccompaniedFreightNoTrailer,
+  testRoroDataAccompaniedFreightNoVehicleNoTrailer } from '../__fixtures__/roroData.fixture';
 
 describe('String Conversion', () => {
   it('should capitalise first letter of given', () => {
@@ -36,5 +37,10 @@ describe('String Conversion', () => {
   it('should return expected text when movement is unaccompanied freight', () => {
     const output = formatMovementModeIconText(testRoroDataUnaccompaniedFreight, RORO_UNACCOMPANIED_FREIGHT);
     expect(output).toEqual('Trailer');
+  });
+
+  it('should return expected text when movement is accompanied freight with no vehicle & trailer', () => {
+    const output = formatMovementModeIconText(testRoroDataAccompaniedFreightNoVehicleNoTrailer, RORO_UNACCOMPANIED_FREIGHT);
+    expect(output).toEqual('');
   });
 });

--- a/src/utils/__tests__/stringConversion.test.js
+++ b/src/utils/__tests__/stringConversion.test.js
@@ -40,7 +40,7 @@ describe('String Conversion', () => {
   });
 
   it('should return expected text when movement is accompanied freight with no vehicle & trailer', () => {
-    const output = formatMovementModeIconText(testRoroDataAccompaniedFreightNoVehicleNoTrailer, RORO_UNACCOMPANIED_FREIGHT);
+    const output = formatMovementModeIconText(testRoroDataAccompaniedFreightNoVehicleNoTrailer, RORO_ACCOMPANIED_FREIGHT);
     expect(output).toEqual('');
   });
 });

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -74,6 +74,14 @@ const hasVehicle = (vehicleRegistration) => {
   return vehicleRegistration !== null && vehicleRegistration !== undefined && vehicleRegistration !== '';
 };
 
+const hasVehicleMake = (vehicleMake) => {
+  return vehicleMake !== null && vehicleMake !== undefined && vehicleMake !== '';
+};
+
+const hasVehicleModel = (vehicleModel) => {
+  return vehicleModel !== null && vehicleModel !== undefined && vehicleModel !== '';
+};
+
 const hasTrailer = (trailerRegistration) => {
   return trailerRegistration !== null && trailerRegistration !== undefined && trailerRegistration !== '';
 };
@@ -82,4 +90,11 @@ const hasDriver = (driverName) => {
   return driverName !== null && driverName !== undefined && driverName !== '';
 };
 
-export { modifyRoRoPassengersTaskList, modifyRoRoPassengersTaskDetails, hasTaskVersionPassengers, hasVehicle, hasTrailer, hasDriver };
+export { modifyRoRoPassengersTaskList,
+  modifyRoRoPassengersTaskDetails,
+  hasTaskVersionPassengers,
+  hasVehicle,
+  hasVehicleMake,
+  hasVehicleModel,
+  hasTrailer,
+  hasDriver };

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -70,4 +70,16 @@ const modifyRoRoPassengersTaskDetails = (version) => {
   return version;
 };
 
-export { modifyRoRoPassengersTaskList, modifyRoRoPassengersTaskDetails, hasTaskVersionPassengers };
+const hasVehicle = (vehicleRegistration) => {
+  return vehicleRegistration !== null && vehicleRegistration !== undefined && vehicleRegistration !== '';
+};
+
+const hasTrailer = (trailerRegistration) => {
+  return trailerRegistration !== null && trailerRegistration !== undefined && trailerRegistration !== '';
+};
+
+const hasDriver = (driverName) => {
+  return driverName !== null && driverName !== undefined && driverName !== '';
+};
+
+export { modifyRoRoPassengersTaskList, modifyRoRoPassengersTaskDetails, hasTaskVersionPassengers, hasVehicle, hasTrailer, hasDriver };

--- a/src/utils/stringConversion.js
+++ b/src/utils/stringConversion.js
@@ -1,5 +1,15 @@
+import { hasVehicle, hasTrailer } from './roroDataUtil';
+
 const capitalizeFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
-export default capitalizeFirstLetter;
+const formatTaskIconText = (roroData) => {
+  let output = '';
+  output += hasVehicle(roroData.vehicle?.registrationNumber) ? 'Vehicle' : '';
+  output += (hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) ? ' with ' : '';
+  output += hasTrailer(roroData?.vehicle?.trailer?.regNumber) ? 'Trailer' : '';
+  return output;
+};
+
+export { capitalizeFirstLetter, formatTaskIconText };

--- a/src/utils/stringConversion.js
+++ b/src/utils/stringConversion.js
@@ -11,7 +11,8 @@ const formatMovementModeIconText = (roroData, movementMode) => {
     output += hasVehicle(roroData.vehicle?.registrationNumber) ? 'Vehicle' : '';
   } else {
     output += hasVehicle(roroData.vehicle?.registrationNumber) ? 'Vehicle' : '';
-    output += (hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) ? ' with ' : '';
+    output += (hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber))
+      ? ' with ' : '';
     output += hasTrailer(roroData?.vehicle?.trailer?.regNumber) ? 'Trailer' : '';
   }
   return output;

--- a/src/utils/stringConversion.js
+++ b/src/utils/stringConversion.js
@@ -1,15 +1,20 @@
+import { RORO_TOURIST } from '../constants';
 import { hasVehicle, hasTrailer } from './roroDataUtil';
 
 const capitalizeFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
-const formatTaskIconText = (roroData) => {
+const formatMovementModeIconText = (roroData, movementMode) => {
   let output = '';
-  output += hasVehicle(roroData.vehicle?.registrationNumber) ? 'Vehicle' : '';
-  output += (hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) ? ' with ' : '';
-  output += hasTrailer(roroData?.vehicle?.trailer?.regNumber) ? 'Trailer' : '';
+  if (movementMode === RORO_TOURIST) {
+    output += hasVehicle(roroData.vehicle?.registrationNumber) ? 'Vehicle' : '';
+  } else {
+    output += hasVehicle(roroData.vehicle?.registrationNumber) ? 'Vehicle' : '';
+    output += (hasVehicle(roroData.vehicle?.registrationNumber) && hasTrailer(roroData.vehicle?.trailer?.regNumber)) ? ' with ' : '';
+    output += hasTrailer(roroData?.vehicle?.trailer?.regNumber) ? 'Trailer' : '';
+  }
   return output;
 };
 
-export { capitalizeFirstLetter, formatTaskIconText };
+export { capitalizeFirstLetter, formatMovementModeIconText };


### PR DESCRIPTION
## Description
This PR (part of a spike) looks at making sure the text displayed in Task Details summary matches the icon displayed.

## To Test
- Pull and run against dev.
- Pick a task for `RoRo Accompanied`, `RoRo Unaccompanied`, `RoRo Tourist`, check that the movement mode icon matches the text displayed in task details.

### Guide

- For RoRo Accompanied (with vehicle & trailer): It should say `Vehicle with Trailer`

- For RoRo Accompanied (with vehicle, no trailer): It should say `Vehicle`

- For RoRo Unaccompanied (with trailer, no vehicle): It should say `Trailer`

- For RoRo Tourist (with vehicle): It should say `Vehicle`

- For RoRo Tourist (single passenger): It should say `1 foot passenger`

- For RoRo Tourist (group): It should say `X foot passengers` <- `x` being any value greater than 1

#### e.g
![Task Details Page](https://user-images.githubusercontent.com/19333750/150583143-4e94c45c-580a-4865-85e2-e31a55baa04d.png)


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
