### PR TITLE
COP-9672: Sorting and showing highest threat level at frontend

### DIFF
--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -243,6 +243,20 @@ const renderSectionsBasedOnTIS = (movementMode, taskSummaryBasedOnTIS, version) 
   );
 };
 
+const renderHighestThreatLevel = (version) => {
+  let threatsArray = [];
+  const childSets = version.find(({ propName }) => propName === 'selectors').childSets;
+  if (childSets && childSets.length) {
+    childSets.map((set) => {
+      set.contents.map((c) => {
+        if (c.propName === 'category') threatsArray.push(c.content);
+      });
+    });
+  }
+
+  return threatsArray.length ? `CATEGORY ${threatsArray.sort()[0]}` : threatLevel;
+};
+
 const TaskVersions = ({ taskSummaryBasedOnTIS, taskVersions, businessKey, taskVersionDifferencesCounts, movementMode }) => {
   dayjs.extend(utc);
   /*
@@ -281,7 +295,7 @@ const TaskVersions = ({ taskSummaryBasedOnTIS, taskVersions, businessKey, taskVe
                 <div className="task-versions--right">
                   <ul className="govuk-list">
                     <li>{pluralise.withCount(taskVersionDifferencesCounts[index], '% change', '% changes', 'No changes')} in this version</li>
-                    {threatLevel ? <li>Highest threat level is <span className="govuk-body govuk-tag govuk-tag--positiveTarget">{threatLevel}</span></li> : <li>No rule matches</li>}
+                    {threatLevel ? <li>Highest threat level is <span className="govuk-body govuk-tag govuk-tag--positiveTarget">{renderHighestThreatLevel(version)}</span></li> : <li>No rule matches</li>}
                   </ul>
                 </div>
               </>

--- a/src/routes/__tests__/TaskVersions.test.jsx
+++ b/src/routes/__tests__/TaskVersions.test.jsx
@@ -7,7 +7,7 @@ import { taskSingleVersion, taskNoRulesMatch, taskFootPassengerSingleVersion, ta
   noVehicleTwoPaxTsBasedOnTISData } from '../__fixtures__/taskVersions';
 
 describe('TaskVersions', () => {
-  it('should render the selector with Highest threat level is Category', () => {
+  it('should render the selector with Highest threat Category level', () => {
     render(<TaskVersions
       taskSummaryBasedOnTIS={taskSummaryBasedOnTISData}
       taskVersions={taskSingleVersion}
@@ -15,6 +15,7 @@ describe('TaskVersions', () => {
       movementMode="RORO Unaccompanied Freight"
     />);
     expect(screen.queryByText('Category')).toBeInTheDocument();
+    expect(screen.queryByText('B')).toBeInTheDocument();
   });
 
   it('should render No rule matches', () => {


### PR DESCRIPTION
## Description
Display highest threat level in task details

## To Test
Select a task with multiple selectors on task list page. 
The task detail page would show the highest threat level for each version

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
