### PR TITLE
COP-9847: Add tests to verify auto populated haulier section on TIS

### DIFF
--- a/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
+++ b/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
@@ -368,6 +368,55 @@
           "washResponses": null,
           "matchMerge": null,
           "changeHistory": null
+         },
+         {
+          "metadata": {
+           "identityRecord": {
+            "poleId": {
+             "v2": {
+              "id": "ROROTSV:P=3c3d77a87e49e7057576506e9f6e9bdd"
+             },
+             "v1": null
+            },
+            "type": "P"
+           },
+           "sourceRecord": {
+            "name": "ROROTSV",
+            "shortName": "ROT",
+            "location": "archive/GroupId=none/CollectionDate=2021-01-13/DataFeedId=6/DataFeedTaskId=5838526/CERBERUS_8_rorotsv_freight_AccompTrailer_voyage2",
+            "id": "3c3d77a87e49e7057576506e9f6e9bdd",
+            "audit": {
+             "createdBy": "Fe+pMgMN+NFYnEMEp198pw==",
+             "createdTimestamp": 1596817140000,
+             "updatedBy": null,
+             "updatedTimestamp": null,
+             "deletedBy": null,
+             "deletedTimestamp": null
+            }
+           },
+           "complianceRecord": {
+            "visibility": "UNKNOWN",
+            "gscMarker": null,
+            "retentionMarkerDays": -1
+           },
+           "mappingRecord": {
+            "name": "RR-TSV-Party",
+            "version": "1"
+           }
+          },
+          "type": "ORGANISATION",
+          "organisation": {
+           "type": "ORGHAULIER",
+           "name": "Haulier Auto Test UK",
+           "registrationNumber": 1234567,
+           "vatNumber": null,
+           "industrySector": null,
+           "numberOfEmployees": null
+          },
+          "attributes": null,
+          "matching": null,
+          "features": null,
+          "changeHistory": null
          }
         ],
         "documents": null,
@@ -686,6 +735,81 @@
           "features": null,
           "washResponses": null,
           "matchMerge": null,
+          "changeHistory": null
+         },
+         {
+          "metadata": {
+           "identityRecord": {
+            "poleId": {
+             "v2": {
+              "id": "ROROTSV:P=3c3d77a87e49e7057576506e9f6e9bdd,L=e61561707007db5560611f6f75736359"
+             },
+             "v1": null
+            },
+            "type": "L"
+           },
+           "sourceRecord": {
+            "name": "ROROTSV",
+            "shortName": "ROT",
+            "location": "archive/GroupId=none/CollectionDate=2021-01-13/DataFeedId=6/DataFeedTaskId=5838526/CERBERUS_8_rorotsv_freight_AccompTrailer_voyage2",
+            "id": "e61561707007db5560611f6f75736359",
+            "audit": {
+             "createdBy": "Fe+pMgMN+NFYnEMEp198pw==",
+             "createdTimestamp": 1596817140000,
+             "updatedBy": null,
+             "updatedTimestamp": null,
+             "deletedBy": null,
+             "deletedTimestamp": null
+            }
+           },
+           "complianceRecord": {
+            "visibility": "UNKNOWN",
+            "gscMarker": null,
+            "retentionMarkerDays": -1
+           },
+           "mappingRecord": {
+            "name": "RR-TSV-Location-Address",
+            "version": "1"
+           }
+          },
+          "type": "ADDRESS",
+          "party": {
+           "poleId": {
+            "v2": {
+             "id": "ROROTSV:P=3c3d77a87e49e7057576506e9f6e9bdd"
+            },
+            "v1": null
+           },
+           "type": "P"
+          },
+          "role": "PTOLASSO",
+          "startTimestamp": null,
+          "endTimestamp": null,
+          "address": {
+           "type": "LOCADDR",
+           "postCode": null,
+           "poBox": "SE11 2PS",
+           "fullAddress": "Unit 82 Central Docks, Canary Wharf, East London, E16 2SR",
+           "name": "Haulier Auto Test UK",
+           "siteLocation": null,
+           "number": 100,
+           "street": "Test address",
+           "town": "Greater London",
+           "area": null,
+           "district": null,
+           "county": "Essex",
+           "country": "GB",
+           "uniquePropertyReferenceNumber": null,
+           "latitude": null,
+           "longitude": null
+          },
+          "attributes": {
+           "attrs": {
+            "addressLine1": "Unit 100  Dock Lands"
+           }
+          },
+          "matching": null,
+          "features": null,
           "changeHistory": null
          }
         ],

