### PR TITLE
COP-9852: Add test to verify Passenger information hidden on TIS

### DIFF
--- a/cypress/fixtures/accompanied-task-no-passengers.json
+++ b/cypress/fixtures/accompanied-task-no-passengers.json
@@ -1,0 +1,93 @@
+{
+  "vehicle": {
+    "Vehicle registration": "IR-9688",
+    "Type": "HGV",
+    "Make": "BMW",
+    "Model": "520D",
+    "Country of registration": "GB",
+    "Colour": "Red"
+  },
+  "account": {
+    "Full name": "Product of France Wines",
+    "Short name": "Prod of Fr Wines",
+    "Reference number": "PF-6653",
+    "Address": "Unit 82 Central Docks Calais",
+    "Telephone": "0333 637851",
+    "Mobile": "",
+    "Email": ""
+  },
+  "haulier": {
+    "name": "Gondrand UK",
+    "address": "Unit 82 Central Docks",
+    "city": "London",
+    "country": "GB"
+  },
+  "driver": {
+    "Name": "Isiaih Ford",
+    "Date of birth": "09/10/1991",
+    "Gender": "M",
+    "Nationality": "DK",
+    "Travel document type": "Passport",
+    "Travel document number": "566746DL",
+    "Travel document expiry": "29/10/2023"
+  },
+  "goods": {
+    "Description": "Wine",
+    "Is cargo hazardous?": "No",
+    "Weight of goods": ""
+  },
+  "Booking-and-check-in": {
+    "Reference": "AA123412781",
+    "Ticket number": "1234567",
+    "Type": "R",
+    "Name": "",
+    "Address": "",
+    "Date and time": "1 Mar 2021 at 15:50, a month before travel",
+    "Country": "GB",
+    "Payment method": "CQ",
+    "Ticket price": "",
+    "Ticket type": "Return",
+    "Check-in": ""
+  },
+  "rules": {
+    "Rule name": "Paid by Cash",
+    "Threat": "Tier 1",
+    "Rule verison": "1",
+    "Abuse Type": "National Security at the Border",
+    "Agency": "",
+    "Description": "Test"
+  },
+  "vessel": {
+    "name": "PRIDE OF CANTERBURY",
+    "shippingCompany": "P & O Ferries Limite"
+  },
+  "passengersTIS":[
+    {
+      "Name": "Fred Flintstone",
+      "Date of birth": "15/7/1991",
+      "Gender": "F",
+      "Nationality": "DE",
+      "Travel document type": "Passport",
+      "Travel document number": "875786876",
+      "Travel document expiry": "22/3/2022"
+    },
+    {
+      "Name": "Barney Rubble",
+      "Date of birth": "12/7/1991",
+      "Gender": "M",
+      "Nationality": "GB",
+      "Travel document type": "Passport",
+      "Travel document number": "244746NL",
+      "Travel document expiry": "1/2/2021"
+    }
+  ],
+  "TargetingIndicators": {
+     "Total Score": "80",
+     "Total Indicators": "3",
+     "indicators": {
+        "Paid by cash": "30",
+        "Empty trailer for round trip": "30",
+        "Empty vehicle": "20"
+     }
+  }
+}


### PR DESCRIPTION
## Description
Add test to verify Passenger information hidden on TIS

Scenario 1: View task with passengers in TIS
Given a task has passengers
WHEN the Target Information sheet is displayed
THEN the passenger fields are displayed

Scenario 2: View task withOUT passengers in TIS
Given a task has NO passengers
WHEN the Target Information sheet is displayed
THEN the passenger fields are NOT displayed

## To Test
npm run cypress:runner
run first 4 tests from spec `issue-a-target.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
