### PR TITLE
COP-8641: Add tests to verify Selectors grouping with global reference ID

### DIFF
--- a/cypress/fixtures/selectors-group-expected.json
+++ b/cypress/fixtures/selectors-group-expected.json
@@ -1,0 +1,141 @@
+{
+  "Selectors": [
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Tester",
+        "Source reference": "intel source",
+        "Category": "A",
+        "Threat type": "National Security at the Border",
+        "Point of contact message": "selector for auto testing",
+        "Point of contact": "Point Of Contact Testing",
+        "Inbound action": "No action required",
+        "Outbound action": "No action required",
+        "Notes": "notes testing",
+        "Creator": "test user"
+      },
+      "group": {
+        "Selector 2021-51": "Supplemental warnings",
+        "Selector 2022-225": "Warnings from testing for group reference",
+        "Selector 2021-278": "Warnings from testing",
+        "Selector 2021-279": "bdfbdfbf",
+        "entities": [
+          {
+            "Entity": "Organisation"
+          },
+          {
+            "Attribute": "telephone"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "01234 56723737"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          },
+          {
+            "Entity": "vehicle"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "DK-45678"
+          },
+          {
+            "Entity": "Vehicle"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "ABC123"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          },
+          {
+            "Entity": "Trailer"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "qwerty"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Unaccompanied Freight"
+          }
+        ]
+      }
+    },
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Velit in sunt aliquip voluptate tempore consectetur",
+        "Source reference": "Qui adipisci consectetur ullam consequatur a aspernatur in",
+        "Category": "C",
+        "Threat type": "Alcohol",
+        "Point of contact message": "Blanditiis consectetur impedit omnis veniam veniam quibusdam ad eiusmod et consequatur fuga Fugiat nesciunt tenetur expedita aliquam",
+        "Point of contact": "Dolores est qui laboriosam velit tenetur aut sit laborum Temporibus distinctio Aut hic non autem",
+        "Inbound action": "Worthy of attention",
+        "Outbound action": "Monitor only",
+        "Notes": "notes",
+        "Creator": "user"
+      },
+      "group": {
+        "Selector 2022-245": "This is a different group reference",
+        "entities": [
+          {
+            "Entity": "Person"
+          },
+          {
+            "Attribute": "familyName"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "TURNER"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/cypress/fixtures/selectors-group-versions-expected.json
+++ b/cypress/fixtures/selectors-group-versions-expected.json
@@ -1,0 +1,303 @@
+{
+  "Selectors-version-2": [
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Tester",
+        "Source reference": "intel source",
+        "Category": "A",
+        "Threat type": "National Security at the Border",
+        "Point of contact message": "selector for auto testing",
+        "Point of contact": "Point Of Contact Testing",
+        "Inbound action": "No action required",
+        "Outbound action": "No action required",
+        "Notes": "notes testing",
+        "Creator": "test user"
+      },
+      "group": {
+        "Selector 2021-10": "Supplemental warnings",
+        "entities": [
+          {
+            "Entity": "Organisation"
+          },
+          {
+            "Attribute": "telephone"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "01234 56723737"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          }
+        ]
+      }
+    },
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Tester",
+        "Source reference": "intel source",
+        "Category": "A",
+        "Threat type": "National Security at the Border",
+        "Point of contact message": "selector for auto testing",
+        "Point of contact": "Point Of Contact Testing",
+        "Inbound action": "No action required",
+        "Outbound action": "No action required",
+        "Notes": "notes testing",
+        "Creator": "test user"
+      },
+      "group": {
+        "Selector 2022-100": "Warnings from testing for group reference",
+        "entities": [
+          {
+            "Entity": "vehicle"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "DK-45678"
+          }
+        ]
+      }
+    },
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Velit in sunt aliquip voluptate tempore consectetur",
+        "Source reference": "Qui adipisci consectetur ullam consequatur a aspernatur in",
+        "Category": "C",
+        "Threat type": "Alcohol",
+        "Point of contact message": "Blanditiis consectetur impedit omnis veniam veniam quibusdam ad eiusmod et consequatur fuga Fugiat nesciunt tenetur expedita aliquam",
+        "Point of contact": "Dolores est qui laboriosam velit tenetur aut sit laborum Temporibus distinctio Aut hic non autem",
+        "Inbound action": "Worthy of attention",
+        "Outbound action": "Monitor only",
+        "Notes": "notes",
+        "Creator": "user"
+      },
+      "group": {
+        "Selector 2022-245": "This is a different group reference",
+        "entities": [
+          {
+            "Entity": "Person"
+          },
+          {
+            "Attribute": "familyName"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "TURNER"
+          }
+        ]
+      }
+    },
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Tester",
+        "Source reference": "intel source",
+        "Category": "A",
+        "Threat type": "National Security at the Border",
+        "Point of contact message": "selector for auto testing",
+        "Point of contact": "Point Of Contact Testing",
+        "Inbound action": "No action required",
+        "Outbound action": "No action required",
+        "Notes": "notes testing",
+        "Creator": "test user"
+      },
+      "group": {
+        "Selector 2021-278": "Warnings from testing",
+        "entities": [
+          {
+            "Entity": "Vehicle"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "ABC123"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          }
+        ]
+      }
+    },
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Tester",
+        "Source reference": "intel source",
+        "Category": "A",
+        "Threat type": "National Security at the Border",
+        "Point of contact message": "selector for auto testing",
+        "Point of contact": "Point Of Contact Testing",
+        "Inbound action": "action required",
+        "Outbound action": "No action required",
+        "Notes": "notes testing",
+        "Creator": "test user"
+      },
+      "group": {
+        "Selector 2021-279": "bdfbdfbf",
+        "entities": [
+          {
+            "Entity": "Trailer"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "qwerty"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Unaccompanied Freight"
+          }
+        ]
+      }
+    }
+  ],
+  "Selectors-version-1": [
+    {
+      "selectorGroupInfo": {
+        "Requesting officer": "Tester",
+        "Source reference": "intel source",
+        "Category": "A",
+        "Threat type": "National Security at the Border",
+        "Point of contact message": "selector for auto testing",
+        "Point of contact": "Point Of Contact Testing",
+        "Inbound action": "No action required",
+        "Outbound action": "No action required",
+        "Notes": "notes testing",
+        "Creator": "test user"
+      },
+      "group": {
+        "Selector 2021-51": "Supplemental warnings",
+        "Selector 2022-225": "Warnings from testing for group reference",
+        "Selector 2021-278": "Warnings from testing",
+        "Selector 2021-279": "bdfbdfbf",
+        "entities": [
+          {
+            "Entity": "Organisation"
+          },
+          {
+            "Attribute": "telephone"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "01234 56723737"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          },
+          {
+            "Entity": "vehicle"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "DK-45678"
+          },
+          {
+            "Entity": "Vehicle"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "ABC123"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          },
+          {
+            "Entity": "Trailer"
+          },
+          {
+            "Attribute": "registrationNumber"
+          },
+          {
+            "Operator": "equal"
+          },
+          {
+            "Value": "qwerty"
+          },
+          {
+            "Entity": "Message"
+          },
+          {
+            "Attribute": "mode"
+          },
+          {
+            "Operator": "in"
+          },
+          {
+            "Value": "RORO Unaccompanied Freight"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/cypress/fixtures/tasks-with-rules-selectors/RoRo-task-selectors-same-group-reference.json
+++ b/cypress/fixtures/tasks-with-rules-selectors/RoRo-task-selectors-same-group-reference.json
@@ -1,0 +1,1433 @@
+{
+  "variables": {
+    "rbtPayload": {
+      "type": "Json",
+      "value": {
+        "data": {
+          "movementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+          "riskSubmissionId": 8550,
+          "riskCreatedDate": "2021-07-13T09:30:03.106021Z",
+          "riskType": "Pre-Arrival",
+          "matchedRules": [
+            {
+              "ruleId":535,
+              "ruleName":"Selector Matched Rule",
+              "ruleType":"Both",
+              "ruleVersion":1,
+              "ruleDescription":"Test",
+              "securityLabels":[
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 1",
+              "indicatorMatches":[
+                {
+                  "entity":"Message",
+                  "descriptor":"selectorsMatched",
+                  "operator":"equal",
+                  "value":"true"
+                },
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[Air Freight, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+                }
+              ],
+              "abuseTypes":[
+                "National Security at the Border"
+              ]
+            },
+            {
+              "ruleId":546,
+              "ruleName":"Paid by cash - perf rule",
+              "ruleType":"Pre-load",
+              "ruleVersion":1,
+              "ruleDescription":"Debitis esse volupt",
+              "securityLabels":[
+                "null",
+                "null",
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 2",
+              "indicatorMatches":[
+                {
+                  "entity":"Booking",
+                  "descriptor":"cashPaid",
+                  "operator":"equal",
+                  "value":"true"
+                },
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[RORO Accompanied Freight, RORO Tourist]"
+                }
+              ],
+              "abuseTypes":[
+                "Plant Health"
+              ]
+            },
+            {
+              "ruleId":556,
+              "ruleName":"Checkin lead time",
+              "ruleType":"Both",
+              "ruleVersion":1,
+              "ruleDescription":"Qui nesciunt suscip",
+              "securityLabels":[
+                "null",
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 4",
+              "indicatorMatches":[
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+                },
+                {
+                  "entity":"Booking",
+                  "descriptor":"checkInLeadTime",
+                  "operator":"between",
+                  "value":"[1, 24]"
+                }
+              ],
+              "abuseTypes":[
+                "Class A Drugs"
+              ]
+            }
+          ],
+          "matchedSelectors":[
+            {
+              "selectorId": 279,
+              "selectorReference": "2021-279",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate": "2021-12-08T08:23:40.257Z",
+              "endDate": "2022-01-19T23:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "bfbfdbf",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "SR-220",
+              "warnings": "bdfbdfbf",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "MAH gateway",
+              "indicatorMatches": [
+                {
+                  "entity": "Trailer",
+                  "descriptor": "registrationNumber",
+                  "operator": "equal",
+                  "value": "qwerty"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+            },
+            {
+              "selectorId": 278,
+              "selectorReference": "2021-278",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate": "2021-12-02T16:48:51.203Z",
+              "endDate": "2022-01-13T23:59:59Z",
+              "category": "A",
+              "agencyCode": "Food Standards Agency (FSA)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "jyjyt",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "SR-219",
+              "warnings": "Warnings from testing",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "MAH gateway",
+              "indicatorMatches": [
+                {
+                  "entity": "Vehicle",
+                  "descriptor": "registrationNumber",
+                  "operator": "equal",
+                  "value": "ABC123"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+            },
+            {
+              "selectorId":225,
+              "selectorReference":"2022-225",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate":"2022-01-27T10:23:12.732Z",
+              "endDate":"2022-07-27T10:23:12.732Z",
+              "category":"A",
+              "agencyCode":"BF",
+              "intelligenceSource":"intel source",
+              "pointOfContact":"Point Of Contact Testing",
+              "pocMessage":"selector for auto testing",
+              "priority":"Selector",
+              "inboundActionCode":"No action required",
+              "outboundActionCode":"No action required",
+              "threatType":"National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver":"null",
+              "securityLabels":[
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference":"null",
+              "warnings":"Warnings from testing for group reference",
+              "requestingOfficer":"Tester",
+              "requestingTeam":"null",
+              "indicatorMatches":[
+                {
+                  "entity":"vehicle",
+                  "descriptor":"registrationNumber",
+                  "operator":"equal",
+                  "value":"DK-45678"
+                }
+              ],
+              "selectorMatchedOnDate":"2022-02-08T16:18:43.998Z"
+            },
+            {
+              "selectorId": 51,
+              "selectorReference": "2021-51",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate": "2021-07-09T13:42:48.381Z",
+              "endDate": "2021-08-20T22:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Tier 2",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "Henry Hamlet",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "Local Reference",
+              "warnings": "Supplemental warnings",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "RoRo accompanied",
+              "indicatorMatches": [
+                {
+                  "entity": "Organisation",
+                  "descriptor": "telephone",
+                  "operator": "equal",
+                  "value": "01234 56723737"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-09-05T09:30:02.896Z"
+            },
+            {
+              "selectorId":245,
+              "selectorReference":"2022-245",
+              "groupReference":"SR-227",
+              "groupVersionNumber":1,
+              "startDate":"2022-02-01T09:40:27.767Z",
+              "endDate":"2023-02-01T23:59:59Z",
+              "category":"C",
+              "agencyCode":"Borders and Aviation Security Unit Homeland Security Group (HSG)",
+              "intelligenceSource":"Qui adipisci consectetur ullam consequatur a aspernatur in",
+              "pointOfContact":"Dolores est qui laboriosam velit tenetur aut sit laborum Temporibus distinctio Aut hic non autem",
+              "pocMessage":"Blanditiis consectetur impedit omnis veniam veniam quibusdam ad eiusmod et consequatur fuga Fugiat nesciunt tenetur expedita aliquam",
+              "priority":"Selector",
+              "inboundActionCode":"Worthy of attention",
+              "outboundActionCode":"Monitor only",
+              "threatType":"Alcohol",
+              "notes":"notes",
+              "creator":"user",
+              "approver":"Ut adipisci culpa reiciendis dicta ullam vel duis laboriosam eiusmod",
+              "securityLabels":[
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference":"Quos ex reprehenderit dolor dolor at quia placeat fugiat qui voluptas non reiciendis voluptatum molestiae",
+              "warnings":"This is a different group reference",
+              "requestingOfficer":"Velit in sunt aliquip voluptate tempore consectetur",
+              "requestingTeam":"RoRo tourist",
+              "indicatorMatches":[
+                {
+                  "entity":"Person",
+                  "descriptor":"familyName",
+                  "operator":"equal",
+                  "value":"TURNER"
+                }
+              ],
+              "selectorMatchedOnDate":"2022-02-08T16:18:43.998Z"
+            }
+          ],
+          "movement": {
+            "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+            "firstCerberusTimestamp": 1626168602828,
+            "cerberusTimestamp": 1626168602828,
+            "latestMessageType": "ENRICH",
+            "messageAnalysis": {
+              "messageMatches": [
+                {
+                  "sourceMessageVersion": 1,
+                  "expectedMatches": 13,
+                  "countOfMatches": 0,
+                  "sourceMsgEnriches": 1
+                }
+              ],
+              "countOfSourceMessages": 1,
+              "countOfSnapshots": 0,
+              "countOfNoStateChanges": 0,
+              "countOfWashes": 0,
+              "countOfEnrichments": 1,
+              "firstRunlogTimestamp": 1626168602828,
+              "lastRunlogTimestamp": 1626168602828,
+              "firstSnapshotTimestamp": 0,
+              "lastSnapshotTimestamp": 0,
+              "firstNSCTimestamp": 0,
+              "lastNSCTimestamp": 0,
+              "firstWashTimestamp": 0,
+              "lastWashTimestamp": 0,
+              "firstEnrichTimestamp": 1626168602828,
+              "lastEnrichTimestamp": 1626168602828,
+              "matchesComplete": false,
+              "latestVersion": "1.0"
+            },
+            "serviceMovement": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=Test Message 10684"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "Test Message 10684",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Movement",
+                  "version": "1"
+                }
+              },
+              "type": "MOVEMENT",
+              "effectiveFromTimestamp": 1596459900000,
+              "effectiveToTimestamp": 1596548700000,
+              "dueTimestamp": null,
+              "status": null,
+              "movement": {
+                "type": "Pre-Arrival",
+                "businessIdentifier": "357485636-10684",
+                "mode": "RORO Accompanied Freight",
+                "source": "DFDS",
+                "actualDepartureTimestamp": 1596459900000
+              },
+              "attributes": {
+                "attrs": {
+                  "countryOfBooking": "GB",
+                  "ticketNumber": "1234567",
+                  "waybillNumber": "99990001",
+                  "method": "method",
+                  "adultCount": "001",
+                  "bookingDateTime": "2021-11-17T09:15:00",
+                  "descriptionOfCargo": "Printed Paper",
+                  "childCount": "0",
+                  "ticketType": "Return",
+                  "driverCount": "001",
+                  "reference": "357485636",
+                  "oapCount": "0",
+                  "checkInDateTime": "2021-08-03T12:05:00",
+                  "hazardousCargo": "false",
+                  "paymentMethod": "Cash",
+                  "infantCount": "0"
+                }
+              },
+              "features": {
+                "feats": {
+                  "SELECTORS-MATCHED-LIST": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "META:51|2021-51|2021-07-09T13:42:48.381Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:51|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
+                        "META:50|2021-50|2021-07-09T13:42:43.639Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:50|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
+                        "META:52|2021-52|2021-07-09T13:43:10.327Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|srg|B|No action required|No action required|greg|gregre|rgeger|Class B&C Drugs inc. Cannabis|grre|greger|gerger|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:52|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602896
+                  },
+                  "STANDARDISED:bookingDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-02T09:15Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "RORO-BOOKING-MOVEMENT-CO-TRAVELLERS": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "Bailey|Ben|M|4171|GB|OBJDOCPAS|ST0394612|18659|GB|PERPAS|ROROXML:P=79ebe735351bb31426478fa75c2d9f1f"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602839
+                  },
+                  "SELECTOR-MATCHED": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602896
+                  },
+                  "STANDARDISED:cashPaid": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:checkInDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-03T12:05Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:bookingIntentHours": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 27,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "persons": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "33f544d684db9e59150ae84406709122",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "PERSON",
+                "person": {
+                  "type": "PERTDRIVER",
+                  "title": null,
+                  "familyName": "Brown",
+                  "givenName": "Bob",
+                  "fullName": "Bob Brown",
+                  "dateOfBirth": 435,
+                  "dateOfDeath": null,
+                  "gender": "M",
+                  "nationality": "NL",
+                  "yearOfBirth": 1971,
+                  "monthOfBirth": 3,
+                  "dayOfBirth": 12,
+                  "countryOfBirth": null,
+                  "placeOfBirth": null,
+                  "ethnicity": null,
+                  "maritalStatus": null,
+                  "religion": null,
+                  "passportNumber": "244746NL"
+                },
+                "attributes": {
+                  "attrs": {
+                    "role": "DRIVER"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "organisations": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "01cf4601377f37392b1865e0ba8705d6",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGBOOKER",
+                  "name": "test",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "countryOfBooking": "GB",
+                    "reference": "357485636",
+                    "ticketPrice": "30 quid",
+                    "bookingType": "Test",
+                    "bookingDateTime": "2020-08-02T09:15:00",
+                    "CheckInDateTime": "2020-08-03T12:05:00",
+                    "paymentMethod": "Cash",
+                    "ticketType": "Return"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "805d8df7e346ed835e3d1ed91830b433",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGACCOUNT",
+                  "name": "Uni Print",
+                  "registrationNumber": "Test",
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "holderName": "Univeral Printers Ltd",
+                    "shortName": "short name",
+                    "accountNumber": "Test",
+                    "referenceNumber": "PO000359675"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0895a52dec8fa239341e4b25ddb43145",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGHAULIER",
+                  "name": "Matthesons",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "documents": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122,O=0c054324d71c36114b03ecd12e80b5c2"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0c054324d71c36114b03ecd12e80b5c2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Document",
+                    "version": "1"
+                  }
+                },
+                "type": "DOCUMENT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOOUSES",
+                "startTimestamp": 1596456420000,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "document": {
+                  "type": "OBJDOCPAS",
+                  "value": "244746NL",
+                  "subject": null,
+                  "category": "P",
+                  "status": null,
+                  "placeOfIssue": null,
+                  "countryOfIssue": "NL",
+                  "dateOfIssue": null,
+                  "validFromDate": null,
+                  "expiryDate": 18659
+                },
+                "attributes": {
+                  "attrs": {
+                    "documentType": "Passport"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vehicles": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=null[7f86ffada2c7f7981b3cfdf6c786073e],O=7f86ffada2c7f7981b3cfdf6c786073e"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "7f86ffada2c7f7981b3cfdf6c786073e",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Vehicle",
+                    "version": "1"
+                  }
+                },
+                "type": "VEHICLE",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[7f86ffada2c7f7981b3cfdf6c786073e]"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vehicle": {
+                  "type": "OBJVEHCTRL",
+                  "make": null,
+                  "model": null,
+                  "vin": null,
+                  "registrationNumber": "NL-234-392",
+                  "registrationCountry": null,
+                  "year": null,
+                  "colour": null,
+                  "markings": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "type": "TR",
+                    "sealNumber": "test",
+                    "role": "FREIGHT"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=null[33654c2386bd600f646d015a460c5be6],O=33654c2386bd600f646d015a460c5be6"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "33654c2386bd600f646d015a460c5be6",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Vehicle",
+                    "version": "1"
+                  }
+                },
+                "type": "VEHICLE",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[33654c2386bd600f646d015a460c5be6]"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vehicle": {
+                  "type": "OBJVEHC",
+                  "make": null,
+                  "model": "Discovery",
+                  "vin": null,
+                  "registrationNumber": "GB09KLT-10684",
+                  "registrationCountry": "GB",
+                  "year": null,
+                  "colour": null,
+                  "markings": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "length": "36",
+                    "netWeight": "3455",
+                    "grossWeight": "43623",
+                    "role": "FREIGHT",
+                    "statusOfLoading": "Empty",
+                    "height": "3.6"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vessel": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[4646ef69c498ad934f46bbb1f2cd161f],O=4646ef69c498ad934f46bbb1f2cd161f"
+                    },
+                    "v1": null
+                  },
+                  "type": "O"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "4646ef69c498ad934f46bbb1f2cd161f",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Object-Vessel",
+                  "version": "1"
+                }
+              },
+              "type": "VESSEL",
+              "party": {
+                "poleId": {
+                  "v2": {
+                    "id": "ROROXML:P=null[4646ef69c498ad934f46bbb1f2cd161f]"
+                  },
+                  "v1": null
+                },
+                "type": "P"
+              },
+              "role": "UNKNOWN",
+              "startTimestamp": null,
+              "endTimestamp": null,
+              "name": null,
+              "description": null,
+              "additionalInformation": null,
+              "url": null,
+              "vessel": {
+                "type": "OBJVESWTR",
+                "name": "DOVER SEAWAYS",
+                "operator": "DFDS",
+                "registrationNumber": null,
+                "registrationCountry": null,
+                "registrationPort": null,
+                "mmsi": null,
+                "imo": null,
+                "callSign": null
+              },
+              "attributes": null,
+              "matching": null,
+              "features": null,
+              "washResponses": null,
+              "matchMerge": null,
+              "changeHistory": null
+            },
+            "addresses": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433,L=21cb57f58c17fba29fc784f1ec5d71d1"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "21cb57f58c17fba29fc784f1ec5d71d1",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Address",
+                    "version": "1"
+                  }
+                },
+                "type": "ADDRESS",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLASSO",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "address": {
+                  "type": "LOCADDR",
+                  "postCode": "KJFSG094",
+                  "poBox": null,
+                  "fullAddress": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+                  "name": "Uni Print",
+                  "siteLocation": null,
+                  "number": null,
+                  "street": null,
+                  "town": "Bognor Regis",
+                  "area": null,
+                  "district": null,
+                  "county": null,
+                  "country": "GB",
+                  "uniquePropertyReferenceNumber": null,
+                  "latitude": null,
+                  "longitude": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "addressLine1": "Unit 9-12 Pinkerton Way"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "d4843a5da9a8086797c4da4f286d41e2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Address",
+                    "version": "1"
+                  }
+                },
+                "type": "ADDRESS",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLASSO",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "address": {
+                  "type": "LOCADDR",
+                  "postCode": "KJFSG094",
+                  "poBox": null,
+                  "fullAddress": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+                  "name": "Matthesons",
+                  "siteLocation": null,
+                  "number": null,
+                  "street": null,
+                  "town": "Bognor Regis",
+                  "area": null,
+                  "district": null,
+                  "county": null,
+                  "country": "GB",
+                  "uniquePropertyReferenceNumber": null,
+                  "latitude": null,
+                  "longitude": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "addressLine1": "Unit 9-12 Pinkerton Way"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "contacts": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433,L=adab2c3024f2dde53d68d5a7c6be20ba"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "adab2c3024f2dde53d68d5a7c6be20ba",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Contact",
+                    "version": "1"
+                  }
+                },
+                "type": "CONTACT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "ORGACCOUNT",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "contact": {
+                  "type": "LOCTEL",
+                  "value": "01234 56723737"
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145,L=d86e6214de4d8f74d8ecb8927dd49369"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "d86e6214de4d8f74d8ecb8927dd49369",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Contact",
+                    "version": "1"
+                  }
+                },
+                "type": "CONTACT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLUSES",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "contact": {
+                  "type": "LOCTELMOB",
+                  "value": "01243785239"
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "voyage": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=e6b8656baf167c24a68f25cf6e82b497"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "e6b8656baf167c24a68f25cf6e82b497",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Voyage",
+                  "version": "1"
+                }
+              },
+              "type": "VOYAGE",
+              "effectiveFromTimestamp": 1596459900000,
+              "effectiveToTimestamp": 1596548700000,
+              "dueTimestamp": null,
+              "status": null,
+              "voyage": {
+                "type": "COMMERCIAL",
+                "voyageType": "SEA",
+                "departureLocation": "DOV",
+                "departureCountry": null,
+                "scheduledDepartureTimestamp": 1637506150000,
+                "actualDepartureTimestamp": 1637506150000,
+                "arrivalLocation": "CAL",
+                "arrivalCountry": null,
+                "scheduledArrivalTimestamp": null,
+                "actualArrivalTimestamp": null,
+                "intermediateLocations": null,
+                "passengerCount": null,
+                "crewCount": null,
+                "durationMinutes": null,
+                "routeId": null,
+                "carrier": "DFDS",
+                "craftId": "DOVER SEAWAYS"
+              },
+              "attributes": {
+                "attrs": {
+                  "freightMovementCount": "001"
+                }
+              },
+              "features": {
+                "feats": {
+                  "STANDARDISED:arrivalPort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "FR CQF"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602834
+                  },
+                  "STANDARDISED:estimatedArrivalTimestamp": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 1596465300000,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:departurePort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "GB DVR"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602834
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "consolidation": null,
+            "consignments": null
+          }
+        }
+      }
+    },
+    "initiatedBy": {
+      "type": "String",
+      "value": "rbtEngine"
+    }
+  },
+  "businessKey": "CERB-ROROTSV:CMID=fe650bc1a0ffede048d0527c17d8dd16/c29399d06f3fcda4d0bced3fd302b468/8ee41bc78fab154e299f2c066e756e62/4bfa9f48dcf627f73a6754d3e21ace0c/e292892eec399204a63244a8d4712851"
+}