--- a/cypress/fixtures/accompanied-task-2-passengers-details.json
+++ b/cypress/fixtures/accompanied-task-2-passengers-details.json
@@ -17,10 +17,10 @@
     "Email": ""
   },
   "haulier": {
-    "Name": "Gondrand UK",
-    "Address": "Unit 82 Central Docks, Canary Wharf, East London, E16 2SR",
-    "Telephone": "020 89637851",
-    "Mobile": ""
+    "name": "Gondrand UK",
+    "address": "Unit 82 Central Docks",
+    "city": "London",
+    "country": "GB"
   },
   "driver": {
     "Name": "Isiaih Ford",

--- a/cypress/fixtures/unaccompanied-task-details.json
+++ b/cypress/fixtures/unaccompanied-task-details.json
@@ -17,10 +17,10 @@
     "Email": ""
   },
   "haulier": {
-    "Name": "",
-    "Address": "",
-    "Telephone": "",
-    "Mobile": ""
+    "name": "Haulier Auto Test UK",
+    "address": "Unit 100  Dock Lands",
+    "city": "Greater London",
+    "country": "GB"
   },
   "driver": {
     "Name": "",

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -78,6 +78,15 @@ describe('Issue target from cerberus UI using target sheet information form', ()
           cy.verifyDate('docExpiry', passengerDocExpiry[0], passengerDocExpiry[1], passengerDocExpiry[2]);
         });
       }
+
+      cy.verifySelectedCheckBox('detailsOf', ['haulier']);
+
+      cy.get('.formio-component-haulier').within(() => {
+        cy.verifyElementText('name', targetData.haulier.name);
+        cy.verifyElementText('address', targetData.haulier.address);
+        cy.verifyElementText('city', targetData.haulier.city);
+        cy.verifyElementText('country', targetData.haulier.country);
+      });
     });
 
     cy.fixture('target-information.json').then((targetInfo) => {
@@ -88,6 +97,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.typeTodaysDateTime('eta');
 
       cy.verifySelectedDropdownValue('category', 'A');
+
+      cy.verifyElementText('manifestedLoad', 'Wine');
 
       cy.multiSelectDropDown('strategy', [targetInfo.strategy[0], targetInfo.strategy[2], targetInfo.strategy[3]]);
 
@@ -187,6 +198,14 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.get('.formio-component-registrationNationality').should('be.visible');
       cy.verifyElementText('name', expectedDetails.vessel.name);
       cy.verifyElementText('company', expectedDetails.vessel.shippingCompany);
+      cy.verifySelectedCheckBox('detailsOf', ['haulier']);
+
+      cy.get('.formio-component-haulier').within(() => {
+        cy.verifyElementText('name', expectedDetails.haulier.name);
+        cy.verifyElementText('address', expectedDetails.haulier.address);
+        cy.verifyElementText('city', expectedDetails.haulier.city);
+        cy.verifyElementText('country', expectedDetails.haulier.country);
+      });
     });
 
     cy.fixture('target-information.json').then((targetInfo) => {
@@ -199,6 +218,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.typeTodaysDateTime('eta');
 
       cy.verifySelectedDropdownValue('category', 'B');
+
+      cy.verifyElementText('manifestedLoad', 'Corkscrews');
 
       cy.selectDropDownValue('strategy', targetInfo.strategy[Math.floor(Math.random() * targetInfo.strategy.length)]);
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -136,6 +136,16 @@ Cypress.Commands.add('selectCheckBox', (elementName, value) => {
   }
 });
 
+Cypress.Commands.add('verifySelectedCheckBox', (elementName, values) => {
+  for (let value of values) {
+    cy.get(`${formioComponent}${elementName}`)
+      .contains(new RegExp(`^${value}$`, 'g'))
+      .closest('div')
+      .find('input')
+      .should('be.checked');
+  }
+});
+
 Cypress.Commands.add('clickNext', () => {
   cy.get('button[ref$="next"]').should('be.enabled');
   cy.wait(1000);


### PR DESCRIPTION
## Description
Add tests to verify the following scenario,

Scenario : Task contains haulier details
Given a task contains details of a haulier
WHEN the Target information Sheet is displayed
THEN the "haulier" Checkbox is selected AND
the fields for recording haulier details are displayed

## To Test
npm run cypress:runner
execute the following 2 tests from spec `issue-a-target.spec.js`
`Should submit a target successfully from a RoRo-accompanied task and it should be moved to target issued tab`
`Should submit a target successfully from a RoRo-Unaccompanied task and it should be moved to target issued tab`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
