### PR TITLE
COP-9967 - Update dayjs config for relative past time

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ const config = {
   dayjsConfig: {
     relativeTime: {
       future: '%s before travel',
-      past: '%s after travel',
+      past: '%s ago',
       s: 'a few seconds',
       m: 'a minute',
       mm: '%d minutes',

--- a/src/routes/__tests__/TaskVersions.test.jsx
+++ b/src/routes/__tests__/TaskVersions.test.jsx
@@ -119,7 +119,7 @@ describe('TaskVersions', () => {
       movementMode="RORO Tourist"
     />);
 
-    expect(screen.queryByText('3 Aug 2020 at 12:05, a day after travel')).toBeInTheDocument();
+    expect(screen.queryByText('3 Aug 2020 at 12:05, a day ago')).toBeInTheDocument();
   });
 
   it('should not render check-in relative time for RORO Tourist foot passengers', () => {


### PR DESCRIPTION
## Description
This PR updates the config used by dayjs.

## To Test
- Pull & run against dev
- Pick a task and go into task details.
- In the task summary located in the `grey box` to the upper section of the page, it should now say `Arrival X hour|hours|day|days|year|years|month|months ago`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
