### PR TITLE
add highest threat level sorting filter

### DIFF
--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -115,11 +115,11 @@ const TasksTab = ({ taskStatus, filtersToApply, setError, targetTaskCount = 0 })
         ? [
           {
             field: 'arrival-date',
-            order: 'asc',
+            order: 'desc',
           },
           {
             field: 'highest-threat-level',
-            order: 'asc',
+            order: 'desc',
           },
         ]
         : null;

--- a/src/routes/TaskLists/TaskListPage.jsx
+++ b/src/routes/TaskLists/TaskListPage.jsx
@@ -117,6 +117,10 @@ const TasksTab = ({ taskStatus, filtersToApply, setError, targetTaskCount = 0 })
             field: 'arrival-date',
             order: 'asc',
           },
+          {
+            field: 'highest-threat-level',
+            order: 'asc',
+          },
         ]
         : null;
       try {

--- a/src/routes/__tests__/TaskListPage.test.jsx
+++ b/src/routes/__tests__/TaskListPage.test.jsx
@@ -730,6 +730,39 @@ describe('TaskListPage', () => {
     expect(screen.queryAllByText('Scenario 1 Rule')).toHaveLength(1);
   });
 
+  it('should post correct filter and sort values when getting a targeting task page', async () => {
+    mockAxios
+      .onPost('/targeting-tasks/status-counts')
+      .reply(200, [countResponse])
+      .onPost('/targeting-tasks/pages')
+      .reply(200, []);
+
+    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+
+    expect(mockAxios.history.post).toHaveLength(3);
+    expect(JSON.parse(mockAxios.history.post[2].data)).toEqual({
+      filterParams: {
+        hasSelectors: null,
+        movementModes: [],
+      },
+      pageParams: {
+        limit: 100,
+        offset: 0,
+      },
+      sortParams: [
+        {
+          field: 'arrival-date',
+          order: 'desc',
+        },
+        {
+          field: 'highest-threat-level',
+          order: 'desc',
+        },
+      ],
+      status: 'NEW',
+    });
+  });
+
   describe('UseInterval Hook', () => {
     let callback = jest.fn();
 


### PR DESCRIPTION
## Description
This PR adds the highest-threat-level sorting parameter to the task list page for tasks that are IN_PROGRESS or NEW

## To Test

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
