### PR TITLE
COP-9796: Update tests to adapt latest changes for task Filters

### DIFF
--- a/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-pre-arrival-mode.spec.js
@@ -18,6 +18,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       'RoRo accompanied freight',
       'RoRo Tourist',
     ];
+    let expectedFilterNames = [];
     cy.get('a[href="#new"]').invoke('text').as('total-tasks').then((totalTargets) => {
       cy.log('Total number of Targets', parseInt(totalTargets.match(/\d+/)[0], 10));
     });
@@ -25,11 +26,13 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     cy.get('.cop-filters-container').within(() => {
       cy.get('h2.govuk-heading-s').should('have.text', 'Filters');
       cy.get('.cop-filters-header .govuk-link').should('have.text', 'Clear all filters');
+
       cy.get('.govuk-checkboxes li').each((element) => {
         cy.wrap(element).invoke('text').then((value) => {
-          let expectedFilterName = value.slice(0, value.indexOf('('));
-          expect(filterNames).to.contains(expectedFilterName);
+          expectedFilterNames.push(value.substring(0, value.indexOf('(')).trim());
         });
+      }).then(() => {
+        expect(expectedFilterNames).to.deep.equal(filterNames);
       });
     });
   });
@@ -42,7 +45,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyModesFilter(mode, 'new').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'NEW').then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -71,7 +74,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyModesFilter(mode, 'inProgress').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'IN_PROGRESS').then((response) => {
           expect(response.inProgress).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -100,7 +103,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyModesFilter(mode, 'issued').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'ISSUED').then((response) => {
           expect(response.issued).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -129,7 +132,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
       cy.applyModesFilter(mode, 'complete').then((actualTargets) => {
         cy.log('actual targets', actualTargets);
         actualTotalTargets += actualTargets;
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'COMPLETE').then((response) => {
           expect(response.complete).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -152,13 +155,13 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     // COP-5715 switch between the tabs, filter should be retained
     filterOptions.forEach((mode) => {
       cy.applyModesFilter(mode, 'new').then((actualTargets) => {
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'NEW').then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
         cy.get('a[href="#complete"]').click();
         cy.get('a[href="#new"]').click();
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'NEW').then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -168,13 +171,13 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     // COP-5715 reload the page after filter applied on the page, filter should be retained
     filterOptions.forEach((mode) => {
       cy.applyModesFilter(mode, 'new').then((actualTargets) => {
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'NEW').then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
         cy.reload();
         cy.wait(2000);
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'NEW').then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -184,13 +187,13 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     // COP-9661 Multi-select modes persist selection on page refresh
     filterOptions.forEach((mode) => {
       cy.applyModesFilter(mode, 'new').then((actualTargets) => {
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'NEW').then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.reload();
         cy.contains('Clear all filters').click();
         cy.wait(2000);
-        cy.getTaskCount(mode, null).then((response) => {
+        cy.getTaskCount(mode, null, 'NEW').then((response) => {
           expect(response.new).be.equal(actualTargets);
         });
         cy.contains('Clear all filters').click();
@@ -200,15 +203,14 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
   it('Should apply filter tasks by roro-unaccompanied mode & has selectors on New tasks', () => {
     let expectedTargets;
-    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+    cy.getTaskCount(null, 'any', 'NEW').then((numberOfTasks) => {
       expectedTargets = numberOfTasks.new;
     });
 
     // COP-9191 Apply each pre-arrival filter, compare the expected number of targets
-
     cy.applyModesFilter('RORO_UNACCOMPANIED_FREIGHT', 'new').then(() => {
       cy.applySelectorFilter('true', 'new').then((actualTargets) => {
-        cy.getTaskCount('RORO_UNACCOMPANIED_FREIGHT', 'true').then((FilterExpectedTargets) => {
+        cy.getTaskCount('RORO_UNACCOMPANIED_FREIGHT', 'true', 'NEW').then((FilterExpectedTargets) => {
           expect(FilterExpectedTargets.new).be.equal(actualTargets);
         });
       });
@@ -230,7 +232,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
     let expectedTargets;
     cy.get('a[href="#inProgress"]').click();
 
-    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+    cy.getTaskCount(null, 'any', 'IN_PROGRESS').then((numberOfTasks) => {
       expectedTargets = numberOfTasks.inProgress;
     });
 
@@ -238,7 +240,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
     cy.applyModesFilter('RORO_UNACCOMPANIED_FREIGHT', 'inProgress').then(() => {
       cy.applySelectorFilter('false', 'inProgress').then((actualTargets) => {
-        cy.getTaskCount('RORO_UNACCOMPANIED_FREIGHT', 'false').then((FilterExpectedTargets) => {
+        cy.getTaskCount('RORO_UNACCOMPANIED_FREIGHT', 'false', 'IN_PROGRESS').then((FilterExpectedTargets) => {
           expect(FilterExpectedTargets.inProgress).be.equal(actualTargets);
         });
       });
@@ -259,7 +261,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   it('Should apply more than one pre-arrival filter modes on newly created tasks', () => {
     let actualTotalTargets = 0;
 
-    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+    cy.getTaskCount(null, 'any', 'NEW').then((numberOfTasks) => {
       actualTotalTargets = numberOfTasks.new;
     });
 
@@ -270,7 +272,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
 
     // COP-9210 Apply more than one pre-arrival filter, compare the expected number of targets
     cy.applyModesFilter(filters, 'new').then((actualTargets) => {
-      cy.getTaskCount(filters, null).then((response) => {
+      cy.getTaskCount(filters, null, 'NEW').then((response) => {
         expect(response.new).be.equal(actualTargets);
       });
     });
@@ -297,7 +299,7 @@ describe('Filter tasks by pre-arrival mode on task management Page', () => {
   it('Should select pre-arrival filter modes but not apply on newly created tasks', () => {
     let actualTotalTargets = 0;
 
-    cy.getTaskCount(null, 'any').then((numberOfTasks) => {
+    cy.getTaskCount(null, 'any', 'NEW').then((numberOfTasks) => {
       actualTotalTargets = numberOfTasks.new;
     });
 

--- a/cypress/integration/cerberus/filter-tasks-by-selectors.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-selectors.spec.js
@@ -213,7 +213,7 @@ describe('Filter tasks by Selectors on task management Page', () => {
     });
   });
 
-  it.skip('Should apply filter tasks by selectors present and check count on each of the tab', () => {
+  it('Should apply filter tasks by selectors present and check count on each of the tab', () => {
     // COP-9796 Apply selectors Present filter, compare the Count next to the Filter & count on the status Tab
     cy.applySelectorFilter('true', 'new').then(() => {
       Object.keys(statusTab).forEach((key) => {
@@ -234,7 +234,7 @@ describe('Filter tasks by Selectors on task management Page', () => {
     });
   });
 
-  it.skip('Should apply filter tasks by selectors Not Present and check count on each of the tab', () => {
+  it('Should apply filter tasks by selectors Not Present and check count on each of the tab', () => {
     // COP-9796 Apply selectors Not Present filter, compare the Count next to the Filter & count on the status Tab
     cy.applySelectorFilter('false', 'new').then(() => {
       Object.keys(statusTab).forEach((key) => {
@@ -255,7 +255,7 @@ describe('Filter tasks by Selectors on task management Page', () => {
     });
   });
 
-  it.skip('Should apply filter tasks by selectors Any and check count on each of the tab', () => {
+  it('Should apply filter tasks by selectors Any and check count on each of the tab', () => {
     // COP-9796 Apply selectors Not Present filter, compare the Count next to the Filter & count on the status Tab
     cy.applySelectorFilter('any', 'new').then(() => {
       Object.keys(statusTab).forEach((key) => {

--- a/cypress/integration/cerberus/filter-tasks-by-selectors.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-selectors.spec.js
@@ -8,6 +8,13 @@ describe('Filter tasks by Selectors on task management Page', () => {
     'any',
   ];
 
+  const statusTab = {
+    'new': 'NEW',
+    'inProgress': 'IN_PROGRESS',
+    'issued': 'ISSUED',
+    'complete': 'COMPLETE',
+  };
+
   beforeEach(() => {
     cy.login(Cypress.env('userName'));
     cy.navigation('Tasks');
@@ -15,10 +22,11 @@ describe('Filter tasks by Selectors on task management Page', () => {
 
   it('Should view filter tasks by selectors', () => {
     const filterNames = [
-      'Not present',
       'Present',
+      'Not present',
       'Any',
     ];
+    let expectedFilterNames = [];
 
     cy.get('a[href="#new"]').invoke('text').as('total-tasks').then((totalTargets) => {
       cy.log('Total number of Targets', parseInt(totalTargets.match(/\d+/)[0], 10));
@@ -29,8 +37,10 @@ describe('Filter tasks by Selectors on task management Page', () => {
       cy.get('.cop-filters-header .govuk-link').should('have.text', 'Clear all filters');
       cy.get('.govuk-radios__item [name="hasSelectors"]').next().each((element) => {
         cy.wrap(element).invoke('text').then((value) => {
-          expect(filterNames).to.include(value);
+          expectedFilterNames.push(value.substring(0, value.indexOf('(')).trim());
         });
+      }).then(() => {
+        expect(expectedFilterNames).to.deep.equal(filterNames);
       });
     });
   });
@@ -45,13 +55,13 @@ describe('Filter tasks by Selectors on task management Page', () => {
         if (selector !== 'any') {
           actualTotalTargets += actualTargets;
         }
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'NEW').then((numberOfTasks) => {
           // COP-9367 Number of tasks per selector filter (logic needs to be changed when COP-9796 implemented)
-          cy.get('.govuk-radios__item span').eq(index).invoke('text').then((selectorTargets) => {
+          cy.get('.govuk-radios__item label').eq(index).invoke('text').then((selectorTargets) => {
             let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
-            expect(targets).be.equal(numberOfTasks.total);
+            expect(targets).be.equal(numberOfTasks.new);
           });
-          expect(numberOfTasks.new).be.equal(actualTargets);
+          expect(numberOfTasks.total).be.equal(actualTotalTargets);
         });
       });
     });
@@ -80,9 +90,9 @@ describe('Filter tasks by Selectors on task management Page', () => {
         if (selector !== 'any') {
           actualTotalTargets += actualTargets;
         }
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'IN_PROGRESS').then((numberOfTasks) => {
           // COP-9367 Number of tasks per selector filter (logic needs to be changed when COP-9796 implemented)
-          cy.get('.govuk-radios__item span').eq(index).invoke('text').then((selectorTargets) => {
+          cy.get('.govuk-radios__item label').eq(index).invoke('text').then((selectorTargets) => {
             let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
             expect(targets).be.equal(numberOfTasks.total);
           });
@@ -115,9 +125,9 @@ describe('Filter tasks by Selectors on task management Page', () => {
         if (selector !== 'any') {
           actualTotalTargets += actualTargets;
         }
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'ISSUED').then((numberOfTasks) => {
           // COP-9367 Number of tasks per selector filter (logic needs to be changed when COP-9796 implemented)
-          cy.get('.govuk-radios__item span').eq(index).invoke('text').then((selectorTargets) => {
+          cy.get('.govuk-radios__item label').eq(index).invoke('text').then((selectorTargets) => {
             let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
             expect(targets).be.equal(numberOfTasks.total);
           });
@@ -150,9 +160,9 @@ describe('Filter tasks by Selectors on task management Page', () => {
         if (selector !== 'any') {
           actualTotalTargets += actualTargets;
         }
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'COMPLETE').then((numberOfTasks) => {
           // COP-9367 Number of tasks per selector filter (logic needs to be changed when COP-9796 implemented)
-          cy.get('.govuk-radios__item span').eq(index).invoke('text').then((selectorTargets) => {
+          cy.get('.govuk-radios__item label').eq(index).invoke('text').then((selectorTargets) => {
             let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
             expect(targets).be.equal(numberOfTasks.total);
           });
@@ -177,12 +187,12 @@ describe('Filter tasks by Selectors on task management Page', () => {
     // COP-9191 switch between the tabs, filter should be retained
     filterOptions.forEach((selector) => {
       cy.applySelectorFilter(selector, 'new').then((actualTargets) => {
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'NEW').then((numberOfTasks) => {
           expect(numberOfTasks.new).be.equal(actualTargets);
         });
         cy.get('a[href="#complete"]').click();
         cy.get('a[href="#new"]').click();
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'NEW').then((numberOfTasks) => {
           expect(numberOfTasks.new).be.equal(actualTargets);
         });
       });
@@ -191,13 +201,76 @@ describe('Filter tasks by Selectors on task management Page', () => {
     // COP-9191 reload the page after filter applied on the page, filter should be retained
     filterOptions.forEach((selector) => {
       cy.applySelectorFilter(selector, 'new').then((actualTargets) => {
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'NEW').then((numberOfTasks) => {
           expect(numberOfTasks.new).be.equal(actualTargets);
         });
         cy.reload();
         cy.wait(2000);
-        cy.getTaskCount(null, selector).then((numberOfTasks) => {
+        cy.getTaskCount(null, selector, 'NEW').then((numberOfTasks) => {
           expect(numberOfTasks.new).be.equal(actualTargets);
+        });
+      });
+    });
+  });
+
+  it.skip('Should apply filter tasks by selectors present and check count on each of the tab', () => {
+    // COP-9796 Apply selectors Present filter, compare the Count next to the Filter & count on the status Tab
+    cy.applySelectorFilter('true', 'new').then(() => {
+      Object.keys(statusTab).forEach((key) => {
+        cy.get(`a[href="#${key}"]`).click();
+        cy.getTaskCount(null, 'true', statusTab[key]).then((numberOfTasks) => {
+          // COP-9796 Number of tasks per selector filter on each of the status tab
+          cy.wait(1000);
+          cy.get('.govuk-radios__item label').eq(0).invoke('text').then((selectorTargets) => {
+            let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
+            expect(targets).be.equal(numberOfTasks[key]);
+            cy.get(`a[href="#${key}"]`).invoke('text').then((totalTargets) => {
+              totalTargets = parseInt(totalTargets.match(/\d+/)[0], 10);
+              expect(totalTargets).be.equal(targets);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it.skip('Should apply filter tasks by selectors Not Present and check count on each of the tab', () => {
+    // COP-9796 Apply selectors Not Present filter, compare the Count next to the Filter & count on the status Tab
+    cy.applySelectorFilter('false', 'new').then(() => {
+      Object.keys(statusTab).forEach((key) => {
+        cy.get(`a[href="#${key}"]`).click();
+        cy.getTaskCount(null, 'false', statusTab[key]).then((numberOfTasks) => {
+          // COP-9796 Number of tasks per selector filter on each of the status tab
+          cy.wait(1000);
+          cy.get('.govuk-radios__item label').eq(1).invoke('text').then((selectorTargets) => {
+            let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
+            expect(targets).be.equal(numberOfTasks[key]);
+            cy.get(`a[href="#${key}"]`).invoke('text').then((totalTargets) => {
+              totalTargets = parseInt(totalTargets.match(/\d+/)[0], 10);
+              expect(totalTargets).be.equal(targets);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it.skip('Should apply filter tasks by selectors Any and check count on each of the tab', () => {
+    // COP-9796 Apply selectors Not Present filter, compare the Count next to the Filter & count on the status Tab
+    cy.applySelectorFilter('any', 'new').then(() => {
+      Object.keys(statusTab).forEach((key) => {
+        cy.get(`a[href="#${key}"]`).click();
+        cy.getTaskCount(null, 'any', statusTab[key]).then((numberOfTasks) => {
+          // COP-9796 Number of tasks per selector filter on each of the status tab
+          cy.wait(1000);
+          cy.get('.govuk-radios__item label').eq(2).invoke('text').then((selectorTargets) => {
+            let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
+            expect(targets).be.equal(numberOfTasks[key]);
+            cy.get(`a[href="#${key}"]`).invoke('text').then((totalTargets) => {
+              totalTargets = parseInt(totalTargets.match(/\d+/)[0], 10);
+              expect(totalTargets).be.equal(targets);
+            });
+          });
         });
       });
     });

--- a/cypress/integration/cerberus/filter-tasks-by-selectors.spec.js
+++ b/cypress/integration/cerberus/filter-tasks-by-selectors.spec.js
@@ -61,7 +61,7 @@ describe('Filter tasks by Selectors on task management Page', () => {
             let targets = parseInt(selectorTargets.match(/\d+/)[0], 10);
             expect(targets).be.equal(numberOfTasks.new);
           });
-          expect(numberOfTasks.total).be.equal(actualTotalTargets);
+          expect(numberOfTasks.new).be.equal(actualTargets);
         });
       });
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -981,11 +981,14 @@ Cypress.Commands.add('createCerberusTask', (payload, taskName) => {
   });
 });
 
-Cypress.Commands.add('getTaskCount', (modeName, selector) => {
+Cypress.Commands.add('getTaskCount', (modeName, selector, statusTab) => {
   let payload;
   if (modeName === null && selector !== 'any') {
     payload = [
       {
+        'taskStatuses': [
+          statusTab,
+        ],
         'movementModes': [],
         'hasSelectors': selector,
       },
@@ -993,6 +996,9 @@ Cypress.Commands.add('getTaskCount', (modeName, selector) => {
   } else if (selector === 'any') {
     payload = [
       {
+        'taskStatuses': [
+          statusTab,
+        ],
         'movementModes': [],
         'hasSelectors': null,
       },
@@ -1000,6 +1006,9 @@ Cypress.Commands.add('getTaskCount', (modeName, selector) => {
   } else if (modeName instanceof Array) {
     payload = [
       {
+        'taskStatuses': [
+          statusTab,
+        ],
         'movementModes': modeName,
         'hasSelectors': selector,
       },
@@ -1007,6 +1016,9 @@ Cypress.Commands.add('getTaskCount', (modeName, selector) => {
   } else {
     payload = [
       {
+        'taskStatuses': [
+          statusTab,
+        ],
         'movementModes': [modeName],
         'hasSelectors': selector,
       },


### PR DESCRIPTION
## Description
Automation tests update to verify the following scenarios
Scenario: view STATUS task list (Replace the word STATUS with the status's below)
GIVEN the STATUS task list tab contains tasks from RBT and SBT
WHEN the targeter views the STATUS task list tab
THEN the number of STATUS tasks containing no selectors is displayed next to the "no selectors" filter
AND the number of STATUS tasks containing selectors is displayed next to the "Selectors" filter

STATUS: "New"; "In-Progress"; "Target Issued"; "Complete"

## To Test
npm run cypress:runner
run all tests in the  following 2 specs
`filter-tasks-by-selectors.spec.js`
`filter-tasks-by-pre-arrival-mode.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
