### PR TITLE
COP-9849 - Swaps out previously used eta value for scheduled departure time

### DIFF
--- a/src/routes/__tests__/TaskVersions.test.jsx
+++ b/src/routes/__tests__/TaskVersions.test.jsx
@@ -129,7 +129,7 @@ describe('TaskVersions', () => {
       movementMode="RORO Tourist"
     />);
 
-    expect(screen.queryByText('3 Aug 2020 at 12:05, a day ago')).toBeInTheDocument();
+    expect(screen.queryByText('3 Aug 2020 at 12:05, 2 days before travel')).toBeInTheDocument();
   });
 
   it('should not render check-in relative time for RORO Tourist foot passengers', () => {

--- a/src/utils/__tests__/roroDataUtil.test.jsx
+++ b/src/utils/__tests__/roroDataUtil.test.jsx
@@ -1,4 +1,8 @@
-import { modifyRoRoPassengersTaskList, hasCheckinDate, hasEta, hasCarrierCounts } from '../roroDataUtil';
+import { modifyRoRoPassengersTaskList,
+  hasCheckinDate,
+  hasEta,
+  hasCarrierCounts,
+  extractTaskVersionsBookingField } from '../roroDataUtil';
 
 import { testRoroData } from '../__fixtures__/roroData.fixture';
 
@@ -65,5 +69,36 @@ describe('RoRoData Util', () => {
     ];
     const result = hasCarrierCounts(suppliedPassengerCounts);
     expect(result).toBeTruthy();
+  });
+
+  it('should return a concatenated datetime string', () => {
+    const expectedCheckInDataTime = '2020-08-03T12:05:00,2020-08-03T13:05:00Z';
+    const taskVersionMinified = [
+      {
+        fieldSetName: 'Booking and check-in',
+        hasChildSet: false,
+        contents: [
+          {
+            fieldName: 'Check-in',
+            type: 'DATETIME',
+            content: '2020-08-03T12:05:00',
+            versionLastUpdated: null,
+            propName: 'checkIn',
+          },
+        ],
+        type: 'null',
+        propName: 'booking',
+      },
+    ];
+    const testRoroDataMinified = {
+      roro: {
+        details: {
+          departureTime: '2020-08-03T13:05:00Z',
+        },
+      },
+    };
+    const result = extractTaskVersionsBookingField(taskVersionMinified, testRoroDataMinified);
+    const modifiedCheckInTime = result.contents.find(({ propName }) => propName === 'checkIn').content;
+    expect(modifiedCheckInTime).toEqual(expectedCheckInDataTime);
   });
 });

