### PR TITLE
COP-8703: Add tests to verify Display updated tasks that had previously completed assessment

### DIFF
--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -453,7 +453,7 @@ describe('Task Details of different tasks on task details Page', () => {
 
     cy.wait(2000);
 
-    cy.verifyTaskHasMultipleVersion(businessKey);
+    cy.verifyTaskHasUpdated(businessKey, 'Updated');
   });
 
   it('Should verify task details on each version retained', () => {
@@ -579,7 +579,7 @@ describe('Task Details of different tasks on task details Page', () => {
 
     cy.wait(2000);
 
-    cy.verifyTaskHasMultipleVersion(businessKey);
+    cy.verifyTaskHasUpdated(businessKey, 'Updated');
   });
 
   it('Should verify single task created for the same target with different versions when Failed Cerberus payloads sent without delay', () => {
@@ -714,7 +714,7 @@ describe('Task Details of different tasks on task details Page', () => {
 
     cy.wait(2000);
 
-    cy.verifyTaskHasMultipleVersion(businessKey);
+    cy.verifyTaskHasUpdated(businessKey, 'Updated');
   });
 
   // COP-8934 two versions have passenger details and one version doesn't have passenger details
@@ -910,7 +910,7 @@ describe('Task Details of different tasks on task details Page', () => {
 
     cy.wait(2000);
 
-    cy.verifyTaskHasMultipleVersion(businessKey);
+    cy.verifyTaskHasUpdated(businessKey, 'Updated');
   });
 
   it('Should verify all the target indicators received in the payload displayed on UI', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1150,24 +1150,30 @@ Cypress.Commands.add('getAllSelectorMatches', (locator) => {
     });
 });
 
-function getTaskUpdatedStatus(businessKey) {
+function verifyTaskUpdatedStatus(businessKey, status) {
+  let locator;
+  if (status === 'Updated') {
+    locator = '.govuk-tag--updatedTarget';
+  } else {
+    locator = '.govuk-tag--relistedTarget';
+  }
   cy.get('.govuk-task-list-card').contains(businessKey).closest('section').then((element) => {
-    cy.wrap(element).find('.govuk-tag--updatedTarget').invoke('text').then((taskUpdated) => {
-      expect(taskUpdated).to.be.equal('Updated');
+    cy.wrap(element).find(locator).invoke('text').then((taskUpdated) => {
+      expect(taskUpdated).to.be.equal(status);
     });
   });
 }
 
-Cypress.Commands.add('verifyTaskHasMultipleVersion', (businessKey) => {
+Cypress.Commands.add('verifyTaskHasUpdated', (businessKey, status) => {
   const nextPage = 'a[data-test="next"]';
   cy.get('body').then(($el) => {
     if ($el.find(nextPage).length > 0) {
       cy.findTaskInAllThePages(businessKey, null, null).then(() => {
-        getTaskUpdatedStatus(businessKey);
+        verifyTaskUpdatedStatus(businessKey, status);
       });
     } else {
       cy.findTaskInSinglePage(businessKey, null, null).then(() => {
-        getTaskUpdatedStatus(businessKey);
+        verifyTaskUpdatedStatus(businessKey, status);
       });
     }
   });


### PR DESCRIPTION
## Description
Add test to verify the following scenario,
Scenario: Complete task updated
Given a task is 'complete'
When an update is received
Then the task is displayed in the 'New' tasks tab
AND it is displayed as "Updated"
AND all task details/versions/comments/activity are displayed
AND the task is no longer visible in the 'complete' tab

## To Test
npm run cypress:runner
run test `Should complete assessment of a task with a reason as take no further action` from spec `task-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
