### PR TITLE
COP-9973: RoRo Unaccompanied mode not showing driver and pax details

### DIFF
--- a/src/routes/TaskDetails/TaskVersionsMode/RoRoUnaccompaniedMode.jsx
+++ b/src/routes/TaskDetails/TaskVersionsMode/RoRoUnaccompaniedMode.jsx
@@ -89,7 +89,7 @@ const RoRoUnaccompaniedTaskVersion = ({ version, movementMode, taskSummaryData }
         {renderSecondColumn(version, taskSummaryData)}
       </div>
       <div className="govuk-grid-column-one-third vertical-dotted-line-two">
-        {renderThirdColumn(version)}
+        { movementMode !== 'RORO_UNACCOMPANIED_FREIGHT' && renderThirdColumn(version) }
       </div>
     </div>
   );

--- a/src/routes/TaskLists/TaskListMode.jsx
+++ b/src/routes/TaskLists/TaskListMode.jsx
@@ -299,34 +299,6 @@ const TaskListMode = ({ roroData, target, movementModeIcon }) => {
               <div className="govuk-grid-item">
                 <div>
                   <h3 className="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-font-size-16 govuk-!-font-weight-regular">
-                    Driver details
-                  </h3>
-                  <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
-                    {roroData.driver ? (
-                      <>
-                        {roroData.driver.firstName && <li className="govuk-!-font-weight-bold">{roroData.driver.firstName}</li>}
-                        {roroData.driver.middleName && <li className="govuk-!-font-weight-bold">{roroData.driver.middleName}</li>}
-                        {roroData.driver.lastName && <li className="govuk-!-font-weight-bold">{roroData.driver.lastName}</li>}
-                        {roroData.driver.dob && <li>DOB: {roroData.driver.dob}</li>}
-                        <li>{pluralise.withCount(target.aggregateDriverTrips || '?', '% trip', '% trips')}</li>
-                      </>
-                    ) : (<li className="govuk-!-font-weight-bold">Unknown</li>)}
-                  </ul>
-                  <h3 className="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-font-size-16 govuk-!-font-weight-regular">
-                    Passenger details
-                  </h3>
-                  <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
-                    {roroData.passengers && roroData.passengers.length > 0 ? (
-                      <>
-                        <li className="govuk-!-font-weight-bold">{pluralise.withCount(passengers.length - 1, '% passenger', '% passengers')}</li>
-                      </>
-                    ) : (<li className="govuk-!-font-weight-bold">None</li>)}
-                  </ul>
-                </div>
-              </div>
-              <div className="govuk-grid-item verticel-dotted-line">
-                <div>
-                  <h3 className="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-font-size-16 govuk-!-font-weight-regular">
                     Trailer details
                   </h3>
                   <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
@@ -376,6 +348,34 @@ const TaskListMode = ({ roroData, target, movementModeIcon }) => {
                     </>
                   ) : (<li className="govuk-!-font-weight-bold">Unknown</li>)}
                 </ul>
+              </div>
+              <div className="govuk-grid-item verticel-dotted-line">
+                <div className="hidden">
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-font-size-16 govuk-!-font-weight-regular">
+                    Driver details
+                  </h3>
+                  <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
+                    {roroData.driver && (
+                      <>
+                        {roroData.driver.firstName && <li className="govuk-!-font-weight-bold">{roroData.driver.firstName}</li>}
+                        {roroData.driver.middleName && <li className="govuk-!-font-weight-bold">{roroData.driver.middleName}</li>}
+                        {roroData.driver.lastName && <li className="govuk-!-font-weight-bold">{roroData.driver.lastName}</li>}
+                        {roroData.driver.dob && <li>DOB: {roroData.driver.dob}</li>}
+                        <li>{pluralise.withCount(target.aggregateDriverTrips || '?', '% trip', '% trips')}</li>
+                      </>
+                    )}
+                  </ul>
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-font-size-16 govuk-!-font-weight-regular">
+                    Passenger details
+                  </h3>
+                  <ul className="govuk-body-s govuk-list govuk-!-margin-bottom-2">
+                    {roroData.passengers && roroData.passengers.length > 0 ? (
+                      <>
+                        <li className="govuk-!-font-weight-bold">{pluralise.withCount(passengers.length - 1, '% passenger', '% passengers')}</li>
+                      </>
+                    ) : (<li className="govuk-!-font-weight-bold">None</li>)}
+                  </ul>
+                </div>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Description
Unaccompanied card showing driver and pax details not needed

## To Test
Step 1: Select RoRo unaccompanied freight on Task Management -> Apply filters . The task card shouldn't show the Driver and Passenger details
Step 2: Select view details on the task card. The task details page won't the the driver and passenger details for RoRo unaccompanied Mode
![image](https://user-images.githubusercontent.com/1534608/154506655-414ba7f9-602e-4f84-968a-c28fa73e3877.png)

![image](https://user-images.githubusercontent.com/1534608/154506762-deaa5e1b-27c1-4e4a-9e0a-3b617b950988.png)


## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [*] All reviewer comments resolved/answered? \*