--- a/cypress/fixtures/tasks-with-rules-selectors/RoRo-task-selectors-v1-same-group-reference.json
+++ b/cypress/fixtures/tasks-with-rules-selectors/RoRo-task-selectors-v1-same-group-reference.json
@@ -1,0 +1,1397 @@
+{
+  "variables": {
+    "rbtPayload": {
+      "type": "Json",
+      "value": {
+        "data": {
+          "movementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+          "riskSubmissionId": 8550,
+          "riskCreatedDate": "2021-07-13T09:30:03.106021Z",
+          "riskType": "Pre-Arrival",
+          "matchedRules": [
+            {
+              "ruleId":535,
+              "ruleName":"Selector Matched Rule",
+              "ruleType":"Both",
+              "ruleVersion":1,
+              "ruleDescription":"Test",
+              "securityLabels":[
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 1",
+              "indicatorMatches":[
+                {
+                  "entity":"Message",
+                  "descriptor":"selectorsMatched",
+                  "operator":"equal",
+                  "value":"true"
+                },
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[Air Freight, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+                }
+              ],
+              "abuseTypes":[
+                "National Security at the Border"
+              ]
+            },
+            {
+              "ruleId":546,
+              "ruleName":"Paid by cash - perf rule",
+              "ruleType":"Pre-load",
+              "ruleVersion":1,
+              "ruleDescription":"Debitis esse volupt",
+              "securityLabels":[
+                "null",
+                "null",
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 2",
+              "indicatorMatches":[
+                {
+                  "entity":"Booking",
+                  "descriptor":"cashPaid",
+                  "operator":"equal",
+                  "value":"true"
+                },
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[RORO Accompanied Freight, RORO Tourist]"
+                }
+              ],
+              "abuseTypes":[
+                "Plant Health"
+              ]
+            },
+            {
+              "ruleId":556,
+              "ruleName":"Checkin lead time",
+              "ruleType":"Both",
+              "ruleVersion":1,
+              "ruleDescription":"Qui nesciunt suscip",
+              "securityLabels":[
+                "null",
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 4",
+              "indicatorMatches":[
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+                },
+                {
+                  "entity":"Booking",
+                  "descriptor":"checkInLeadTime",
+                  "operator":"between",
+                  "value":"[1, 24]"
+                }
+              ],
+              "abuseTypes":[
+                "Class A Drugs"
+              ]
+            }
+          ],
+          "matchedSelectors":[
+            {
+              "selectorId": 279,
+              "selectorReference": "2021-279",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate": "2021-12-08T08:23:40.257Z",
+              "endDate": "2022-01-19T23:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "bfbfdbf",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "SR-220",
+              "warnings": "bdfbdfbf",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "MAH gateway",
+              "indicatorMatches": [
+                {
+                  "entity": "Trailer",
+                  "descriptor": "registrationNumber",
+                  "operator": "equal",
+                  "value": "qwerty"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+            },
+            {
+              "selectorId": 278,
+              "selectorReference": "2021-278",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate": "2021-12-02T16:48:51.203Z",
+              "endDate": "2022-01-13T23:59:59Z",
+              "category": "A",
+              "agencyCode": "Food Standards Agency (FSA)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "jyjyt",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "SR-219",
+              "warnings": "Warnings from testing",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "MAH gateway",
+              "indicatorMatches": [
+                {
+                  "entity": "Vehicle",
+                  "descriptor": "registrationNumber",
+                  "operator": "equal",
+                  "value": "ABC123"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+            },
+            {
+              "selectorId":225,
+              "selectorReference":"2022-225",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate":"2022-01-27T10:23:12.732Z",
+              "endDate":"2022-07-27T10:23:12.732Z",
+              "category":"A",
+              "agencyCode":"BF",
+              "intelligenceSource":"intel source",
+              "pointOfContact":"Point Of Contact Testing",
+              "pocMessage":"selector for auto testing",
+              "priority":"Selector",
+              "inboundActionCode":"No action required",
+              "outboundActionCode":"No action required",
+              "threatType":"National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver":"null",
+              "securityLabels":[
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference":"null",
+              "warnings":"Warnings from testing for group reference",
+              "requestingOfficer":"Tester",
+              "requestingTeam":"null",
+              "indicatorMatches":[
+                {
+                  "entity":"vehicle",
+                  "descriptor":"registrationNumber",
+                  "operator":"equal",
+                  "value":"DK-45678"
+                }
+              ],
+              "selectorMatchedOnDate":"2022-02-08T16:18:43.998Z"
+            },
+            {
+              "selectorId": 51,
+              "selectorReference": "2021-51",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate": "2021-07-09T13:42:48.381Z",
+              "endDate": "2021-08-20T22:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Tier 2",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "Henry Hamlet",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "Local Reference",
+              "warnings": "Supplemental warnings",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "RoRo accompanied",
+              "indicatorMatches": [
+                {
+                  "entity": "Organisation",
+                  "descriptor": "telephone",
+                  "operator": "equal",
+                  "value": "01234 56723737"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-09-05T09:30:02.896Z"
+            }
+          ],
+          "movement": {
+            "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+            "firstCerberusTimestamp": 1626168602828,
+            "cerberusTimestamp": 1626168602828,
+            "latestMessageType": "ENRICH",
+            "messageAnalysis": {
+              "messageMatches": [
+                {
+                  "sourceMessageVersion": 1,
+                  "expectedMatches": 13,
+                  "countOfMatches": 0,
+                  "sourceMsgEnriches": 1
+                }
+              ],
+              "countOfSourceMessages": 1,
+              "countOfSnapshots": 0,
+              "countOfNoStateChanges": 0,
+              "countOfWashes": 0,
+              "countOfEnrichments": 1,
+              "firstRunlogTimestamp": 1626168602828,
+              "lastRunlogTimestamp": 1626168602828,
+              "firstSnapshotTimestamp": 0,
+              "lastSnapshotTimestamp": 0,
+              "firstNSCTimestamp": 0,
+              "lastNSCTimestamp": 0,
+              "firstWashTimestamp": 0,
+              "lastWashTimestamp": 0,
+              "firstEnrichTimestamp": 1626168602828,
+              "lastEnrichTimestamp": 1626168602828,
+              "matchesComplete": false,
+              "latestVersion": "1.0"
+            },
+            "serviceMovement": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=Test Message 10684"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "Test Message 10684",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Movement",
+                  "version": "1"
+                }
+              },
+              "type": "MOVEMENT",
+              "effectiveFromTimestamp": 1596459900000,
+              "effectiveToTimestamp": 1596548700000,
+              "dueTimestamp": null,
+              "status": null,
+              "movement": {
+                "type": "Pre-Arrival",
+                "businessIdentifier": "357485636-10684",
+                "mode": "RORO Accompanied Freight",
+                "source": "DFDS",
+                "actualDepartureTimestamp": 1596459900000
+              },
+              "attributes": {
+                "attrs": {
+                  "countryOfBooking": "GB",
+                  "ticketNumber": "1234567",
+                  "waybillNumber": "99990001",
+                  "method": "method",
+                  "adultCount": "001",
+                  "bookingDateTime": "2021-11-17T09:15:00",
+                  "descriptionOfCargo": "Printed Paper",
+                  "childCount": "0",
+                  "ticketType": "Return",
+                  "driverCount": "001",
+                  "reference": "357485636",
+                  "oapCount": "0",
+                  "checkInDateTime": "2021-08-03T12:05:00",
+                  "hazardousCargo": "false",
+                  "paymentMethod": "Cash",
+                  "infantCount": "0"
+                }
+              },
+              "features": {
+                "feats": {
+                  "SELECTORS-MATCHED-LIST": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "META:51|2021-51|2021-07-09T13:42:48.381Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:51|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
+                        "META:50|2021-50|2021-07-09T13:42:43.639Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:50|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
+                        "META:52|2021-52|2021-07-09T13:43:10.327Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|srg|B|No action required|No action required|greg|gregre|rgeger|Class B&C Drugs inc. Cannabis|grre|greger|gerger|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:52|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602896
+                  },
+                  "STANDARDISED:bookingDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-02T09:15Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "RORO-BOOKING-MOVEMENT-CO-TRAVELLERS": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "Bailey|Ben|M|4171|GB|OBJDOCPAS|ST0394612|18659|GB|PERPAS|ROROXML:P=79ebe735351bb31426478fa75c2d9f1f"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602839
+                  },
+                  "SELECTOR-MATCHED": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602896
+                  },
+                  "STANDARDISED:cashPaid": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:checkInDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-03T12:05Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:bookingIntentHours": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 27,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "persons": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "33f544d684db9e59150ae84406709122",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "PERSON",
+                "person": {
+                  "type": "PERTDRIVER",
+                  "title": null,
+                  "familyName": "Brown",
+                  "givenName": "Bob",
+                  "fullName": "Bob Brown",
+                  "dateOfBirth": 435,
+                  "dateOfDeath": null,
+                  "gender": "M",
+                  "nationality": "NL",
+                  "yearOfBirth": 1971,
+                  "monthOfBirth": 3,
+                  "dayOfBirth": 12,
+                  "countryOfBirth": null,
+                  "placeOfBirth": null,
+                  "ethnicity": null,
+                  "maritalStatus": null,
+                  "religion": null,
+                  "passportNumber": "244746NL"
+                },
+                "attributes": {
+                  "attrs": {
+                    "role": "DRIVER"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "organisations": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "01cf4601377f37392b1865e0ba8705d6",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGBOOKER",
+                  "name": "test",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "countryOfBooking": "GB",
+                    "reference": "357485636",
+                    "ticketPrice": "30 quid",
+                    "bookingType": "Test",
+                    "bookingDateTime": "2020-08-02T09:15:00",
+                    "CheckInDateTime": "2020-08-03T12:05:00",
+                    "paymentMethod": "Cash",
+                    "ticketType": "Return"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "805d8df7e346ed835e3d1ed91830b433",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGACCOUNT",
+                  "name": "Uni Print",
+                  "registrationNumber": "Test",
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "holderName": "Univeral Printers Ltd",
+                    "shortName": "short name",
+                    "accountNumber": "Test",
+                    "referenceNumber": "PO000359675"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0895a52dec8fa239341e4b25ddb43145",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGHAULIER",
+                  "name": "Matthesons",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "documents": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122,O=0c054324d71c36114b03ecd12e80b5c2"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0c054324d71c36114b03ecd12e80b5c2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Document",
+                    "version": "1"
+                  }
+                },
+                "type": "DOCUMENT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOOUSES",
+                "startTimestamp": 1596456420000,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "document": {
+                  "type": "OBJDOCPAS",
+                  "value": "244746NL",
+                  "subject": null,
+                  "category": "P",
+                  "status": null,
+                  "placeOfIssue": null,
+                  "countryOfIssue": "NL",
+                  "dateOfIssue": null,
+                  "validFromDate": null,
+                  "expiryDate": 18659
+                },
+                "attributes": {
+                  "attrs": {
+                    "documentType": "Passport"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vehicles": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=null[7f86ffada2c7f7981b3cfdf6c786073e],O=7f86ffada2c7f7981b3cfdf6c786073e"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "7f86ffada2c7f7981b3cfdf6c786073e",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Vehicle",
+                    "version": "1"
+                  }
+                },
+                "type": "VEHICLE",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[7f86ffada2c7f7981b3cfdf6c786073e]"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vehicle": {
+                  "type": "OBJVEHCTRL",
+                  "make": null,
+                  "model": null,
+                  "vin": null,
+                  "registrationNumber": "NL-234-392",
+                  "registrationCountry": null,
+                  "year": null,
+                  "colour": null,
+                  "markings": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "type": "TR",
+                    "sealNumber": "test",
+                    "role": "FREIGHT"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=null[33654c2386bd600f646d015a460c5be6],O=33654c2386bd600f646d015a460c5be6"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "33654c2386bd600f646d015a460c5be6",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Vehicle",
+                    "version": "1"
+                  }
+                },
+                "type": "VEHICLE",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[33654c2386bd600f646d015a460c5be6]"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vehicle": {
+                  "type": "OBJVEHC",
+                  "make": null,
+                  "model": "Discovery",
+                  "vin": null,
+                  "registrationNumber": "GB09KLT-10684",
+                  "registrationCountry": "GB",
+                  "year": null,
+                  "colour": null,
+                  "markings": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "length": "36",
+                    "netWeight": "3455",
+                    "grossWeight": "43623",
+                    "role": "FREIGHT",
+                    "statusOfLoading": "Empty",
+                    "height": "3.6"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vessel": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[4646ef69c498ad934f46bbb1f2cd161f],O=4646ef69c498ad934f46bbb1f2cd161f"
+                    },
+                    "v1": null
+                  },
+                  "type": "O"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "4646ef69c498ad934f46bbb1f2cd161f",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Object-Vessel",
+                  "version": "1"
+                }
+              },
+              "type": "VESSEL",
+              "party": {
+                "poleId": {
+                  "v2": {
+                    "id": "ROROXML:P=null[4646ef69c498ad934f46bbb1f2cd161f]"
+                  },
+                  "v1": null
+                },
+                "type": "P"
+              },
+              "role": "UNKNOWN",
+              "startTimestamp": null,
+              "endTimestamp": null,
+              "name": null,
+              "description": null,
+              "additionalInformation": null,
+              "url": null,
+              "vessel": {
+                "type": "OBJVESWTR",
+                "name": "DOVER SEAWAYS",
+                "operator": "DFDS",
+                "registrationNumber": null,
+                "registrationCountry": null,
+                "registrationPort": null,
+                "mmsi": null,
+                "imo": null,
+                "callSign": null
+              },
+              "attributes": null,
+              "matching": null,
+              "features": null,
+              "washResponses": null,
+              "matchMerge": null,
+              "changeHistory": null
+            },
+            "addresses": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433,L=21cb57f58c17fba29fc784f1ec5d71d1"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "21cb57f58c17fba29fc784f1ec5d71d1",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Address",
+                    "version": "1"
+                  }
+                },
+                "type": "ADDRESS",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLASSO",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "address": {
+                  "type": "LOCADDR",
+                  "postCode": "KJFSG094",
+                  "poBox": null,
+                  "fullAddress": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+                  "name": "Uni Print",
+                  "siteLocation": null,
+                  "number": null,
+                  "street": null,
+                  "town": "Bognor Regis",
+                  "area": null,
+                  "district": null,
+                  "county": null,
+                  "country": "GB",
+                  "uniquePropertyReferenceNumber": null,
+                  "latitude": null,
+                  "longitude": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "addressLine1": "Unit 9-12 Pinkerton Way"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "d4843a5da9a8086797c4da4f286d41e2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Address",
+                    "version": "1"
+                  }
+                },
+                "type": "ADDRESS",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLASSO",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "address": {
+                  "type": "LOCADDR",
+                  "postCode": "KJFSG094",
+                  "poBox": null,
+                  "fullAddress": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+                  "name": "Matthesons",
+                  "siteLocation": null,
+                  "number": null,
+                  "street": null,
+                  "town": "Bognor Regis",
+                  "area": null,
+                  "district": null,
+                  "county": null,
+                  "country": "GB",
+                  "uniquePropertyReferenceNumber": null,
+                  "latitude": null,
+                  "longitude": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "addressLine1": "Unit 9-12 Pinkerton Way"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "contacts": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433,L=adab2c3024f2dde53d68d5a7c6be20ba"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "adab2c3024f2dde53d68d5a7c6be20ba",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Contact",
+                    "version": "1"
+                  }
+                },
+                "type": "CONTACT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "ORGACCOUNT",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "contact": {
+                  "type": "LOCTEL",
+                  "value": "01234 56723737"
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145,L=d86e6214de4d8f74d8ecb8927dd49369"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "d86e6214de4d8f74d8ecb8927dd49369",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Contact",
+                    "version": "1"
+                  }
+                },
+                "type": "CONTACT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLUSES",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "contact": {
+                  "type": "LOCTELMOB",
+                  "value": "01243785239"
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "voyage": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=e6b8656baf167c24a68f25cf6e82b497"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "e6b8656baf167c24a68f25cf6e82b497",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Voyage",
+                  "version": "1"
+                }
+              },
+              "type": "VOYAGE",
+              "effectiveFromTimestamp": 1596459900000,
+              "effectiveToTimestamp": 1596548700000,
+              "dueTimestamp": null,
+              "status": null,
+              "voyage": {
+                "type": "COMMERCIAL",
+                "voyageType": "SEA",
+                "departureLocation": "DOV",
+                "departureCountry": null,
+                "scheduledDepartureTimestamp": 1637506150000,
+                "actualDepartureTimestamp": 1637506150000,
+                "arrivalLocation": "CAL",
+                "arrivalCountry": null,
+                "scheduledArrivalTimestamp": null,
+                "actualArrivalTimestamp": null,
+                "intermediateLocations": null,
+                "passengerCount": null,
+                "crewCount": null,
+                "durationMinutes": null,
+                "routeId": null,
+                "carrier": "DFDS",
+                "craftId": "DOVER SEAWAYS"
+              },
+              "attributes": {
+                "attrs": {
+                  "freightMovementCount": "001"
+                }
+              },
+              "features": {
+                "feats": {
+                  "STANDARDISED:arrivalPort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "FR CQF"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602834
+                  },
+                  "STANDARDISED:estimatedArrivalTimestamp": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 1596465300000,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:departurePort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "GB DVR"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602834
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "consolidation": null,
+            "consignments": null
+          }
+        }
+      }
+    },
+    "initiatedBy": {
+      "type": "String",
+      "value": "rbtEngine"
+    }
+  },
+  "businessKey": "CERB-ROROTSV:CMID=fe650bc1a0ffede048d0527c17d8dd16/c29399d06f3fcda4d0bced3fd302b468/8ee41bc78fab154e299f2c066e756e62/4bfa9f48dcf627f73a6754d3e21ace0c/e292892eec399204a63244a8d4712851"
+}

