### PR TITLE
COP-9934: Update test to accept enter key when adding comment for a task

### DIFF
--- a/cypress/integration/cerberus/task-details.spec.js
+++ b/cypress/integration/cerberus/task-details.spec.js
@@ -54,7 +54,7 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
 
     cy.get('.formio-component-note textarea')
       .should('be.visible')
-      .type(taskNotes, { force: true });
+      .type(`${taskNotes} {enter} text after enter button`, { force: true });
 
     cy.get('.formio-component-submit button').click('top');
 
@@ -62,9 +62,11 @@ describe('Render tasks from Camunda and manage them on task details Page', () =>
       expect(response.statusCode).to.equal(200);
     });
 
+    cy.wait(2000);
+
     cy.get('.govuk-grid-column-one-third').within(() => {
       cy.get('.govuk-body-s a').first().should('have.text', 'cypressuser-cerberus@lodev.xyz');
-      cy.contains('Add notes for testing & check it stored').should('have.text', taskNotes);
+      cy.get('.activity-body-container').eq(0).find('p.govuk-body').should('have.text', `${taskNotes} \n text after enter button`);
     });
 
     cy.get('button.link-button').should('be.visible').and('have.text', 'Unclaim task').click();


### PR DESCRIPTION
## Description
Update test to accept enter key when adding comment for a task

## To Test
npm run cypress:runner

run the test `Should add notes for the selected tasks` from spec `task-details.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
