### PR TITLE
COP-9955: Generate tasks with different selectors and rules for sorting

### DIFF
--- a/cypress/integration/cerberus/task-management.spec.js
+++ b/cypress/integration/cerberus/task-management.spec.js
@@ -2,14 +2,11 @@
 /// <reference path="../support/index.d.ts" />
 
 describe('Render tasks from Camunda and manage them on task management Page', () => {
-  let dateNowFormatted;
   const MAX_TASK_PER_PAGE = 100;
   const nextPage = 'a[data-test="next"]';
 
   before(() => {
     cy.clock();
-    dateNowFormatted = Cypress.dayjs(new Date()).format('DD-MM-YYYY');
-
   });
 
   beforeEach(() => {
@@ -120,9 +117,10 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
   });
 
   it('Should verify tasks are sorted in correct order selectors with highest category should be at top of the list on task management page', () => {
+    let dateNowFormatted = Cypress.dayjs().format('DD-MM-YYYY');
     let arrivalTime = Cypress.dayjs().subtract(3, 'day').valueOf();
     cy.fixture('/tasks-with-rules-selectors/task-selectors-rules.json').then((task) => {
-      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp =arrivalTime;
+      task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = arrivalTime;
       let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');
       task.variables.rbtPayload.value.data.matchedSelectors[0].category = 'A';
       task.variables.rbtPayload.value = JSON.stringify(task.variables.rbtPayload.value);
@@ -131,7 +129,6 @@ describe('Render tasks from Camunda and manage them on task management Page', ()
         cy.checkTaskDisplayed(`${response.businessKey}`);
       });
     });
-
 
     cy.fixture('/tasks-with-rules-selectors/task-selectors-rules.json').then((task) => {
       task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = arrivalTime;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -977,15 +977,13 @@ Cypress.Commands.add('removeOptionFromMultiSelectDropdown', (elementName, values
 
 Cypress.Commands.add('createCerberusTask', (payload, taskName) => {
   let expectedTaskSummary = {};
-  let date = new Date();
   let dateNowFormatted = Cypress.dayjs().format('DD-MM-YYYY');
   let bookingDateTime;
   const dateFormat = 'D MMM YYYY [at] HH:mm';
   cy.fixture(payload).then((task) => {
     let registrationNumber = task.variables.rbtPayload.value.data.movement.vehicles[0].vehicle.registrationNumber;
     const rndInt = Math.floor(Math.random() * 20) + 1;
-    date.setDate(date.getDate() + rndInt);
-    task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = date.getTime();
+    task.variables.rbtPayload.value.data.movement.voyage.voyage.actualArrivalTimestamp = Cypress.dayjs().add(rndInt, 'day').valueOf();
     bookingDateTime = task.variables.rbtPayload.value.data.movement.serviceMovement.attributes.attrs.bookingDateTime;
     bookingDateTime = Cypress.dayjs(bookingDateTime).format(dateFormat);
     let mode = task.variables.rbtPayload.value.data.movement.serviceMovement.movement.mode.replace(/ /g, '-');


### PR DESCRIPTION
## Description
Generate tasks with different selectors and rules for sorting

## To Test
npm run cypress:runner
run the test `Should verify tasks are sorted in correct order selectors with highest category should be at top of the list on task management page` 

check the tasks sorted by the rules given in COP-9955

Notes: it is not possible to verify the sorting tasks with selectors and rule as there always be different other tasks available.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