--- a/cypress/fixtures/tasks-with-rules-selectors/RoRo-task-selectors-v2-diff-group-reference.json
+++ b/cypress/fixtures/tasks-with-rules-selectors/RoRo-task-selectors-v2-diff-group-reference.json
@@ -1,0 +1,1433 @@
+{
+  "variables": {
+    "rbtPayload": {
+      "type": "Json",
+      "value": {
+        "data": {
+          "movementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+          "riskSubmissionId": 8550,
+          "riskCreatedDate": "2021-07-13T09:30:03.106021Z",
+          "riskType": "Pre-Arrival",
+          "matchedRules": [
+            {
+              "ruleId":535,
+              "ruleName":"Selector Matched Rule",
+              "ruleType":"Both",
+              "ruleVersion":1,
+              "ruleDescription":"Test",
+              "securityLabels":[
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 1",
+              "indicatorMatches":[
+                {
+                  "entity":"Message",
+                  "descriptor":"selectorsMatched",
+                  "operator":"equal",
+                  "value":"true"
+                },
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[Air Freight, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+                }
+              ],
+              "abuseTypes":[
+                "National Security at the Border"
+              ]
+            },
+            {
+              "ruleId":546,
+              "ruleName":"Paid by cash - perf rule",
+              "ruleType":"Pre-load",
+              "ruleVersion":1,
+              "ruleDescription":"Debitis esse volupt",
+              "securityLabels":[
+                "null",
+                "null",
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 2",
+              "indicatorMatches":[
+                {
+                  "entity":"Booking",
+                  "descriptor":"cashPaid",
+                  "operator":"equal",
+                  "value":"true"
+                },
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[RORO Accompanied Freight, RORO Tourist]"
+                }
+              ],
+              "abuseTypes":[
+                "Plant Health"
+              ]
+            },
+            {
+              "ruleId":556,
+              "ruleName":"Checkin lead time",
+              "ruleType":"Both",
+              "ruleVersion":1,
+              "ruleDescription":"Qui nesciunt suscip",
+              "securityLabels":[
+                "null",
+                "null",
+                "null",
+                "null"
+              ],
+              "ruleMatchedOnDate":"2022-02-11T11:56:02Z",
+              "rulePriority":"Tier 4",
+              "indicatorMatches":[
+                {
+                  "entity":"Message",
+                  "descriptor":"mode",
+                  "operator":"in",
+                  "value":"[RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+                },
+                {
+                  "entity":"Booking",
+                  "descriptor":"checkInLeadTime",
+                  "operator":"between",
+                  "value":"[1, 24]"
+                }
+              ],
+              "abuseTypes":[
+                "Class A Drugs"
+              ]
+            }
+          ],
+          "matchedSelectors":[
+            {
+              "selectorId": 279,
+              "selectorReference": "2021-279",
+              "groupReference":"SR-215",
+              "groupVersionNumber":1,
+              "startDate": "2021-12-08T08:23:40.257Z",
+              "endDate": "2022-01-19T23:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "bfbfdbf",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "SR-220",
+              "warnings": "bdfbdfbf",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "MAH gateway",
+              "indicatorMatches": [
+                {
+                  "entity": "Trailer",
+                  "descriptor": "registrationNumber",
+                  "operator": "equal",
+                  "value": "qwerty"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+            },
+            {
+              "selectorId": 278,
+              "selectorReference": "2021-278",
+              "groupReference":"SR-216",
+              "groupVersionNumber":1,
+              "startDate": "2021-12-02T16:48:51.203Z",
+              "endDate": "2022-01-13T23:59:59Z",
+              "category": "A",
+              "agencyCode": "Food Standards Agency (FSA)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Selector",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "jyjyt",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "SR-219",
+              "warnings": "Warnings from testing",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "MAH gateway",
+              "indicatorMatches": [
+                {
+                  "entity": "Vehicle",
+                  "descriptor": "registrationNumber",
+                  "operator": "equal",
+                  "value": "ABC123"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+            },
+            {
+              "selectorId":225,
+              "selectorReference":"2022-100",
+              "groupReference":"SR-217",
+              "groupVersionNumber":1,
+              "startDate":"2022-01-27T10:23:12.732Z",
+              "endDate":"2022-07-27T10:23:12.732Z",
+              "category":"A",
+              "agencyCode":"BF",
+              "intelligenceSource":"intel source",
+              "pointOfContact":"Point Of Contact Testing",
+              "pocMessage":"selector for auto testing",
+              "priority":"Selector",
+              "inboundActionCode":"No action required",
+              "outboundActionCode":"No action required",
+              "threatType":"National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver":"null",
+              "securityLabels":[
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference":"null",
+              "warnings":"Warnings from testing for group reference",
+              "requestingOfficer":"Tester",
+              "requestingTeam":"null",
+              "indicatorMatches":[
+                {
+                  "entity":"vehicle",
+                  "descriptor":"registrationNumber",
+                  "operator":"equal",
+                  "value":"DK-45678"
+                }
+              ],
+              "selectorMatchedOnDate":"2022-02-08T16:18:43.998Z"
+            },
+            {
+              "selectorId": 51,
+              "selectorReference": "2021-10",
+              "groupReference":"SR-218",
+              "groupVersionNumber":1,
+              "startDate": "2021-07-09T13:42:48.381Z",
+              "endDate": "2021-08-20T22:59:59Z",
+              "category": "A",
+              "agencyCode": "Counter Terrorism Police (CTP)",
+              "intelligenceSource": "intel source",
+              "pointOfContact": "Point Of Contact Testing",
+              "pocMessage": "selector for auto testing",
+              "priority": "Tier 2",
+              "inboundActionCode": "No action required",
+              "outboundActionCode": "No action required",
+              "threatType": "National Security at the Border",
+              "notes": "notes testing",
+              "creator": "test user",
+              "approver": "Henry Hamlet",
+              "securityLabels": [
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference": "Local Reference",
+              "warnings": "Supplemental warnings",
+              "requestingOfficer": "Tester",
+              "requestingTeam": "RoRo accompanied",
+              "indicatorMatches": [
+                {
+                  "entity": "Organisation",
+                  "descriptor": "telephone",
+                  "operator": "equal",
+                  "value": "01234 56723737"
+                },
+                {
+                  "entity": "Message",
+                  "descriptor": "mode",
+                  "operator": "in",
+                  "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                }
+              ],
+              "selectorMatchedOnDate": "2021-09-05T09:30:02.896Z"
+            },
+            {
+              "selectorId":245,
+              "selectorReference":"2022-245",
+              "groupReference":"SR-227",
+              "groupVersionNumber":1,
+              "startDate":"2022-02-01T09:40:27.767Z",
+              "endDate":"2023-02-01T23:59:59Z",
+              "category":"C",
+              "agencyCode":"Borders and Aviation Security Unit Homeland Security Group (HSG)",
+              "intelligenceSource":"Qui adipisci consectetur ullam consequatur a aspernatur in",
+              "pointOfContact":"Dolores est qui laboriosam velit tenetur aut sit laborum Temporibus distinctio Aut hic non autem",
+              "pocMessage":"Blanditiis consectetur impedit omnis veniam veniam quibusdam ad eiusmod et consequatur fuga Fugiat nesciunt tenetur expedita aliquam",
+              "priority":"Selector",
+              "inboundActionCode":"Worthy of attention",
+              "outboundActionCode":"Monitor only",
+              "threatType":"Alcohol",
+              "notes":"notes",
+              "creator":"user",
+              "approver":"Ut adipisci culpa reiciendis dicta ullam vel duis laboriosam eiusmod",
+              "securityLabels":[
+                "DATA_RISK_PREARRIVAL"
+              ],
+              "localReference":"Quos ex reprehenderit dolor dolor at quia placeat fugiat qui voluptas non reiciendis voluptatum molestiae",
+              "warnings":"This is a different group reference",
+              "requestingOfficer":"Velit in sunt aliquip voluptate tempore consectetur",
+              "requestingTeam":"RoRo tourist",
+              "indicatorMatches":[
+                {
+                  "entity":"Person",
+                  "descriptor":"familyName",
+                  "operator":"equal",
+                  "value":"TURNER"
+                }
+              ],
+              "selectorMatchedOnDate":"2022-02-08T16:18:43.998Z"
+            }
+          ],
+          "movement": {
+            "cerberusMovementId": "ROROXML:CMID=5cab661edbc124203d7c148bec9eb092/608999ce5bb3091a6361e30e84c71948/2f9a5d455992ca1932cd818be3a74d5c",
+            "firstCerberusTimestamp": 1626168602828,
+            "cerberusTimestamp": 1626168602828,
+            "latestMessageType": "ENRICH",
+            "messageAnalysis": {
+              "messageMatches": [
+                {
+                  "sourceMessageVersion": 1,
+                  "expectedMatches": 13,
+                  "countOfMatches": 0,
+                  "sourceMsgEnriches": 1
+                }
+              ],
+              "countOfSourceMessages": 1,
+              "countOfSnapshots": 0,
+              "countOfNoStateChanges": 0,
+              "countOfWashes": 0,
+              "countOfEnrichments": 1,
+              "firstRunlogTimestamp": 1626168602828,
+              "lastRunlogTimestamp": 1626168602828,
+              "firstSnapshotTimestamp": 0,
+              "lastSnapshotTimestamp": 0,
+              "firstNSCTimestamp": 0,
+              "lastNSCTimestamp": 0,
+              "firstWashTimestamp": 0,
+              "lastWashTimestamp": 0,
+              "firstEnrichTimestamp": 1626168602828,
+              "lastEnrichTimestamp": 1626168602828,
+              "matchesComplete": false,
+              "latestVersion": "1.0"
+            },
+            "serviceMovement": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=Test Message 10684"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "Test Message 10684",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Movement",
+                  "version": "1"
+                }
+              },
+              "type": "MOVEMENT",
+              "effectiveFromTimestamp": 1596459900000,
+              "effectiveToTimestamp": 1596548700000,
+              "dueTimestamp": null,
+              "status": null,
+              "movement": {
+                "type": "Pre-Arrival",
+                "businessIdentifier": "357485636-10684",
+                "mode": "RORO Accompanied Freight",
+                "source": "DFDS",
+                "actualDepartureTimestamp": 1596459900000
+              },
+              "attributes": {
+                "attrs": {
+                  "countryOfBooking": "GB",
+                  "ticketNumber": "1234567",
+                  "waybillNumber": "99990001",
+                  "method": "method",
+                  "adultCount": "001",
+                  "bookingDateTime": "2021-11-17T09:15:00",
+                  "descriptionOfCargo": "Printed Paper",
+                  "childCount": "0",
+                  "ticketType": "Return",
+                  "driverCount": "001",
+                  "reference": "357485636",
+                  "oapCount": "0",
+                  "checkInDateTime": "2021-08-03T12:05:00",
+                  "hazardousCargo": "false",
+                  "paymentMethod": "Cash",
+                  "infantCount": "0"
+                }
+              },
+              "features": {
+                "feats": {
+                  "SELECTORS-MATCHED-LIST": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "META:51|2021-51|2021-07-09T13:42:48.381Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:51|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
+                        "META:50|2021-50|2021-07-09T13:42:43.639Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|bffg|B|No action required|No action required|hrth|hthtr|rtht|Class B&C Drugs inc. Cannabis|ffhtr|htrthr|hthtr|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:50|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight",
+                        "META:52|2021-52|2021-07-09T13:43:10.327Z|2021-08-20T22:59:59Z|Counter Terrorism Police (CTP)|BFNIH|srg|B|No action required|No action required|greg|gregre|rgeger|Class B&C Drugs inc. Cannabis|grre|greger|gerger|notes|user|Selector|DATA_RISK_PREARRIVAL",
+                        "INDICATORS:52|Organisation|telephone|equal|01234 56723737¬Message|mode|in|RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602896
+                  },
+                  "STANDARDISED:bookingDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-02T09:15Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "RORO-BOOKING-MOVEMENT-CO-TRAVELLERS": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        "Bailey|Ben|M|4171|GB|OBJDOCPAS|ST0394612|18659|GB|PERPAS|ROROXML:P=79ebe735351bb31426478fa75c2d9f1f"
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602839
+                  },
+                  "SELECTOR-MATCHED": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602896
+                  },
+                  "STANDARDISED:cashPaid": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "BOOL",
+                    "value": true,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:checkInDateTime": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "STRING",
+                    "value": "2020-08-03T12:05Z",
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:bookingIntentHours": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 27,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "persons": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "33f544d684db9e59150ae84406709122",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "PERSON",
+                "person": {
+                  "type": "PERTDRIVER",
+                  "title": null,
+                  "familyName": "Brown",
+                  "givenName": "Paddington",
+                  "fullName": "Paddington Brown",
+                  "dateOfBirth": 435,
+                  "dateOfDeath": null,
+                  "gender": "M",
+                  "nationality": "NL",
+                  "yearOfBirth": 1971,
+                  "monthOfBirth": 3,
+                  "dayOfBirth": 12,
+                  "countryOfBirth": null,
+                  "placeOfBirth": null,
+                  "ethnicity": null,
+                  "maritalStatus": null,
+                  "religion": null,
+                  "passportNumber": "255746NL"
+                },
+                "attributes": {
+                  "attrs": {
+                    "role": "DRIVER"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "organisations": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "01cf4601377f37392b1865e0ba8705d6",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGBOOKER",
+                  "name": "test",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "countryOfBooking": "GB",
+                    "reference": "357485636",
+                    "ticketPrice": "30 quid",
+                    "bookingType": "Test",
+                    "bookingDateTime": "2020-08-02T09:15:00",
+                    "CheckInDateTime": "2020-08-03T12:05:00",
+                    "paymentMethod": "Cash",
+                    "ticketType": "Return"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "805d8df7e346ed835e3d1ed91830b433",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGACCOUNT",
+                  "name": "Uni Print",
+                  "registrationNumber": "Test",
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "holderName": "Univeral Printers Ltd",
+                    "shortName": "short name",
+                    "accountNumber": "Test",
+                    "referenceNumber": "PO000359675"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145"
+                      },
+                      "v1": null
+                    },
+                    "type": "P"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0895a52dec8fa239341e4b25ddb43145",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Party",
+                    "version": "1"
+                  }
+                },
+                "type": "ORGANISATION",
+                "organisation": {
+                  "type": "ORGHAULIER",
+                  "name": "Matthesons",
+                  "registrationNumber": null,
+                  "vatNumber": null,
+                  "industrySector": null,
+                  "numberOfEmployees": null
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "documents": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=33f544d684db9e59150ae84406709122,O=0c054324d71c36114b03ecd12e80b5c2"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "0c054324d71c36114b03ecd12e80b5c2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Document",
+                    "version": "1"
+                  }
+                },
+                "type": "DOCUMENT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=33f544d684db9e59150ae84406709122"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOOUSES",
+                "startTimestamp": 1596456420000,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "document": {
+                  "type": "OBJDOCPAS",
+                  "value": "244746NL",
+                  "subject": null,
+                  "category": "P",
+                  "status": null,
+                  "placeOfIssue": null,
+                  "countryOfIssue": "NL",
+                  "dateOfIssue": null,
+                  "validFromDate": null,
+                  "expiryDate": 18659
+                },
+                "attributes": {
+                  "attrs": {
+                    "documentType": "Passport"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vehicles": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=null[7f86ffada2c7f7981b3cfdf6c786073e],O=7f86ffada2c7f7981b3cfdf6c786073e"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "7f86ffada2c7f7981b3cfdf6c786073e",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Vehicle",
+                    "version": "1"
+                  }
+                },
+                "type": "VEHICLE",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[7f86ffada2c7f7981b3cfdf6c786073e]"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vehicle": {
+                  "type": "OBJVEHCTRL",
+                  "make": null,
+                  "model": null,
+                  "vin": null,
+                  "registrationNumber": "NL-234-392",
+                  "registrationCountry": null,
+                  "year": null,
+                  "colour": null,
+                  "markings": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "type": "TR",
+                    "sealNumber": "test",
+                    "role": "FREIGHT"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=null[33654c2386bd600f646d015a460c5be6],O=33654c2386bd600f646d015a460c5be6"
+                      },
+                      "v1": null
+                    },
+                    "type": "O"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "33654c2386bd600f646d015a460c5be6",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Object-Vehicle",
+                    "version": "1"
+                  }
+                },
+                "type": "VEHICLE",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[33654c2386bd600f646d015a460c5be6]"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vehicle": {
+                  "type": "OBJVEHC",
+                  "make": null,
+                  "model": "Discovery",
+                  "vin": null,
+                  "registrationNumber": "GB09KLT-10684",
+                  "registrationCountry": "GB",
+                  "year": null,
+                  "colour": null,
+                  "markings": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "length": "36",
+                    "netWeight": "3455",
+                    "grossWeight": "43623",
+                    "role": "FREIGHT",
+                    "statusOfLoading": "Empty",
+                    "height": "3.6"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "vessel": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=null[4646ef69c498ad934f46bbb1f2cd161f],O=4646ef69c498ad934f46bbb1f2cd161f"
+                    },
+                    "v1": null
+                  },
+                  "type": "O"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "4646ef69c498ad934f46bbb1f2cd161f",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Object-Vessel",
+                  "version": "1"
+                }
+              },
+              "type": "VESSEL",
+              "party": {
+                "poleId": {
+                  "v2": {
+                    "id": "ROROXML:P=null[4646ef69c498ad934f46bbb1f2cd161f]"
+                  },
+                  "v1": null
+                },
+                "type": "P"
+              },
+              "role": "UNKNOWN",
+              "startTimestamp": null,
+              "endTimestamp": null,
+              "name": null,
+              "description": null,
+              "additionalInformation": null,
+              "url": null,
+              "vessel": {
+                "type": "OBJVESWTR",
+                "name": "DOVER SEAWAYS",
+                "operator": "DFDS",
+                "registrationNumber": null,
+                "registrationCountry": null,
+                "registrationPort": null,
+                "mmsi": null,
+                "imo": null,
+                "callSign": null
+              },
+              "attributes": null,
+              "matching": null,
+              "features": null,
+              "washResponses": null,
+              "matchMerge": null,
+              "changeHistory": null
+            },
+            "addresses": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433,L=21cb57f58c17fba29fc784f1ec5d71d1"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "21cb57f58c17fba29fc784f1ec5d71d1",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Address",
+                    "version": "1"
+                  }
+                },
+                "type": "ADDRESS",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLASSO",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "address": {
+                  "type": "LOCADDR",
+                  "postCode": "KJFSG094",
+                  "poBox": null,
+                  "fullAddress": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+                  "name": "Uni Print",
+                  "siteLocation": null,
+                  "number": null,
+                  "street": null,
+                  "town": "Bognor Regis",
+                  "area": null,
+                  "district": null,
+                  "county": null,
+                  "country": "GB",
+                  "uniquePropertyReferenceNumber": null,
+                  "latitude": null,
+                  "longitude": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "addressLine1": "Unit 9-12 Pinkerton Way"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "d4843a5da9a8086797c4da4f286d41e2",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Address",
+                    "version": "1"
+                  }
+                },
+                "type": "ADDRESS",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=01cf4601377f37392b1865e0ba8705d6"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLASSO",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "address": {
+                  "type": "LOCADDR",
+                  "postCode": "KJFSG094",
+                  "poBox": null,
+                  "fullAddress": "Unit 9-12 Pinkerton Way Bognor Regis KJFSG094 GB",
+                  "name": "Matthesons",
+                  "siteLocation": null,
+                  "number": null,
+                  "street": null,
+                  "town": "Bognor Regis",
+                  "area": null,
+                  "district": null,
+                  "county": null,
+                  "country": "GB",
+                  "uniquePropertyReferenceNumber": null,
+                  "latitude": null,
+                  "longitude": null
+                },
+                "attributes": {
+                  "attrs": {
+                    "addressLine1": "Unit 9-12 Pinkerton Way"
+                  }
+                },
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "contacts": [
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433,L=adab2c3024f2dde53d68d5a7c6be20ba"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "adab2c3024f2dde53d68d5a7c6be20ba",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Contact",
+                    "version": "1"
+                  }
+                },
+                "type": "CONTACT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=805d8df7e346ed835e3d1ed91830b433"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "ORGACCOUNT",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "contact": {
+                  "type": "LOCTEL",
+                  "value": "01234 56723737"
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              },
+              {
+                "metadata": {
+                  "identityRecord": {
+                    "poleId": {
+                      "v2": {
+                        "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145,L=d86e6214de4d8f74d8ecb8927dd49369"
+                      },
+                      "v1": null
+                    },
+                    "type": "L"
+                  },
+                  "sourceRecord": {
+                    "name": "ROROXML",
+                    "shortName": "ROX",
+                    "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                    "id": "d86e6214de4d8f74d8ecb8927dd49369",
+                    "audit": {
+                      "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                      "createdTimestamp": 1596456420000,
+                      "updatedBy": null,
+                      "updatedTimestamp": null,
+                      "deletedBy": null,
+                      "deletedTimestamp": null
+                    }
+                  },
+                  "complianceRecord": {
+                    "visibility": "UNKNOWN",
+                    "gscMarker": null,
+                    "retentionMarkerDays": -1
+                  },
+                  "mappingRecord": {
+                    "name": "RR-XML-Location-Contact",
+                    "version": "1"
+                  }
+                },
+                "type": "CONTACT",
+                "party": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:P=0895a52dec8fa239341e4b25ddb43145"
+                    },
+                    "v1": null
+                  },
+                  "type": "P"
+                },
+                "role": "PTOLUSES",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "contact": {
+                  "type": "LOCTELMOB",
+                  "value": "01243785239"
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+              }
+            ],
+            "voyage": {
+              "metadata": {
+                "identityRecord": {
+                  "poleId": {
+                    "v2": {
+                      "id": "ROROXML:S=e6b8656baf167c24a68f25cf6e82b497"
+                    },
+                    "v1": null
+                  },
+                  "type": "S"
+                },
+                "sourceRecord": {
+                  "name": "ROROXML",
+                  "shortName": "ROX",
+                  "location": "archive/GroupId=none/CollectionDate=2020-10-28/DataFeedId=5/DataFeedTaskId=1650552/CERBERUS_XML_3a_roroxml_freight_DFDS_v02",
+                  "id": "e6b8656baf167c24a68f25cf6e82b497",
+                  "audit": {
+                    "createdBy": "+Z9FHV/6VAaBmp/LrXLTnQ==",
+                    "createdTimestamp": 1596456420000,
+                    "updatedBy": null,
+                    "updatedTimestamp": null,
+                    "deletedBy": null,
+                    "deletedTimestamp": null
+                  }
+                },
+                "complianceRecord": {
+                  "visibility": "UNKNOWN",
+                  "gscMarker": null,
+                  "retentionMarkerDays": -1
+                },
+                "mappingRecord": {
+                  "name": "RR-XML-Service-Voyage",
+                  "version": "1"
+                }
+              },
+              "type": "VOYAGE",
+              "effectiveFromTimestamp": 1596459900000,
+              "effectiveToTimestamp": 1596548700000,
+              "dueTimestamp": null,
+              "status": null,
+              "voyage": {
+                "type": "COMMERCIAL",
+                "voyageType": "SEA",
+                "departureLocation": "DOV",
+                "departureCountry": null,
+                "scheduledDepartureTimestamp": 1637506150000,
+                "actualDepartureTimestamp": 1637506150000,
+                "arrivalLocation": "CAL",
+                "arrivalCountry": null,
+                "scheduledArrivalTimestamp": null,
+                "actualArrivalTimestamp": null,
+                "intermediateLocations": null,
+                "passengerCount": null,
+                "crewCount": null,
+                "durationMinutes": null,
+                "routeId": null,
+                "carrier": "DFDS",
+                "craftId": "DOVER SEAWAYS"
+              },
+              "attributes": {
+                "attrs": {
+                  "freightMovementCount": "001"
+                }
+              },
+              "features": {
+                "feats": {
+                  "STANDARDISED:arrivalPort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "FR CQF"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602834
+                  },
+                  "STANDARDISED:estimatedArrivalTimestamp": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "LONG",
+                    "value": 1596465300000,
+                    "valueList": null,
+                    "startTimestamp": null,
+                    "endTimestamp": null
+                  },
+                  "STANDARDISED:departurePort": {
+                    "id": null,
+                    "type": null,
+                    "valueType": "MAP",
+                    "value": null,
+                    "valueList": {
+                      "val": [
+                        {
+                          "UNLO5": "GB DVR"
+                        }
+                      ]
+                    },
+                    "startTimestamp": null,
+                    "endTimestamp": 1626168602834
+                  }
+                }
+              },
+              "changeHistory": null
+            },
+            "consolidation": null,
+            "consignments": null
+          }
+        }
+      }
+    },
+    "initiatedBy": {
+      "type": "String",
+      "value": "rbtEngine"
+    }
+  },
+  "businessKey": "CERB-ROROTSV:CMID=fe650bc1a0ffede048d0527c17d8dd16/c29399d06f3fcda4d0bced3fd302b468/8ee41bc78fab154e299f2c066e756e62/4bfa9f48dcf627f73a6754d3e21ace0c/e292892eec399204a63244a8d4712851"
+}


### PR DESCRIPTION
## Description
Add tests to verify Selectors grouping with global reference ID
Scenario : 
Scenario 1: Multiple selectors in the same selector group
GIVEN a task has multiple selectors with the same Group reference ID
WHEN I view the task details
THEN the Group reference details are displayed in the Task details
AND the multiple selectors with the same group reference are displayed under this

## To Test
npm run cypress:runner 

run the following tests from spec `task-details.spec.js`

`Should verify the selector matches with same group reference`
`Should verify the selector matches with same & different group reference on 2 different version of a task`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
