### PR TITLE
COP-9672: Add test to verify each version in the task details Display Highest threat level

### DIFF
--- a/cypress/fixtures/task-version-passenger/RoRo-task-v1.json
+++ b/cypress/fixtures/task-version-passenger/RoRo-task-v1.json
@@ -59,7 +59,7 @@
                 "null"
               ],
               "ruleMatchedOnDate": "2021-10-08T14:45:26Z",
-              "rulePriority": "Tier 1",
+              "rulePriority": "Tier 2",
               "indicatorMatches": [
                 {
                   "indicatorType": "BASIC",
@@ -94,7 +94,7 @@
                 "null"
               ],
               "ruleMatchedOnDate": "2021-10-08T14:45:26Z",
-              "rulePriority": "Tier 1",
+              "rulePriority": "Tier 3",
               "indicatorMatches": [
                 {
                   "indicatorType": "BASIC",
@@ -188,6 +188,46 @@
                   ]
                 }
               ]
+            },
+            {
+              "selectorId": 50,
+              "selectorReference": "2021-50",
+              "startDate": "2021-07-09T13:42:43.639Z",
+              "endDate": "2021-08-20T22:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "ffhtr",
+              "pointOfContact": "hrth",
+              "pocMessage": "selector auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "Class B&C Drugs inc. Cannabis",
+              "notes": "notes",
+              "creator": "user",
+              "approver": "selector auto testing",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "selector auto testing",
+              "warnings": "rtht",
+              "requestingOfficer": "bffg",
+              "requestingTeam": "BFNIH",
+              "indicatorMatches": [
+                {
+                  "entity": "Organisation",
+                  "descriptor": "telephone",
+                  "operator": "equal",
+                  "value": "01234 56723737"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-07-13T09:30:02.896Z"
             }
           ],
           "movement": {

--- a/cypress/fixtures/task-version-passenger/RoRo-task-v2.json
+++ b/cypress/fixtures/task-version-passenger/RoRo-task-v2.json
@@ -129,7 +129,7 @@
                 "null"
               ],
               "ruleMatchedOnDate": "2021-10-08T14:45:26Z",
-              "rulePriority": "Tier 1",
+              "rulePriority": "Tier 2",
               "indicatorMatches": [
                 {
                   "indicatorType": "BASIC",
@@ -154,41 +154,6 @@
             }
           ],
           "matchedSelectors":[
-            {
-              "selectorId":6,
-              "selectorReference":"2020-6",
-              "startDate":"2021-01-18T01:00:00Z",
-              "endDate":"2021-12-28T23:00:00Z",
-              "category":"B",
-              "agencyCode":"code A",
-              "intelligenceSource":"intel source",
-              "pointOfContact":"poc",
-              "pocMessage":"Message for the POC",
-              "priority":"Tier 2",
-              "inboundActionCode":"Advise originator",
-              "outboundActionCode":"Full attention",
-              "threatType":"National Security at the Border",
-              "notes":"Supplemental notes",
-              "creator":"Joe Jones",
-              "approver":"Henry Hamlet",
-              "securityLabels":[
-                "DATA_RISK_PREARRIVAL"
-              ],
-              "localReference":"Local ref",
-              "warnings":"Supplemental warnings",
-              "requestingOfficer":"Peter Price",
-              "requestingTeam":"RoRo accompanied",
-              "selectorMatchedOnDate":"Mon Jan 18 15:10:13 GMT 2021",
-              "indicatorMatches":[
-                {
-                  "indicatorType":"BASIC",
-                  "index":0,
-                  "values":[
-                    "NL-234-392"
-                  ]
-                }
-              ]
-            }
           ],
           "movement": {
             "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/7419e5ac95e32a620efa03b80e8961c2/a296a0797b9701f912a5a808851e6156",

--- a/cypress/fixtures/task-version-passenger/RoRo-task-v3.json
+++ b/cypress/fixtures/task-version-passenger/RoRo-task-v3.json
@@ -155,41 +155,6 @@
           ],
           "matchedSelectors":[
             {
-              "selectorId":6,
-              "selectorReference":"2020-6",
-              "startDate":"2021-01-18T01:00:00Z",
-              "endDate":"2021-12-28T23:00:00Z",
-              "category":"C",
-              "agencyCode":"code A",
-              "intelligenceSource":"intel source",
-              "pointOfContact":"poc",
-              "pocMessage":"Message for the POC",
-              "priority":"Tier 2",
-              "inboundActionCode":"Advise originator",
-              "outboundActionCode":"Full attention",
-              "threatType":"National Security at the Border",
-              "notes":"Supplemental notes",
-              "creator":"Joe Jones",
-              "approver":"Henry Hamlet",
-              "securityLabels":[
-                "DATA_RISK_PREARRIVAL"
-              ],
-              "localReference":"Local ref",
-              "warnings":"Supplemental warnings",
-              "requestingOfficer":"Peter Price",
-              "requestingTeam":"RoRo accompanied",
-              "selectorMatchedOnDate":"Mon Jan 18 15:10:13 GMT 2021",
-              "indicatorMatches":[
-                {
-                  "indicatorType":"BASIC",
-                  "index":0,
-                  "values":[
-                    "NL-234-392"
-                  ]
-                }
-              ]
-            },
-            {
               "selectorId": 50,
               "selectorReference": "2021-50",
               "startDate": "2021-07-09T13:42:43.639Z",
@@ -234,7 +199,7 @@
               "selectorReference": "2021-52",
               "startDate": "2021-07-09T13:43:10.327Z",
               "endDate": "2021-08-20T22:59:59Z",
-              "category": "A",
+              "category": "C",
               "agencyCode": "Counter Terrorism Police (CTP)",
               "intelligenceSource": "grre",
               "pointOfContact": "greg",

--- a/cypress/fixtures/task-version-passenger/RoRo-task-v3.json
+++ b/cypress/fixtures/task-version-passenger/RoRo-task-v3.json
@@ -24,7 +24,7 @@
                 "null"
               ],
               "ruleMatchedOnDate": "2021-10-08T14:45:26Z",
-              "rulePriority": "Tier 1",
+              "rulePriority": "Tier 3",
               "indicatorMatches": [
                 {
                   "indicatorType": "BASIC",
@@ -59,7 +59,7 @@
                 "null"
               ],
               "ruleMatchedOnDate": "2021-10-08T14:45:26Z",
-              "rulePriority": "Tier 1",
+              "rulePriority": "Tier 3",
               "indicatorMatches": [
                 {
                   "indicatorType": "BASIC",
@@ -94,7 +94,7 @@
                 "null"
               ],
               "ruleMatchedOnDate": "2021-10-08T14:45:26Z",
-              "rulePriority": "Tier 1",
+              "rulePriority": "Tier 3",
               "indicatorMatches": [
                 {
                   "indicatorType": "BASIC",
@@ -129,7 +129,7 @@
                 "null"
               ],
               "ruleMatchedOnDate": "2021-10-08T14:45:26Z",
-              "rulePriority": "Tier 1",
+              "rulePriority": "Tier 3",
               "indicatorMatches": [
                 {
                   "indicatorType": "BASIC",
@@ -159,7 +159,7 @@
               "selectorReference":"2020-6",
               "startDate":"2021-01-18T01:00:00Z",
               "endDate":"2021-12-28T23:00:00Z",
-              "category":"B",
+              "category":"C",
               "agencyCode":"code A",
               "intelligenceSource":"intel source",
               "pointOfContact":"poc",
@@ -188,7 +188,88 @@
                   ]
                 }
               ]
+            },
+            {
+              "selectorId": 50,
+              "selectorReference": "2021-50",
+              "startDate": "2021-07-09T13:42:43.639Z",
+              "endDate": "2021-08-20T22:59:59Z",
+              "category": "B",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "ffhtr",
+              "pointOfContact": "hrth",
+              "pocMessage": "selector auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "Class B&C Drugs inc. Cannabis",
+              "notes": "notes",
+              "creator": "user",
+              "approver": "selector auto testing",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "selector auto testing",
+              "warnings": "rtht",
+              "requestingOfficer": "bffg",
+              "requestingTeam": "BFNIH",
+              "indicatorMatches": [
+                {
+                  "entity": "Organisation",
+                  "descriptor": "telephone",
+                  "operator": "equal",
+                  "value": "01234 56723737"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-07-13T09:30:02.896Z"
+            },
+            {
+              "selectorId": 52,
+              "selectorReference": "2021-52",
+              "startDate": "2021-07-09T13:43:10.327Z",
+              "endDate": "2021-08-20T22:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "grre",
+              "pointOfContact": "greg",
+              "pocMessage": "gregre",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "Class B&C Drugs inc. Cannabis",
+              "notes": "notes",
+              "creator": "user",
+              "approver": "gerger",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "greger",
+              "warnings": "rgeger",
+              "requestingOfficer": "srg",
+              "requestingTeam": "BFNIH",
+              "indicatorMatches": [
+                {
+                  "entity": "Organisation",
+                  "descriptor": "telephone",
+                  "operator": "equal",
+                  "value": "01234 56723737"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-07-13T09:30:02.896Z"
             }
+
           ],
           "movement": {
             "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/7419e5ac95e32a620efa03b80e8961c2/2f9a5d455992ca1932cd818be3a74d5c",

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -103,6 +103,14 @@ describe('Create task with different payload from Cerberus', () => {
         cy.navigation('Tasks');
         cy.get('.govuk-heading-xl').should('have.text', 'Task management');
         cy.checkTaskDisplayed(`${response.businessKey}`);
+
+        // COP-9672 Display No Rule matches in task details if there are no Rule / Selector
+        cy.get('.task-versions .govuk-accordion__section').each((element) => {
+          cy.wrap(element).find('.task-versions--right .govuk-list li').eq(1).invoke('text')
+            .then((value) => {
+              expect('No rule matches').to.be.equal(value);
+            });
+        });
         cy.contains('0 selector matches');
       });
     });

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -1131,8 +1131,8 @@ describe('Task Details of different tasks on task details Page', () => {
 
   it('Should verify task Display highest threat level in task details', () => {
     const highestThreatLevel = [
-      'CATEGORY A',
-      'TIER 1',
+      'CATEGORY B',
+      'Tier 1',
       'CATEGORY A',
     ];
 

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -1129,6 +1129,27 @@ describe('Task Details of different tasks on task details Page', () => {
     });
   });
 
+  it('Should verify task Display highest threat level in task details', () => {
+    const highestThreatLevel = [
+      'CATEGORY A',
+      'TIER 1',
+      'CATEGORY A',
+    ];
+
+    cy.getBusinessKey('RORO-Accompanied-Freight-passenger-info_').then((businessKeys) => {
+      expect(businessKeys.length).to.not.equal(0);
+      cy.wait(4000);
+      cy.checkTaskDisplayed(`${businessKeys[0]}`);
+    });
+
+    // COP-9672 Display highest threat level in task details
+    cy.get('.task-versions .govuk-accordion__section').each((element, index) => {
+      cy.wrap(element).find('.task-versions--right .govuk-list li span.govuk-tag--positiveTarget').invoke('text').then((value) => {
+        expect(highestThreatLevel[index]).to.be.equal(value);
+      });
+    });
+  });
+
   after(() => {
     cy.deleteAutomationTestData();
     cy.contains('Sign out').click();


### PR DESCRIPTION
## Description
Add test to verify following scenario,

GIVEN a task has one or more version
WHEN the task details are displayed
THEN the highest threat level is displayed for each version

GIVEN A task version no longer has a rule/selector match
WHEN the task details are displayed
THEN the version displays "NO RULE MATCHES"

## To Test
npm run cypress:runner

run test `Should verify task Display highest threat level in task details` from spec `task-version-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