--- a/src/utils/__tests__/roroDataUtil.test.jsx
+++ b/src/utils/__tests__/roroDataUtil.test.jsx
@@ -71,8 +71,9 @@ describe('RoRoData Util', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should return a concatenated datetime string', () => {
+  it('should return a check-in time that is a concatenated datetime string', () => {
     const expectedCheckInDataTime = '2020-08-03T12:05:00,2020-08-03T13:05:00Z';
+
     const taskVersionMinified = [
       {
         fieldSetName: 'Booking and check-in',
@@ -90,6 +91,7 @@ describe('RoRoData Util', () => {
         propName: 'booking',
       },
     ];
+
     const testRoroDataMinified = {
       roro: {
         details: {
@@ -97,8 +99,78 @@ describe('RoRoData Util', () => {
         },
       },
     };
+
     const result = extractTaskVersionsBookingField(taskVersionMinified, testRoroDataMinified);
     const modifiedCheckInTime = result.contents.find(({ propName }) => propName === 'checkIn').content;
+
     expect(modifiedCheckInTime).toEqual(expectedCheckInDataTime);
+  });
+
+  it('should return check-in time with no concatenated datetime string when departure time is empty', () => {
+    const expectedCheckInDataTime = '2020-08-03T12:05:00';
+
+    const taskVersionMinified = [
+      {
+        fieldSetName: 'Booking and check-in',
+        hasChildSet: false,
+        contents: [
+          {
+            fieldName: 'Check-in',
+            type: 'DATETIME',
+            content: '2020-08-03T12:05:00',
+            versionLastUpdated: null,
+            propName: 'checkIn',
+          },
+        ],
+        type: 'null',
+        propName: 'booking',
+      },
+    ];
+
+    const testRoroDataMinified = {
+      roro: {
+        details: {
+          departureTime: '',
+        },
+      },
+    };
+
+    const result = extractTaskVersionsBookingField(taskVersionMinified, testRoroDataMinified);
+    const modifiedCheckInTime = result.contents.find(({ propName }) => propName === 'checkIn').content;
+
+    expect(modifiedCheckInTime).toEqual(expectedCheckInDataTime);
+  });
+
+  it('should return check-in time with no concatenated datetime string when check-in time is null', () => {
+    const taskVersionMinified = [
+      {
+        fieldSetName: 'Booking and check-in',
+        hasChildSet: false,
+        contents: [
+          {
+            fieldName: 'Check-in',
+            type: 'DATETIME',
+            content: null,
+            versionLastUpdated: null,
+            propName: 'checkIn',
+          },
+        ],
+        type: 'null',
+        propName: 'booking',
+      },
+    ];
+
+    const testRoroDataMinified = {
+      roro: {
+        details: {
+          departureTime: '2020-08-03T13:05:00Z',
+        },
+      },
+    };
+
+    const result = extractTaskVersionsBookingField(taskVersionMinified, testRoroDataMinified);
+    const modifiedCheckInTime = result.contents.find(({ propName }) => propName === 'checkIn').content;
+
+    expect(modifiedCheckInTime).toBeFalsy();
   });
 });

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -56,6 +56,10 @@ const hasEta = (eta) => {
   return eta !== null && eta !== undefined && eta !== '';
 };
 
+const hasDepartureTime = (departureTime) => {
+  return departureTime !== null && departureTime !== undefined && departureTime !== '';
+};
+
 const hasTaskVersionPassengers = (passengers) => {
   let hasValidPassengers = false;
   for (const passengerChildSets of passengers.childSets) {
@@ -135,10 +139,13 @@ const modifyRoRoPassengersTaskDetails = (version) => {
 
 const extractTaskVersionsBookingField = (version, taskSummaryData) => {
   const bookingField = JSON.parse(JSON.stringify(version.find(({ propName }) => propName === 'booking')));
+  const scheduledDepartureTime = taskSummaryData?.roro?.details?.departureTime;
   if (!hasCheckinDate(bookingField.contents.find(({ propName }) => propName === 'checkIn').content)) {
     return bookingField;
   }
-  const scheduledDepartureTime = taskSummaryData?.roro?.details?.departureTime;
+  if (!hasDepartureTime(scheduledDepartureTime)) {
+    return bookingField;
+  }
   if (bookingField.contents.find(({ propName }) => propName === 'checkIn').type.includes('CHANGED')) {
     bookingField.contents.find(({ propName }) => propName === 'checkIn').type = 'BOOKING_DATETIME-CHANGED';
   } else {

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -135,18 +135,16 @@ const modifyRoRoPassengersTaskDetails = (version) => {
 
 const extractTaskVersionsBookingField = (version, taskSummaryData) => {
   const bookingField = JSON.parse(JSON.stringify(version.find(({ propName }) => propName === 'booking')));
-  let eta = taskSummaryData.roro.details?.eta;
-  if (hasCheckinDate(bookingField.contents.find(({ propName }) => propName === 'checkIn').content)) {
-    if (hasEta(eta)) {
-      eta = eta.substring(0, eta.length - 1);
-      if (bookingField.contents.find(({ propName }) => propName === 'checkIn').type.includes('CHANGED')) {
-        bookingField.contents.find(({ propName }) => propName === 'checkIn').type = 'BOOKING_DATETIME-CHANGED';
-      } else {
-        bookingField.contents.find(({ propName }) => propName === 'checkIn').type = 'BOOKING_DATETIME';
-      }
-      bookingField.contents.find(({ propName }) => propName === 'checkIn').content += `,${eta}`;
-    }
+  if (!hasCheckinDate(bookingField.contents.find(({ propName }) => propName === 'checkIn').content)) {
+    return bookingField;
   }
+  const scheduledDepartureTime = taskSummaryData?.roro?.details?.departureTime;
+  if (bookingField.contents.find(({ propName }) => propName === 'checkIn').type.includes('CHANGED')) {
+    bookingField.contents.find(({ propName }) => propName === 'checkIn').type = 'BOOKING_DATETIME-CHANGED';
+  } else {
+    bookingField.contents.find(({ propName }) => propName === 'checkIn').type = 'BOOKING_DATETIME';
+  }
+  bookingField.contents.find(({ propName }) => propName === 'checkIn').content += `,${scheduledDepartureTime}`;
   return bookingField;
 };
 


### PR DESCRIPTION
## Description
This PR is a minor fix which swaps out the previously used `eta` datetime value for the `departure` datetime used to calculate the relative time difference for the check-in time (an error reported by one of the SMEs).

