### PR TITLE
COP-9954 - Add selector word on task list page

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -153,7 +153,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError, targetTaskCount = 0 })
     if (!contents) {
       return risk.rulePriority;
     }
-    return contents.category ? contents.category : contents.rulePriority;
+    return contents.category ? <span className="govuk-body">SELECTOR <span className="govuk-tag govuk-tag--riskTier">{contents.category}</span></span> : <span className="govuk-tag govuk-tag--riskTier">{contents.rulePriority}</span>;
   };
 
   const extractRiskType = (risk) => {
@@ -299,7 +299,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError, targetTaskCount = 0 })
       });
     }
 
-    // Creating a filtered array removign off empty array elements
+    // Creating a filtered array removing off empty array elements
     sortedThreatsArray = sortedThreatsArray.filter((i) => i === 0 || i);
     return sortedThreatsArray[0];
   };
@@ -337,9 +337,7 @@ const TasksTab = ({ taskStatus, filtersToApply, setError, targetTaskCount = 0 })
                     </div>
                     <div className="govuk-grid-column">
                       {highestRisk && (
-                      <span className="govuk-tag govuk-tag--riskTier">
-                        {extractThreatLevel(highestRisk)}
-                      </span>
+                        extractThreatLevel(highestRisk)
                       )}
                       <span className="govuk-body task-risk-statement">
                         {formatTargetRisk(target.summary, highestRisk)}

--- a/src/routes/__assets__/TaskListPage.scss
+++ b/src/routes/__assets__/TaskListPage.scss
@@ -102,6 +102,9 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
             margin-top: 15px;
         }
     }
+    .govuk-tag {
+        padding-bottom: 2px;
+    }
 }
 
 .task-list--item-2 {
@@ -227,7 +230,7 @@ ul.item-list--bulleted {
     }
     &.govuk-tag--riskTier {
         background-color: #BC2410;
-        margin-right: 0.5rem;
+        margin-right: 0.25rem;
         margin-bottom: 0.25rem;
     }
     &.govuk-tag--positiveOutcome {

--- a/src/routes/__fixtures__/taskListData_ISSUED.fixture.json
+++ b/src/routes/__fixtures__/taskListData_ISSUED.fixture.json
@@ -13,7 +13,121 @@
       "threatIndicators": [],
       "category": "target_B",
       "eventPort": "",
-      "risks": [],
+      "risks": {
+        "selectors": [
+          {
+            "contents": {
+              "groupNumber": "2021-50",
+              "requestingOfficer": "bffg",
+              "sourceReference": "ffhtr",
+              "groupReference": "selector auto testing",
+              "category": "B",
+              "threatType": "Class B&C Drugs inc. Cannabis",
+              "pointOfContactMessage": "selector auto testing",
+              "pointOfContact": "hrth",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "warnings": "rtht",
+              "notes": "notes",
+              "creator": "user",
+              "selectorId": 50
+            },
+            "childSets": [
+              {
+                "entity": "Message",
+                "attribute": "mode",
+                "operator": "in",
+                "indicatorValue": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+              }
+            ]
+          },
+          {
+            "contents": {
+              "groupNumber": "2021-51",
+              "requestingOfficer": "Peter Price",
+              "sourceReference": "intel source",
+              "groupReference": "Local Reference",
+              "category": "B",
+              "threatType": "National Security at the Border",
+              "pointOfContactMessage": "Message for the POC",
+              "pointOfContact": "Point Of Contact",
+              "inboundActionCode": "Advise originator",
+              "outboundActionCode": "Full attention",
+              "warnings": "Supplemental warnings",
+              "notes": "Supplemental notes",
+              "creator": "Joe Jones",
+              "selectorId": 51
+            },
+            "childSets": [
+              {
+                "entity": "Message",
+                "attribute": "mode",
+                "operator": "in",
+                "indicatorValue": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+              }
+            ]
+          },
+          {
+            "contents": {
+              "groupNumber": "2021-52",
+              "requestingOfficer": "srg",
+              "sourceReference": "grre",
+              "groupReference": "greger",
+              "category": "B",
+              "threatType": "Class B&C Drugs inc. Cannabis",
+              "pointOfContactMessage": "gregre",
+              "pointOfContact": "greg",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "warnings": "rgeger",
+              "notes": "notes",
+              "creator": "user",
+              "selectorId": 52
+            },
+            "childSets": [
+              {
+                "entity": "Message",
+                "attribute": "mode",
+                "operator": "in",
+                "indicatorValue": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+              }
+            ]
+          }
+        ],
+        "rules": [
+          {
+            "contents": {
+              "name": "Scenario 1 Rule",
+              "rulePriority": "Tier 1",
+              "ruleVersion": 1,
+              "abuseType": "Class A Drugs",
+              "agencyCode": "",
+              "description": "COP Scenario 1",
+              "ruleId": 191
+            },
+            "childSets": [
+              {
+                "contents": {
+                  "entity": "",
+                  "attribute": "",
+                  "operator": "",
+                  "indicatorValue": ""
+                },
+                "childSets": []
+              },
+              {
+                "contents": {
+                  "entity": "",
+                  "attribute": "",
+                  "operator": "",
+                  "indicatorValue": ""
+                },
+                "childSets": []
+              }
+            ]
+          }
+        ]
+      },
       "numberOfVersions": 1,
       "roro": {
         "roroFreightType": "unaccompanied",
@@ -28,8 +142,7 @@
           "vehicle": {},
           "load": {},
           "account": {},
-          "passengers":[
-          ]
+          "passengers": []
         }
       }
     }

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -679,4 +679,16 @@ describe('TaskListPage', () => {
     expect(screen.getByText('Any (37)')).toBeInTheDocument();
     expect(screen.getByLabelText('Any (37)')).toBeChecked();
   });
+
+  it('should render the word SELECTOR next to category label on task', async () => {
+    mockAxios
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, taskListDataIssued);
+
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+
+    expect(screen.queryAllByText('SELECTOR')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Description
This PR brings back the omitted `SELECTOR` keyword for tasks where the highest risk is of type category

## To Test
- Pull & run against dev
- For any task that has a Category as the highest risk, the word `SELECTOR` will be appended at the start before the label.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
