### PR TITLE
COP-9745: Add tests to verify task details of tourist types

### DIFF
--- a/cypress/fixtures/RoRo-Tourist-muliple-passengers.json
+++ b/cypress/fixtures/RoRo-Tourist-muliple-passengers.json
@@ -224,7 +224,28 @@
                   "driverCount": "1"
                 }
               },
-              "features": null,
+              "features": {
+                "feats" : {
+                  "VEHICLE-PORT-HOP-IN2OUT": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "FIRST-TIME-ACCOUNT-DRIVER": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
               "changeHistory": null
             },
             "voyage": {

--- a/cypress/fixtures/RoRo-Tourist-single-passengers.json
+++ b/cypress/fixtures/RoRo-Tourist-single-passengers.json
@@ -224,7 +224,28 @@
                   "driverCount": "1"
                 }
               },
-              "features": null,
+              "features": {
+                "feats" : {
+                  "VEHICLE-PORT-HOP-IN2OUT": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "FIRST-TIME-ACCOUNT-DRIVER": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
               "changeHistory": null
             },
             "voyage": {

--- a/cypress/fixtures/tourist-task-with-multiple-passengers.json
+++ b/cypress/fixtures/tourist-task-with-multiple-passengers.json
@@ -1,0 +1,72 @@
+{
+  "passengers": [
+      {
+        "Name": "Donald Duck",
+        "Date of birth": "23/02/1986",
+        "Gender": "M",
+        "Nationality": "GB",
+        "Travel document type": "OBJDOCPAS",
+        "Travel document number": "244746NL",
+        "Travel document expiry": "01/02/2021"
+      },
+      {
+        "Name": "Fred Flintstone",
+        "Date of birth": "22/11/1991",
+        "Gender": "F",
+        "Nationality": "DE",
+        "Travel document type": "OBJDOCPAS",
+        "Travel document number": "875786876",
+        "Travel document expiry": "22/03/2022"
+      },
+      {
+        "Name": "Micky Gaby",
+        "Date of birth": "22/11/1991",
+        "Gender": "F",
+        "Nationality": "FR",
+        "Travel document type": "OBJDOCPAS",
+        "Travel document number": "875786876",
+        "Travel document expiry": "22/03/2022"
+      },
+      {
+        "Name": "Barney Rubble",
+        "Date of birth": "01/03/1989",
+        "Gender": "M",
+        "Nationality": "GB",
+        "Travel document type": "OBJDOCPAS",
+        "Travel document number": "244746NL",
+        "Travel document expiry": "01/02/2021"
+      }
+  ],
+  "Document": {
+    "Travel document type": "OBJDOCPAS",
+    "Travel document number": "566746DL",
+    "Travel document expiry": "29/10/2023"
+  },
+  "primary traveller": {
+    "Name": "Isiaih Ford",
+    "Date of birth": "13/10/1991",
+    "Gender": "M",
+    "Nationality": "AUS"
+  },
+  "Booking-and-check-in": {
+    "Reference": "AB555412781",
+    "Ticket number": "1234567",
+    "Type": "R",
+    "Name": "",
+    "Address": "",
+    "Date and time": "2 Aug 2020 at 15:50, 5 days before travel",
+    "Country": "GB",
+    "Payment method": "CQ",
+    "Ticket price": "",
+    "Ticket type": "Return",
+    "Check-in": ""
+  },
+  "TargetingIndicators": {
+    "Total Score": "50",
+    "Total Indicators": "2",
+    "indicators": {
+      "UK port hop inbound": "20",
+      "First use of account (Driver)": "30"
+    }
+  }
+}

--- a/cypress/fixtures/tourist-task-with-single-passenger.json
+++ b/cypress/fixtures/tourist-task-with-single-passenger.json
@@ -1,0 +1,32 @@
+{
+  "primary traveller": {
+    "Name": "Isiaih Ford",
+    "Date of birth": "13/10/1991",
+    "Gender": "M",
+    "Nationality": "AUS",
+    "Travel document type": "OBJDOCPAS",
+    "Travel document number": "566746DL",
+    "Travel document expiry": "29/10/2023"
+  },
+  "Booking-and-check-in": {
+    "Reference": "AB555412781",
+    "Ticket number": "1234567",
+    "Type": "R",
+    "Name": "",
+    "Address": "",
+    "Date and time": "2 Aug 2020 at 15:50, 5 days before travel",
+    "Country": "GB",
+    "Payment method": "CQ",
+    "Ticket price": "",
+    "Ticket type": "Return",
+    "Check-in": ""
+  },
+  "TargetingIndicators": {
+    "Total Score": "50",
+    "Total Indicators": "2",
+    "indicators": {
+      "UK port hop inbound": "20",
+      "First use of account (Driver)": "30"
+    }
+  }
+}

--- a/cypress/fixtures/tourist-task-with-vehicle-details.json
+++ b/cypress/fixtures/tourist-task-with-vehicle-details.json
@@ -1,0 +1,48 @@
+{
+  "vehicle": {
+  "Vehicle registration": "HL09YXR",
+  "Type": "HGV",
+  "Make": "Ford",
+  "Model": "Fiesta",
+  "Country of registration": "GB",
+  "Colour": ""
+  },
+  "driver": {
+    "Name": "Daisy Flower",
+    "Date of birth": "13/05/1978",
+    "Gender": "F",
+    "Nationality": "GB",
+    "Travel document type": "OBJDOCPAS",
+    "Travel document number": "ST453786",
+    "Travel document expiry": "01/02/2021"
+  },
+  "passengers": {
+    "Name": "Darren Ball",
+    "Date of birth": "16/03/1990",
+    "Gender": "M",
+    "Nationality": "GB",
+    "Travel document type": "ST2447631",
+    "Travel document number": "18659",
+    "Travel document expiry": ""
+  },
+  "Booking-and-check-in": {
+    "Reference": "DFDS347376",
+    "Ticket number": "DFDS-1000974",
+    "Type": "Online",
+    "Name": "Dean Fulton",
+    "Address": "",
+    "Date and time": "3 Aug 2020 at 11:25, a day before travel",
+    "Country": "",
+    "Payment method": "Other",
+    "Ticket price": "",
+    "Ticket type": "Single",
+    "Check-in": "4 Aug 2020 at 18:40, 2 years before travel"
+  },
+  "TargetingIndicators": {
+    "Total Score": "20",
+    "Total Indicators": "1",
+    "indicators": {
+      "Late booking tourist (24-72 hours)": "20"
+    }
+  }
+}

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -127,7 +127,7 @@ describe('Create task with different payload from Cerberus', () => {
       let dateNowFormatted = Cypress.dayjs(date).format('DD-MM-YYYY');
       let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
-      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-${mode}-MULIPLE-PASSENGERS`).then((response) => {
+      cy.postTasks(task, `AUTOTEST-${dateNowFormatted}-${mode}-MULTIPLE-PASSENGERS`).then((response) => {
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.verifyTouristTaskSummary(`${response.businessKey}`).then((taskDetails) => {

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -975,6 +975,160 @@ describe('Task Details of different tasks on task details Page', () => {
     });
   });
 
+  it('Should verify task details of RoRo-Tourist with Vehicle', () => {
+    cy.getBusinessKey('-TOURIST-RBT-SBT_').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.wait(4000);
+      cy.checkTaskDisplayed(`${businessKeys[0]}`);
+    });
+
+    cy.fixture('tourist-task-with-vehicle-details.json').then((expectedDetails) => {
+      cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+        cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+          cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+            expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
+          });
+          cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+            expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+          });
+        });
+
+        cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+          cy.getTargetIndicatorDetails().then((details) => {
+            delete details.Indicator;
+            expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+          });
+        });
+      });
+
+      cy.contains('h3', 'Vehicle').next().within((elements) => {
+        cy.getVehicleDetails(elements).then((details) => {
+          expect(details).to.deep.equal(expectedDetails.vehicle);
+        });
+      });
+
+      cy.contains('h3', 'Driver').next().within(() => {
+        cy.getTaskDetails().then((details) => {
+          expect(details).to.deep.equal(expectedDetails.driver);
+        });
+      });
+
+      cy.contains('h3', 'Occupants').nextAll().within(() => {
+        cy.contains('h3', 'Passengers').next().within(() => {
+          cy.getTaskDetails().then((details) => {
+            expect(details).to.deep.equal(expectedDetails.passengers);
+          });
+        });
+      });
+
+      cy.contains('h3', 'Booking and check-in').next().within(() => {
+        cy.getTaskDetails().then((details) => {
+          expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
+        });
+      });
+    });
+  });
+
+  it('Should verify task details of RoRo-Tourist with Single Passenger', () => {
+    cy.getBusinessKey('-SINGLE-PASSENGER').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.wait(4000);
+      cy.checkTaskDisplayed(`${businessKeys[0]}`);
+    });
+
+    cy.fixture('tourist-task-with-single-passenger.json').then((expectedDetails) => {
+      cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+        cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+          cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+            expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
+          });
+          cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+            expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+          });
+        });
+
+        cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+          cy.getTargetIndicatorDetails().then((details) => {
+            delete details.Indicator;
+            expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+          });
+        });
+      });
+
+      cy.contains('h3', 'Primary Traveller').next().within((elements) => {
+        cy.getVehicleDetails(elements).then((details) => {
+          expect(details).to.deep.equal(expectedDetails['primary traveller']);
+        });
+      });
+
+      cy.contains('h3', 'Booking and check-in').next().within(() => {
+        cy.getTaskDetails().then((details) => {
+          expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
+        });
+      });
+    });
+  });
+
+  it('Should verify task details of RoRo-Tourist with Multiple Passenger', () => {
+    cy.getBusinessKey('-MULTIPLE-PASSENGERS').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.wait(4000);
+      cy.checkTaskDisplayed(`${businessKeys[0]}`);
+    });
+
+    let passengers = [];
+
+    cy.fixture('tourist-task-with-multiple-passengers.json').then((expectedDetails) => {
+      cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
+        cy.wrap(elements).filter('.govuk-task-details-grid-row').eq(1).within(() => {
+          cy.get('.govuk-grid-key').eq(0).invoke('text').then((numberOfIndicators) => {
+            expect(numberOfIndicators).to.be.equal(expectedDetails.TargetingIndicators['Total Indicators']);
+          });
+          cy.get('.govuk-grid-key').eq(1).invoke('text').then((totalScore) => {
+            expect(totalScore).to.be.equal(expectedDetails.TargetingIndicators['Total Score']);
+          });
+        });
+
+        cy.wrap(elements).filter('.govuk-task-details-indicator-container').within(() => {
+          cy.getTargetIndicatorDetails().then((details) => {
+            delete details.Indicator;
+            expect(details).to.deep.equal(expectedDetails.TargetingIndicators.indicators);
+          });
+        });
+      });
+
+      cy.contains('h3', 'Document').next().within((elements) => {
+        cy.getVehicleDetails(elements).then((details) => {
+          expect(details).to.deep.equal(expectedDetails.Document);
+        });
+      });
+
+      cy.contains('h3', 'Primary Traveller').next().within((elements) => {
+        cy.getVehicleDetails(elements).then((details) => {
+          expect(details).to.deep.equal(expectedDetails['primary traveller']);
+        });
+      });
+
+      cy.contains('h3', 'Other travellers').nextAll().within((elements) => {
+        cy.wrap(elements).find('.govuk-task-details-grid-column').each((element) => {
+          cy.wrap(element).within(() => {
+            cy.getTaskDetails().then((details) => {
+              passengers.push(details);
+            });
+          });
+        }).then(() => {
+          expect(passengers).to.deep.equal(expectedDetails.passengers);
+        });
+      });
+
+      cy.contains('h3', 'Booking and check-in').next().within(() => {
+        cy.getTaskDetails().then((details) => {
+          expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
+        });
+      });
+    });
+  });
+
   after(() => {
     cy.deleteAutomationTestData();
     cy.contains('Sign out').click();


### PR DESCRIPTION
## Description
Add tests to verify following scenarios,
For RoRo Tourist (By Car) Show: (No change)

Column 1: Targeting Indicators | Vehicle

Column 2: Booking and check-in

Column 3: Occupants | Driver

For RoRo Tourist (single foot passenger) show: 

Remove "driven by" - "Single passenger"

Column 1: Targeting Indicators (Hide vehicle section)

Column 2: Booking and check-in

Column 3: Primary traveller


For RoRo Tourist (group passengers) show: 

Column 1: Targeting Indicators / Primary traveller /Document

Column 2: Booking and check-in

Column 3: Other travellers 

## To Test
npm run cypress:runner
execute following tests from spec `task-version-details.spec.js`
`Should verify task details of RoRo-Tourist with Vehicle`
`Should verify task details of RoRo-Tourist with Single Passenger`
`Should verify task details of RoRo-Tourist with Multiple Passenger` 
## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
