### PR TITLE
Entity search fix

### DIFF
--- a/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
+++ b/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
@@ -43,44 +43,6 @@ const renderDocumentExpiry = (passportExpiry, bookedDate) => {
   return 'Unknown';
 };
 
-const renderOccupants = (contents, fieldSetName, bookingDate) => {
-  const name = contents.find(({ propName }) => propName === 'name')?.content;
-  const dob = contents.find(({ propName }) => propName === 'dob')?.content;
-  const gender = contents.find(({ propName }) => propName === 'gender')?.content;
-  const nationality = contents.find(({ propName }) => propName === 'nationality')?.content;
-  const passportNumber = contents.find(({ propName }) => propName === 'docNumber')?.content;
-  const passportExpiry = contents.find(({ propName }) => propName === 'docExpiry')?.content;
-  const bookedDate = bookingDate?.content.split(',')[1];
-
-  return (
-    <div className="govuk-!-margin-bottom-4 bottom-border">
-      <div className="govuk-grid-row govuk-!-margin-bottom-2">
-        <div className="govuk-grid-column-full">
-          <p className="govuk-!-margin-bottom-0 font__light">{fieldSetName}</p>
-          <p className="govuk-!-margin-bottom-0 font__bold">{name}</p>
-          <p className="govuk-!-margin-bottom-0 font__bold">{formatGender(gender)}
-            { dob ? (<span>, born {formatField(SHORT_DATE_ALT, dob)}</span>) : (<span>, Unknown</span>) }
-            { nationality ? (<span>, {nationality}</span>) : (<span>, Unknown</span>)}
-          </p>
-        </div>
-      </div>
-      <div className="govuk-grid-row govuk-!-margin-bottom-2">
-        <div className="govuk-grid-column-full govuk-!-margin-bottom-2">
-          <p className="govuk-!-margin-bottom-0 font__light">Passport</p>
-          <p className="govuk-!-margin-bottom-0 font__bold">{passportNumber || 'Unknown'}</p>
-        </div>
-        <div className="govuk-grid-column-full">
-          <p className="govuk-!-margin-bottom-0 font__light">Validity</p>
-          <p className="govuk-!-margin-bottom-0 font__bold">
-            { passportExpiry ? (<span>Expires {formatField(SHORT_DATE_ALT, passportExpiry)}</span>) : (<span>Unknown</span>) }
-          </p>
-          <p className="govuk-!-margin-bottom-0 font__light">{ renderDocumentExpiry(formatField(SHORT_DATE_ALT, passportExpiry), bookedDate) }</p>
-        </div>
-      </div>
-    </div>
-  );
-};
-
 const renderVersionSection = ({ fieldSetName, contents }, linkPropNames = {}) => {
   if (contents !== undefined && contents !== null && contents.length > 0) {
     const jsxElement = renderFields(contents, linkPropNames);
@@ -114,6 +76,44 @@ const renderGoodsSection = (fieldSet) => {
 
 const renderBookingSection = (fieldSet) => {
   return renderVersionSection(fieldSet);
+};
+
+const renderOccupants = (contents, fieldSetName, bookingDate) => {
+  const name = contents.find(({ propName }) => propName === 'name')?.content;
+  const dob = contents.find(({ propName }) => propName === 'dob')?.content;
+  const gender = contents.find(({ propName }) => propName === 'gender')?.content;
+  const nationality = contents.find(({ propName }) => propName === 'nationality')?.content;
+  const passportNumber = contents.find(({ propName }) => propName === 'docNumber')?.content;
+  const passportExpiry = contents.find(({ propName }) => propName === 'docExpiry')?.content;
+  const bookedDate = bookingDate?.content.split(',')[1];
+  const link = findLink(contents, contents.find(({ propName }) => propName === 'name'), defaultLinkPropNames);
+  return (
+    <div className="govuk-!-margin-bottom-4 bottom-border">
+      <div className="govuk-grid-row govuk-!-margin-bottom-2">
+        <div className="govuk-grid-column-full">
+          <p className="govuk-!-margin-bottom-0 font__light">{fieldSetName}</p>
+          {link ? <p className="govuk-!-margin-bottom-0 font__bold">{formatLinkField('STRING', name, link)}</p> : <p className="govuk-!-margin-bottom-0 font__bold">{name}</p>}
+          <p className="govuk-!-margin-bottom-0 font__bold">{formatGender(gender)}
+            { dob ? (<span>, born {formatField(SHORT_DATE_ALT, dob)}</span>) : (<span>, Unknown</span>) }
+            { nationality ? (<span>, {nationality}</span>) : (<span>, Unknown</span>)}
+          </p>
+        </div>
+      </div>
+      <div className="govuk-grid-row govuk-!-margin-bottom-2">
+        <div className="govuk-grid-column-full govuk-!-margin-bottom-2">
+          <p className="govuk-!-margin-bottom-0 font__light">Passport</p>
+          <p className="govuk-!-margin-bottom-0 font__bold">{passportNumber || 'Unknown'}</p>
+        </div>
+        <div className="govuk-grid-column-full">
+          <p className="govuk-!-margin-bottom-0 font__light">Validity</p>
+          <p className="govuk-!-margin-bottom-0 font__bold">
+            { passportExpiry ? (<span>Expires {formatField(SHORT_DATE_ALT, passportExpiry)}</span>) : (<span>Unknown</span>) }
+          </p>
+          <p className="govuk-!-margin-bottom-0 font__light">{ renderDocumentExpiry(formatField(SHORT_DATE_ALT, passportExpiry), bookedDate) }</p>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 const renderVersionSectionBody = (fieldSet, linkPropNames = {}, className = '') => {

--- a/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
+++ b/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
@@ -66,10 +66,6 @@ const renderAccountSection = (fieldSet) => {
   return renderVersionSection(fieldSet, defaultLinkPropNames);
 };
 
-const renderDriverSection = (fieldSet, bookingDate) => {
-  return renderOccupants(fieldSet.contents, fieldSet.fieldSetName, bookingDate);
-};
-
 const renderGoodsSection = (fieldSet) => {
   return renderVersionSection(fieldSet);
 };
@@ -114,6 +110,10 @@ const renderOccupants = (contents, fieldSetName, bookingDate) => {
       </div>
     </div>
   );
+};
+
+const renderDriverSection = (fieldSet, bookingDate) => {
+  return renderOccupants(fieldSet.contents, fieldSet.fieldSetName, bookingDate);
 };
 
 const renderVersionSectionBody = (fieldSet, linkPropNames = {}, className = '') => {

--- a/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
+++ b/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
@@ -79,20 +79,20 @@ const renderBookingSection = (fieldSet) => {
 };
 
 const renderOccupants = (contents, fieldSetName, bookingDate) => {
-  const name = contents.find(({ propName }) => propName === 'name')?.content;
+  const name = contents.find(({ propName }) => propName === 'name');
   const dob = contents.find(({ propName }) => propName === 'dob')?.content;
   const gender = contents.find(({ propName }) => propName === 'gender')?.content;
   const nationality = contents.find(({ propName }) => propName === 'nationality')?.content;
   const passportNumber = contents.find(({ propName }) => propName === 'docNumber')?.content;
   const passportExpiry = contents.find(({ propName }) => propName === 'docExpiry')?.content;
   const bookedDate = bookingDate?.content.split(',')[1];
-  const link = findLink(contents, contents.find(({ propName }) => propName === 'name'), defaultLinkPropNames);
+  const link = findLink(contents, name, defaultLinkPropNames);
   return (
     <div className="govuk-!-margin-bottom-4 bottom-border">
       <div className="govuk-grid-row govuk-!-margin-bottom-2">
         <div className="govuk-grid-column-full">
           <p className="govuk-!-margin-bottom-0 font__light">{fieldSetName}</p>
-          {link ? <p className="govuk-!-margin-bottom-0 font__bold">{formatLinkField('STRING', name, link)}</p> : <p className="govuk-!-margin-bottom-0 font__bold">{name}</p>}
+          {link ? <p className="govuk-!-margin-bottom-0 font__bold">{formatLinkField(name.type, name.content, link)}</p> : <p className="govuk-!-margin-bottom-0 font__bold">{name.content}</p>}
           <p className="govuk-!-margin-bottom-0 font__bold">{formatGender(gender)}
             { dob ? (<span>, born {formatField(SHORT_DATE_ALT, dob)}</span>) : (<span>, Unknown</span>) }
             { nationality ? (<span>, {nationality}</span>) : (<span>, Unknown</span>)}

--- a/src/routes/__tests__/TaskVersionsMode/SectionRenderer.test.jsx
+++ b/src/routes/__tests__/TaskVersionsMode/SectionRenderer.test.jsx
@@ -625,7 +625,11 @@ describe('SectionRenderer', () => {
               <div className="govuk-grid-row govuk-!-margin-bottom-2">
                 <div className="govuk-grid-column-full">
                   <p className="govuk-!-margin-bottom-0 font__light">Occupant</p>
-                  <p className="govuk-!-margin-bottom-0 font__bold">MRS SECOND PASSENGER</p>
+                  <p className="govuk-!-margin-bottom-0 font__bold">
+                    <a href="http://localhost:4020/search?term=98989898&amp;type=PERSON&amp;fields=[&quot;id&quot;]" target="_blank" rel="noreferrer noopener">
+                      MRS SECOND PASSENGER
+                    </a>
+                  </p>
                   <p className="govuk-!-margin-bottom-0 font__bold">Unknown<span>, Unknown</span><span>, Unknown</span></p>
                 </div>
               </div>
@@ -883,7 +887,11 @@ describe('SectionRenderer', () => {
                   <div className="govuk-grid-row govuk-!-margin-bottom-2">
                     <div className="govuk-grid-column-full">
                       <p className="govuk-!-margin-bottom-0 font__light">Occupant</p>
-                      <p className="govuk-!-margin-bottom-0 font__bold">MR OTHER PASSENGER</p>
+                      <p className="govuk-!-margin-bottom-0 font__bold">
+                        <a href="http://localhost:4020/search?term=56565656&amp;type=PERSON&amp;fields=[&quot;id&quot;]" target="_blank" rel="noreferrer noopener">
+                          MR OTHER PASSENGER
+                        </a>
+                      </p>
                       <p className="govuk-!-margin-bottom-0 font__bold">Unknown<span>, Unknown</span><span>, Unknown</span></p>
                     </div>
                   </div>


### PR DESCRIPTION
## Description
This PR adds back the previously removed rendering of entity search URLS when they were present.

## To Test
- Pull & Run against dev
- In the `NEW` tab, locate the task `ROROTSV:CMID=MRUOCCO-ENTITY-SEARCH-TEST-3`
- Under the occupants section, if there is an entity search URL present, the name of the occupant will be rendered as a link.

![image](https://user-images.githubusercontent.com/19333750/156221346-d5ded9b0-8f34-48d4-b322-1db6a9eaf29c.png)


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
