### PR TITLE
COP-9843: Stoping users adding comments when task are not assigned to them

### DIFF
--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -344,7 +344,7 @@ const TaskDetailsPage = () => {
               )}
             </div>
             <TaskNotes
-              displayForm={assignee}
+              displayForm={assignee === currentUser}
               businessKey={targetData.taskSummaryBasedOnTIS?.parentBusinessKey?.businessKey}
               processInstanceId={processInstanceId}
             />

--- a/src/routes/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/__tests__/TaskDetailsPage.test.jsx
@@ -465,9 +465,10 @@ describe('TaskDetailsPage', () => {
     await waitFor(() => render(<TaskDetailsPage />));
 
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+    expect(screen.queryByText('Assigned to ANOTHER_USER')).not.toBeInTheDocument();
   });
 
-  it('should render notes form when task is assigned to any user', async () => {
+  it('should render notes form when task is assigned to a current user', async () => {
     mockTaskDetailsAxiosCalls({
       processInstanceResponse: [{ id: '123' }],
       taskResponse: [
@@ -487,5 +488,6 @@ describe('TaskDetailsPage', () => {
     await waitFor(() => render(<TaskDetailsPage />));
 
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+    expect(screen.queryByText('Assigned to ANOTHER_USER')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description
COP-9843: Stoping users adding comments when task are not assigned to them (In Progress tab state only)

## To Test
**Scenario 1:**
1. Select a task in any task in **In progress** tab state assigned to someone else.
2. The task details page won't show Add a new note section

**Scenario 2:**
1. Select a task in any task in **In progress** tab state assigned to you(currently loggedIn user).
2. The task details page show Add a new note section

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [*] All reviewer comments resolved/answered? \*
