### PR TITLE
COP-9846 : Add tests to verify Account details auto populated for RoRo Frieght tasks

### DIFF
--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -87,6 +87,11 @@ describe('Issue target from cerberus UI using target sheet information form', ()
         cy.verifyElementText('city', targetData.haulier.city);
         cy.verifyElementText('country', targetData.haulier.country);
       });
+
+      cy.get('.formio-component-account').within(() => {
+        cy.verifyElementText('name', targetData.account['Full name']);
+        cy.verifyElementText('number', targetData.account['Reference number']);
+      });
     });
 
     cy.fixture('target-information.json').then((targetInfo) => {
@@ -206,6 +211,11 @@ describe('Issue target from cerberus UI using target sheet information form', ()
         cy.verifyElementText('city', expectedDetails.haulier.city);
         cy.verifyElementText('country', expectedDetails.haulier.country);
       });
+
+      cy.get('.formio-component-account').within(() => {
+        cy.verifyElementText('name', expectedDetails.account['Full name']);
+        cy.verifyElementText('number', expectedDetails.account['Reference number']);
+      });
     });
 
     cy.fixture('target-information.json').then((targetInfo) => {
@@ -222,6 +232,11 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.verifyElementText('manifestedLoad', 'Corkscrews');
 
       cy.selectDropDownValue('strategy', targetInfo.strategy[Math.floor(Math.random() * targetInfo.strategy.length)]);
+
+      cy.get('.formio-component-account').within(() => {
+        cy.verifyElementText('name', 'DPE logistics');
+        cy.verifyElementText('number', '000524557');
+      });
 
       cy.selectDropDownValue('nominalType', 'Account');
 
@@ -457,6 +472,8 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.typeTodaysDateTime('eta');
 
       cy.verifySelectedDropdownValue('category', 'C');
+
+      cy.get('.formio-component-account').should('have.class', 'formio-hidden');
 
       cy.selectDropDownValue('strategy', targetInfo.strategy[Math.floor(Math.random() * targetInfo.strategy.length)]);
 

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -233,11 +233,6 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
       cy.selectDropDownValue('strategy', targetInfo.strategy[Math.floor(Math.random() * targetInfo.strategy.length)]);
 
-      cy.get('.formio-component-account').within(() => {
-        cy.verifyElementText('name', 'DPE logistics');
-        cy.verifyElementText('number', '000524557');
-      });
-
       cy.selectDropDownValue('nominalType', 'Account');
 
       cy.multiSelectDropDown('threatIndicators', targetInfo['target-indicators']);


### PR DESCRIPTION
## Description
Add tests for following 2 scenarios

Scenario 1:Do not show account questions for RoRo Tourist
GIVEN a task is a RoRo task
WHEN the TIS is displayed
THEN the account questions are NOT displayed

Scenario 2: DO show them for RoRo Freight (accompanied and unaccompanied)
GIVEN a task is a RoRo Freight (accompanied and unaccompanied)
WHEN the TIS is displayed
THEN the account questions are displayed

## To Test
npm run cypress:runner
run all the tests from spec `issue-a-target.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
