### PR TITLE
COP-10007 - Handles null values from unknown count

### DIFF
--- a/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
+++ b/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
@@ -1,10 +1,27 @@
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import moment from 'moment';
-import { formatKey, formatField, formatLinkField } from '../../../utils/formatField';
+import {
+  formatKey,
+  formatField,
+  formatLinkField,
+} from '../../../utils/formatField';
 import formatGender from '../../../utils/genderFormatter';
-import { RORO_UNACCOMPANIED_FREIGHT, RORO_ACCOMPANIED_FREIGHT, RORO_TOURIST_GROUP_ICON, RORO_TOURIST_SINGLE_ICON, RORO_TOURIST, SHORT_DATE_ALT } from '../../../constants';
-import { isValid, hasZeroCount, hasDriver, hasTaskVersionPassengers, hasCarrierCounts } from '../../../utils/roroDataUtil';
+import {
+  RORO_UNACCOMPANIED_FREIGHT,
+  RORO_ACCOMPANIED_FREIGHT,
+  RORO_TOURIST_GROUP_ICON,
+  RORO_TOURIST_SINGLE_ICON,
+  RORO_TOURIST,
+  SHORT_DATE_ALT,
+} from '../../../constants';
+import {
+  isValid,
+  hasZeroCount,
+  hasDriver,
+  hasTaskVersionPassengers,
+  hasCarrierCounts,
+} from '../../../utils/roroDataUtil';
 
 const discardDriver = (passengersField) => {
   const passengers = passengersField;
@@ -21,15 +38,25 @@ const findLink = (contents, content, linkPropNames) => {
   return contents.find((field) => field.propName === linkPropName)?.content;
 };
 
-const renderFields = (contents, linkPropNames = {}, className = 'govuk-task-details-grid-item') => {
+const renderFields = (
+  contents,
+  linkPropNames = {},
+  className = 'govuk-task-details-grid-item',
+) => {
   return contents.map((content) => {
     if (!content.type.includes('HIDDEN')) {
       const link = findLink(contents, content, linkPropNames);
       return (
         <div className={className} key={uuidv4()}>
           <ul>
-            <li className="govuk-grid-key font__light">{formatKey(content.type, content.fieldName)}</li>
-            <li className="govuk-grid-value font__bold">{link ? formatLinkField(content.type, content.content, link) : formatField(content.type, content.content)}</li>
+            <li className="govuk-grid-key font__light">
+              {formatKey(content.type, content.fieldName)}
+            </li>
+            <li className="govuk-grid-value font__bold">
+              {link
+                ? formatLinkField(content.type, content.content, link)
+                : formatField(content.type, content.content)}
+            </li>
           </ul>
         </div>
       );
@@ -38,9 +65,12 @@ const renderFields = (contents, linkPropNames = {}, className = 'govuk-task-deta
 };
 
 const renderDocumentExpiry = (passportExpiry, arrivalTime) => {
-  const expiry = (arrivalTime && passportExpiry) && `${arrivalTime},${moment(passportExpiry).format('YYYY-MM-DDTHH:mm:ss')}`;
+  const expiry = arrivalTime
+    && passportExpiry
+    && `${arrivalTime},${moment(passportExpiry).format('YYYY-MM-DDTHH:mm:ss')}`;
   if (expiry) {
-    return formatField('BOOKING_DATETIME', expiry).split(', ')[1]
+    return formatField('BOOKING_DATETIME', expiry)
+      .split(', ')[1]
       .replace('before travel', 'after travel')
       .replace('ago', 'before travel')
       .replace('a ', 'A ')
@@ -49,15 +79,16 @@ const renderDocumentExpiry = (passportExpiry, arrivalTime) => {
   return 'Unknown';
 };
 
-const renderVersionSection = ({ fieldSetName, contents }, linkPropNames = {}) => {
+const renderVersionSection = (
+  { fieldSetName, contents },
+  linkPropNames = {},
+) => {
   if (contents !== undefined && contents !== null && contents.length > 0) {
     const jsxElement = renderFields(contents, linkPropNames);
     return (
       <div className="task-details-container bottom-border-thick">
         <h3 className="title-heading">{fieldSetName}</h3>
-        <div>
-          {jsxElement}
-        </div>
+        <div>{jsxElement}</div>
       </div>
     );
   }
@@ -80,10 +111,12 @@ const renderBookingSection = (fieldSet) => {
   return renderVersionSection(fieldSet);
 };
 const applyHighlightLabel = (name, dob, gender, nationality) => {
-  if (dob?.type.includes('-CHANGED')
+  if (
+    dob?.type.includes('-CHANGED')
     || gender?.type.includes('-CHANGED')
     || nationality?.type.includes('-CHANGED')
-    || name?.type.includes('-CHANGED')) {
+    || name?.type.includes('-CHANGED')
+  ) {
     return 'task-versions--highlight';
   }
 };
@@ -98,32 +131,80 @@ const renderOccupants = (contents, fieldSetName, arrivalTime = undefined) => {
   const name = contents.find(({ propName }) => propName === 'name');
   const dob = contents.find(({ propName }) => propName === 'dob');
   const gender = contents.find(({ propName }) => propName === 'gender');
-  const nationality = contents.find(({ propName }) => propName === 'nationality');
-  const passportNumber = contents.find(({ propName }) => propName === 'docNumber');
-  const passportExpiry = contents.find(({ propName }) => propName === 'docExpiry');
+  const nationality = contents.find(
+    ({ propName }) => propName === 'nationality',
+  );
+  const passportNumber = contents.find(
+    ({ propName }) => propName === 'docNumber',
+  );
+  const passportExpiry = contents.find(
+    ({ propName }) => propName === 'docExpiry',
+  );
   const link = findLink(contents, name, defaultLinkPropNames);
   return (
     <div className="govuk-!-margin-bottom-4 bottom-border">
       <div className="govuk-grid-row govuk-!-margin-bottom-2">
         <div className="govuk-grid-column-full">
-          <p className="govuk-!-margin-bottom-1 font__light"><span className={applyHighlightLabel(name, dob, gender, nationality)}>{fieldSetName}</span></p>
-          {link
-            ? <p className="govuk-!-margin-bottom-0 font__bold"><span className={applyHighlightValue(name)}>{formatLinkField(name.type, name.content, link)}</span></p>
-            : <p className="govuk-!-margin-bottom-0 font__bold"><span className={applyHighlightValue(name)}>{name.content}</span></p>}
+          <p className="govuk-!-margin-bottom-1 font__light">
+            <span
+              className={applyHighlightLabel(name, dob, gender, nationality)}
+            >
+              {fieldSetName}
+            </span>
+          </p>
+          {link ? (
+            <p className="govuk-!-margin-bottom-0 font__bold">
+              <span className={applyHighlightValue(name)}>
+                {formatLinkField(name.type, name.content, link)}
+              </span>
+            </p>
+          ) : (
+            <p className="govuk-!-margin-bottom-0 font__bold">
+              <span className={applyHighlightValue(name)}>{name.content}</span>
+            </p>
+          )}
           <p className="govuk-!-margin-bottom-0">
-            <span className={`font__bold ${applyHighlightValue(gender)}`}>{formatGender(gender?.content)}</span>
-            { dob?.content ? (<span className={`font__bold ${applyHighlightValue(dob)}`}>, born {formatField(SHORT_DATE_ALT, dob?.content)}</span>) : (<span className={`font__bold ${applyHighlightValue(dob)}`}>, Unknown</span>) }
-            { nationality?.content ? (<span className={`font__bold ${applyHighlightValue(nationality)}`}>, {nationality?.content}</span>) : (<span className={`font__bold ${applyHighlightValue(nationality)}`}>, Unknown</span>)}
+            <span className={`font__bold ${applyHighlightValue(gender)}`}>
+              {formatGender(gender?.content)}
+            </span>
+            {dob?.content ? (
+              <span className={`font__bold ${applyHighlightValue(dob)}`}>
+                , born {formatField(SHORT_DATE_ALT, dob?.content)}
+              </span>
+            ) : (
+              <span className={`font__bold ${applyHighlightValue(dob)}`}>
+                , Unknown
+              </span>
+            )}
+            {nationality?.content ? (
+              <span
+                className={`font__bold ${applyHighlightValue(nationality)}`}
+              >
+                , {nationality?.content}
+              </span>
+            ) : (
+              <span
+                className={`font__bold ${applyHighlightValue(nationality)}`}
+              >
+                , Unknown
+              </span>
+            )}
           </p>
         </div>
       </div>
       <div className="govuk-grid-row govuk-!-margin-bottom-2">
         <div className="govuk-grid-column-full govuk-!-margin-bottom-2">
           <p className="govuk-!-margin-bottom-1 font__light">
-            <span className={`${applyHighlightValue(passportNumber)}`}>Passport</span>
+            <span className={`${applyHighlightValue(passportNumber)}`}>
+              Passport
+            </span>
           </p>
           <p className="govuk-!-margin-bottom-0 font__bold">
-            <span className={`font__bold ${applyHighlightValue(passportNumber)}`}>{passportNumber?.content || 'Unknown'}</span>
+            <span
+              className={`font__bold ${applyHighlightValue(passportNumber)}`}
+            >
+              {passportNumber?.content || 'Unknown'}
+            </span>
           </p>
         </div>
         <div className="govuk-grid-column-full">
@@ -133,11 +214,26 @@ const renderOccupants = (contents, fieldSetName, arrivalTime = undefined) => {
             </span>
           </p>
           <p className="govuk-!-margin-bottom-1">
-            { passportExpiry?.content ? (<span className={`font__bold ${applyHighlightValue(passportExpiry)}`}>Expires {formatField(SHORT_DATE_ALT, passportExpiry?.content)}</span>) : (<span className={`font__bold ${applyHighlightValue(passportExpiry)}`}>Unknown</span>)}
+            {passportExpiry?.content ? (
+              <span
+                className={`font__bold ${applyHighlightValue(passportExpiry)}`}
+              >
+                Expires {formatField(SHORT_DATE_ALT, passportExpiry?.content)}
+              </span>
+            ) : (
+              <span
+                className={`font__bold ${applyHighlightValue(passportExpiry)}`}
+              >
+                Unknown
+              </span>
+            )}
           </p>
           <p className="govuk-!-margin-bottom-0 font__light">
             <span className={applyHighlightValue(passportExpiry)}>
-              { renderDocumentExpiry(formatField(SHORT_DATE_ALT, passportExpiry?.content), arrivalTime) }
+              {renderDocumentExpiry(
+                formatField(SHORT_DATE_ALT, passportExpiry?.content),
+                arrivalTime,
+              )}
             </span>
           </p>
         </div>
@@ -150,7 +246,11 @@ const renderDriverSection = (fieldSet, arrivalTime) => {
   return renderOccupants(fieldSet.contents, fieldSet.fieldSetName, arrivalTime);
 };
 
-const renderVersionSectionBody = (fieldSet, linkPropNames = {}, className = '') => {
+const renderVersionSectionBody = (
+  fieldSet,
+  linkPropNames = {},
+  className = '',
+) => {
   if (fieldSet.length > 0 && fieldSet !== null && fieldSet !== undefined) {
     return renderFields(fieldSet, linkPropNames, className);
   }
@@ -159,16 +259,32 @@ const renderVersionSectionBody = (fieldSet, linkPropNames = {}, className = '') 
 const renderTargetingIndicatorsSection = ({ type, hasChildSet, childSets }) => {
   if (hasChildSet) {
     const targetingIndicators = childSets.map((childSet, index) => {
-      const indicator = childSet.contents.filter(({ propName }) => propName === 'userfacingtext')[0].content;
-      const score = childSet.contents.filter(({ propName }) => propName === 'score')[0].content;
+      const indicator = childSet.contents.filter(
+        ({ propName }) => propName === 'userfacingtext',
+      )[0].content;
+      const score = childSet.contents.filter(
+        ({ propName }) => propName === 'score',
+      )[0].content;
       if (!type.includes('HIDDEN')) {
-        const className = index !== childSets.length - 1 ? 'govuk-task-details-grid-row bottom-border' : 'govuk-task-details-grid-row';
+        const className = index !== childSets.length - 1
+          ? 'govuk-task-details-grid-row bottom-border'
+          : 'govuk-task-details-grid-row';
         return (
           <div className={className} key={uuidv4()}>
             <ul className="list-bullet-container">
-              {type.includes('CHANGED') ? <li className="govuk-grid-key list-bullet font__light task-versions--highlight">{indicator}</li> : <li className="govuk-grid-key list-bullet font__light">{indicator}</li>}
+              {type.includes('CHANGED') ? (
+                <li className="govuk-grid-key list-bullet font__light task-versions--highlight">
+                  {indicator}
+                </li>
+              ) : (
+                <li className="govuk-grid-key list-bullet font__light">
+                  {indicator}
+                </li>
+              )}
             </ul>
-            <span className="govuk-grid-value font__bold">{formatField(type, score)}</span>
+            <span className="govuk-grid-value font__bold">
+              {formatField(type, score)}
+            </span>
           </div>
         );
       }
@@ -181,9 +297,7 @@ const renderTargetingIndicatorsSection = ({ type, hasChildSet, childSets }) => {
               <span className="govuk-grid-key font__light">Indicator</span>
               <span className="govuk-grid-value font__light">Score</span>
             </div>
-            <div className="task-details-container">
-              {targetingIndicators}
-            </div>
+            <div className="task-details-container">{targetingIndicators}</div>
           </div>
         </>
       );
@@ -195,18 +309,25 @@ const renderVehicleSection = ({ contents }, movementMode) => {
   if (movementMode !== RORO_UNACCOMPANIED_FREIGHT.toUpperCase()) {
     if (contents.length > 0) {
       const vehicleArray = contents.filter(({ propName }) => {
-        return propName === 'registrationNumber' || propName === 'make' || propName === 'model'
-          || propName === 'type' || propName === 'registrationNationality' || propName === 'colour'
-          || propName === 'vehicleEntitySearchUrl';
+        return (
+          propName === 'registrationNumber'
+          || propName === 'make'
+          || propName === 'model'
+          || propName === 'type'
+          || propName === 'registrationNationality'
+          || propName === 'colour'
+          || propName === 'vehicleEntitySearchUrl'
+        );
       });
       const linkPropNames = { registrationNumber: 'vehicleEntitySearchUrl' };
-      const vehicleSection = renderVersionSectionBody(vehicleArray, linkPropNames);
+      const vehicleSection = renderVersionSectionBody(
+        vehicleArray,
+        linkPropNames,
+      );
       return (
         <div className="task-details-container bottom-border-thick">
           <h3 className="title-heading">Vehicle</h3>
-          <div className="govuk-task-details-grid-column">
-            {vehicleSection}
-          </div>
+          <div className="govuk-task-details-grid-column">{vehicleSection}</div>
         </div>
       );
     }
@@ -214,22 +335,34 @@ const renderVehicleSection = ({ contents }, movementMode) => {
 };
 
 const renderTrailerSection = ({ contents }, movementMode) => {
-  if (movementMode === RORO_UNACCOMPANIED_FREIGHT.toUpperCase() || movementMode === RORO_ACCOMPANIED_FREIGHT.toUpperCase()) {
+  if (
+    movementMode === RORO_UNACCOMPANIED_FREIGHT.toUpperCase()
+    || movementMode === RORO_ACCOMPANIED_FREIGHT.toUpperCase()
+  ) {
     const trailerDataArray = contents.filter(({ propName }) => {
-      return propName === 'trailerRegistrationNumber' || propName === 'trailerType' || propName === 'trailerRegistrationNationality'
-        || propName === 'trailerLength' || propName === 'trailerHeight' || propName === 'trailerEmptyOrLoaded'
-        || propName === 'trailerEntitySearchUrl';
+      return (
+        propName === 'trailerRegistrationNumber'
+        || propName === 'trailerType'
+        || propName === 'trailerRegistrationNationality'
+        || propName === 'trailerLength'
+        || propName === 'trailerHeight'
+        || propName === 'trailerEmptyOrLoaded'
+        || propName === 'trailerEntitySearchUrl'
+      );
     });
-      // Check that trailer registration exists
+    // Check that trailer registration exists
     if (trailerDataArray[0].content !== null) {
-      const linkPropNames = { trailerRegistrationNumber: 'trailerEntitySearchUrl' };
-      const trailerSection = renderVersionSectionBody(trailerDataArray, linkPropNames);
+      const linkPropNames = {
+        trailerRegistrationNumber: 'trailerEntitySearchUrl',
+      };
+      const trailerSection = renderVersionSectionBody(
+        trailerDataArray,
+        linkPropNames,
+      );
       return (
         <div className="task-details-container bottom-border-thick">
           <h3 className="title-heading">Trailer</h3>
-          <div className="govuk-task-details-grid-column">
-            {trailerSection}
-          </div>
+          <div className="govuk-task-details-grid-column">{trailerSection}</div>
         </div>
       );
     }
@@ -240,17 +373,53 @@ const createOccupantsCarrierCountsFields = (manifestOccupantCategoryCounts) => {
   return manifestOccupantCategoryCounts.map((categoryCount, index) => {
     if (isValid(categoryCount)) {
       if (!categoryCount.type.includes('HIDDEN')) {
-        const className = (index !== manifestOccupantCategoryCounts.length - 1 ? 'govuk-task-details-grid-row bottom-border' : 'govuk-task-details-grid-row');
+        const className = index !== manifestOccupantCategoryCounts.length - 1
+          ? 'govuk-task-details-grid-row bottom-border'
+          : 'govuk-task-details-grid-row';
         return (
           <div className={className} key={uuidv4()}>
             <ul>
-              {categoryCount.type.includes('CHANGED')
-                ? (<li className={`govuk-grid-value font__bold ${hasZeroCount(categoryCount.content) && 'font__grey'} task-versions--highlight`}>{categoryCount.fieldName}</li>)
-                : (<li className={`govuk-grid-value  ${hasZeroCount(categoryCount.content) && 'font__grey'} font__bold`}>{categoryCount.fieldName}</li>)}
+              {categoryCount.type.includes('CHANGED') ? (
+                <li
+                  className={`govuk-grid-value font__bold ${
+                    hasZeroCount(categoryCount.content) && 'font__grey'
+                  } task-versions--highlight`}
+                >
+                  {categoryCount.fieldName}
+                </li>
+              ) : (
+                <li
+                  className={`govuk-grid-value  ${
+                    hasZeroCount(categoryCount.content) && 'font__grey'
+                  } font__bold`}
+                >
+                  {categoryCount.fieldName}
+                </li>
+              )}
             </ul>
-            {categoryCount.type.includes('CHANGED')
-              ? (<span className={`govuk-grid-value font__bold ${hasZeroCount(categoryCount.content) && 'font__grey'} task-versions--highlight`}>{parseInt(formatField(categoryCount.type, categoryCount.content), 10)}</span>)
-              : (<span className={`govuk-grid-value font__bold ${hasZeroCount(categoryCount.content) && 'font__grey'}`}>{parseInt(formatField(categoryCount.type, categoryCount.content), 10)}</span>)}
+            {categoryCount.type.includes('CHANGED') ? (
+              <span
+                className={`govuk-grid-value font__bold ${
+                  hasZeroCount(categoryCount.content) && 'font__grey'
+                } task-versions--highlight`}
+              >
+                {parseInt(
+                  formatField(categoryCount.type, categoryCount.content),
+                  10,
+                )}
+              </span>
+            ) : (
+              <span
+                className={`govuk-grid-value font__bold ${
+                  hasZeroCount(categoryCount.content) && 'font__grey'
+                }`}
+              >
+                {parseInt(
+                  formatField(categoryCount.type, categoryCount.content),
+                  10,
+                )}
+              </span>
+            )}
           </div>
         );
       }
@@ -258,40 +427,79 @@ const createOccupantsCarrierCountsFields = (manifestOccupantCategoryCounts) => {
   });
 };
 
-const renderOccupantCarrierCountsSection = (driverField, passengersField, passengersMetadata, movementMode, movementModeIcon = 'any-icon') => {
+const renderOccupantCarrierCountsSection = (
+  driverField,
+  passengersField,
+  passengersMetadata,
+  movementMode,
+  movementModeIcon = 'any-icon',
+) => {
   if (passengersMetadata) {
-    if (movementMode === RORO_ACCOMPANIED_FREIGHT || movementMode === RORO_TOURIST) {
-    /**
-     * Discard the driver element that was initially added to obtain actual number
-     * of named passengers in the movement
-     */
+    if (
+      movementMode === RORO_ACCOMPANIED_FREIGHT
+      || movementMode === RORO_TOURIST
+    ) {
+      /**
+       * Discard the driver element that was initially added to obtain actual number
+       * of named passengers in the movement
+       */
       const passengersDiscardedDriver = discardDriver(passengersField);
       let occupantsCountJsxElement;
       let driverName;
-      if (movementModeIcon !== RORO_TOURIST_GROUP_ICON && movementModeIcon !== RORO_TOURIST_SINGLE_ICON) {
+      if (
+        movementModeIcon !== RORO_TOURIST_GROUP_ICON
+        && movementModeIcon !== RORO_TOURIST_SINGLE_ICON
+      ) {
         if (driverField.contents.length > 0) {
-          driverName = driverField.contents.find(({ propName }) => propName === 'name').content;
+          driverName = driverField.contents.find(
+            ({ propName }) => propName === 'name',
+          ).content;
         }
       }
-      let manifestOccupantCategoryCounts = passengersMetadata.contents.filter(({ propName }) => {
-        return propName === 'infantCount' || propName === 'childCount'
-      || propName === 'adultCount' || propName === 'oapCount';
-      }).reverse();
+      let manifestOccupantCategoryCounts = passengersMetadata.contents
+        .filter(({ propName }) => {
+          return (
+            propName === 'infantCount'
+            || propName === 'childCount'
+            || propName === 'adultCount'
+            || propName === 'oapCount'
+          );
+        })
+        .reverse();
 
-      if (!hasDriver(driverName) && !hasTaskVersionPassengers(passengersDiscardedDriver)
-        && hasCarrierCounts(manifestOccupantCategoryCounts)) {
-        occupantsCountJsxElement = createOccupantsCarrierCountsFields(manifestOccupantCategoryCounts);
+      if (
+        !hasDriver(driverName)
+        && !hasTaskVersionPassengers(passengersDiscardedDriver)
+        && hasCarrierCounts(manifestOccupantCategoryCounts)
+      ) {
+        occupantsCountJsxElement = createOccupantsCarrierCountsFields(
+          manifestOccupantCategoryCounts,
+        );
       }
 
-      if (hasDriver(driverName) && !hasTaskVersionPassengers(passengersDiscardedDriver)
-        && hasCarrierCounts(manifestOccupantCategoryCounts)) {
-        occupantsCountJsxElement = createOccupantsCarrierCountsFields(manifestOccupantCategoryCounts);
+      if (
+        hasDriver(driverName)
+        && !hasTaskVersionPassengers(passengersDiscardedDriver)
+        && hasCarrierCounts(manifestOccupantCategoryCounts)
+      ) {
+        occupantsCountJsxElement = createOccupantsCarrierCountsFields(
+          manifestOccupantCategoryCounts,
+        );
       }
 
-      if (!hasDriver(driverName) && !hasTaskVersionPassengers(passengersDiscardedDriver)
-        && !hasCarrierCounts(manifestOccupantCategoryCounts)) {
-        manifestOccupantCategoryCounts = passengersMetadata.contents.filter(({ propName }) => { return propName === 'unknownCount'; });
-        occupantsCountJsxElement = createOccupantsCarrierCountsFields(manifestOccupantCategoryCounts);
+      if (
+        !hasDriver(driverName)
+        && !hasTaskVersionPassengers(passengersDiscardedDriver)
+        && !hasCarrierCounts(manifestOccupantCategoryCounts)
+      ) {
+        manifestOccupantCategoryCounts = passengersMetadata.contents.filter(
+          ({ propName }) => {
+            return propName === 'unknownCount';
+          },
+        );
+        occupantsCountJsxElement = manifestOccupantCategoryCounts
+          && manifestOccupantCategoryCounts[0]?.content
+          && createOccupantsCarrierCountsFields(manifestOccupantCategoryCounts);
       }
 
       if (occupantsCountJsxElement) {
@@ -311,48 +519,56 @@ const renderOccupantCarrierCountsSection = (driverField, passengersField, passen
   }
 };
 
-const renderOccupantsSection = ({ childSets }, movementModeIcon, arrivalTime) => {
+const renderOccupantsSection = (
+  { childSets },
+  movementModeIcon,
+  arrivalTime,
+) => {
   // Passenger at position 0 is driver so they are excluded from the remaining passengers
   const remainingTravellers = childSets.slice(1);
   // Actual passenger
   const firstPassenger = remainingTravellers[0]?.contents;
-  const otherPassengers = remainingTravellers ? remainingTravellers.slice(1) : undefined;
+  const otherPassengers = remainingTravellers
+    ? remainingTravellers.slice(1)
+    : undefined;
   let firstPassengerJsxElement;
   let otherPassengersJsxElementBlock;
 
   if (firstPassenger !== null && firstPassenger !== undefined) {
     if (firstPassenger.length > 0) {
-      firstPassengerJsxElement = renderOccupants(firstPassenger, 'Occupant', arrivalTime);
+      firstPassengerJsxElement = renderOccupants(
+        firstPassenger,
+        'Occupant',
+        arrivalTime,
+      );
 
       if (otherPassengers !== null && otherPassengers !== undefined) {
         if (otherPassengers.length > 0) {
-          otherPassengersJsxElementBlock = otherPassengers.map((otherPassenger) => {
-            const passengerJsxElement = renderOccupants(otherPassenger.contents, 'Occupant', arrivalTime);
-            return (
-              <div key={uuidv4()}>
-                {passengerJsxElement}
-              </div>
-            );
-          });
+          otherPassengersJsxElementBlock = otherPassengers.map(
+            (otherPassenger) => {
+              const passengerJsxElement = renderOccupants(
+                otherPassenger.contents,
+                'Occupant',
+                arrivalTime,
+              );
+              return <div key={uuidv4()}>{passengerJsxElement}</div>;
+            },
+          );
         }
       }
       return (
         <>
           <div className="task-details-container">
-            <div>
-              {firstPassengerJsxElement}
-            </div>
+            <div>{firstPassengerJsxElement}</div>
             {otherPassengersJsxElementBlock && (
-            <details className="govuk-details" data-module="govuk-details">
-              <summary className="govuk-details__summary">
-                <span className="govuk-details__summary-text">
-                  Show more
-                </span>
-              </summary>
-              <div className="govuk-hidden-passengers">
-                {otherPassengersJsxElementBlock}
-              </div>
-            </details>
+              <details className="govuk-details" data-module="govuk-details">
+                <summary className="govuk-details__summary">
+                  <span className="govuk-details__summary-text">Show more</span>
+                </summary>
+                <div className="govuk-hidden-passengers">
+                  {otherPassengersJsxElementBlock}
+                </div>
+              </details>
             )}
           </div>
         </>
@@ -367,17 +583,32 @@ const renderPrimaryTraveller = ({ childSets }, movementModeIcon) => {
     let primaryTravellerArray;
     if (movementModeIcon === RORO_TOURIST_SINGLE_ICON) {
       primaryTravellerArray = primaryTraveller.filter(({ propName }) => {
-        return propName === 'name' || propName === 'dob' || propName === 'gender'
-            || propName === 'nationality' || propName === 'docType' || propName === 'docNumber'
-            || propName === 'docExpiry' || propName === 'entitySearchUrl';
+        return (
+          propName === 'name'
+          || propName === 'dob'
+          || propName === 'gender'
+          || propName === 'nationality'
+          || propName === 'docType'
+          || propName === 'docNumber'
+          || propName === 'docExpiry'
+          || propName === 'entitySearchUrl'
+        );
       });
     } else {
       primaryTravellerArray = primaryTraveller.filter(({ propName }) => {
-        return propName === 'name' || propName === 'dob' || propName === 'gender'
-            || propName === 'nationality' || propName === 'entitySearchUrl';
+        return (
+          propName === 'name'
+          || propName === 'dob'
+          || propName === 'gender'
+          || propName === 'nationality'
+          || propName === 'entitySearchUrl'
+        );
       });
     }
-    const primaryTravellerSection = renderVersionSectionBody(primaryTravellerArray, defaultLinkPropNames);
+    const primaryTravellerSection = renderVersionSectionBody(
+      primaryTravellerArray,
+      defaultLinkPropNames,
+    );
     return (
       <div className="task-details-container bottom-border-thick">
         <h3 className="title-heading">Primary Traveller</h3>
@@ -392,11 +623,18 @@ const renderPrimaryTraveller = ({ childSets }, movementModeIcon) => {
 const renderPrimaryTravellerDocument = ({ childSets }) => {
   const primaryTraveller = childSets[0].contents;
   if (primaryTraveller.length > 0) {
-    const primaryTravellerDocumentArray = primaryTraveller.filter(({ propName }) => {
-      return propName === 'docType' || propName === 'docNumber'
-          || propName === 'docExpiry';
-    });
-    const primaryTravellerDocumentSection = renderVersionSectionBody(primaryTravellerDocumentArray);
+    const primaryTravellerDocumentArray = primaryTraveller.filter(
+      ({ propName }) => {
+        return (
+          propName === 'docType'
+          || propName === 'docNumber'
+          || propName === 'docExpiry'
+        );
+      },
+    );
+    const primaryTravellerDocumentSection = renderVersionSectionBody(
+      primaryTravellerDocumentArray,
+    );
     return (
       <div className="task-details-container bottom-border-thick">
         <h3 className="title-heading">Document</h3>
@@ -408,7 +646,8 @@ const renderPrimaryTravellerDocument = ({ childSets }) => {
   }
 };
 
-export { renderHaulierSection,
+export {
+  renderHaulierSection,
   renderVersionSection,
   renderAccountSection,
   renderDriverSection,
@@ -421,4 +660,5 @@ export { renderHaulierSection,
   renderOccupantCarrierCountsSection,
   renderPrimaryTraveller,
   renderPrimaryTravellerDocument,
-  renderDocumentExpiry };
+  renderDocumentExpiry,
+};

--- a/src/routes/__assets__/TaskDetailsPage.scss
+++ b/src/routes/__assets__/TaskDetailsPage.scss
@@ -30,14 +30,14 @@
     }
 }
 
-@media (min-width: 40.0625em){
+@media (min-width: 40.0625em) {
     .govuk-grid-column-two-thirds {
         width: 70%;
         float: left;
     }
 }
 
-@media (min-width: 40.0625em){
+@media (min-width: 40.0625em) {
     .govuk-grid-column-one-third {
         width: 30%;
         float: left;
@@ -98,18 +98,18 @@
 }
 
 .font__light {
-  color: #505a5f;
-  font-weight: lighter;
-  font-size: 15px;
+    color: #505a5f;
+    font-weight: lighter;
+    font-size: 15px;
 }
 
 .font__bold {
-  font-weight: bold;
-  font-size: 15px;
+    font-weight: bold;
+    font-size: 15px;
 }
 
 .bottom-border {
-  border-bottom: 1px solid #b1b4b6;
+    border-bottom: 1px solid #b1b4b6;
 }
 
 .govuk-task-details-grid {
@@ -348,6 +348,9 @@
             margin-top: 10px;
         }
     }
+    .govuk-task-details-counts-container {
+        margin-bottom: 10px;
+    }
 }
 
 .summary-data-list {
@@ -382,13 +385,13 @@
     }
     .c-icon-ship::before {
         left: 5px;
-    }  
+    }
     .second-half {
         padding-right: 10px;
     }
     .first-half {
         padding-left: 10px;
-    }  
+    }
     .second-half {
         padding-right: 10px;
     }

--- a/src/routes/__fixtures__/section-renderer/sectionRendererTaskDetails.js
+++ b/src/routes/__fixtures__/section-renderer/sectionRendererTaskDetails.js
@@ -899,10 +899,79 @@ const noDriverHasPaxHasCategoryCounts = [
   },
 ];
 
+const noDriverNoPaxNoCategoryAndNoUnknownCounts = [
+  {
+    fieldSetName: 'Driver',
+    hasChildSet: false,
+    contents: [],
+    type: 'null',
+    propName: 'driver',
+  },
+  {
+    fieldSetName: 'Passengers',
+    hasChildSet: true,
+    contents: [],
+    childSets: [],
+    type: 'STANDARD',
+    propName: 'passengers',
+  },
+  {
+    fieldSetName: 'Occupants',
+    hasChildSet: false,
+    contents: [
+      {
+        fieldName: 'OAPs',
+        type: 'STRING',
+        content: null,
+        versionLastUpdated: null,
+        propName: 'oapCount',
+      },
+      {
+        fieldName: 'Adults',
+        type: 'STRING',
+        content: null,
+        versionLastUpdated: null,
+        propName: 'adultCount',
+      },
+      {
+        fieldName: 'Children',
+        type: 'STRING',
+        content: null,
+        versionLastUpdated: null,
+        propName: 'childCount',
+      },
+      {
+        fieldName: 'Infants',
+        type: 'STRING',
+        content: null,
+        versionLastUpdated: null,
+        propName: 'infantCount',
+      },
+      {
+        fieldName: 'Total occupants',
+        type: 'STRING',
+        content: '0',
+        versionLastUpdated: null,
+        propName: 'totalOccupants',
+      },
+      {
+        fieldName: 'Unknown',
+        type: 'STRING',
+        content: null,
+        versionLastUpdated: null,
+        propName: 'unknownCount',
+      },
+    ],
+    type: 'null',
+    propName: 'occupants',
+  },
+];
+
 export {
   hasDriverNoPaxHasCategoryCounts,
   noDriverNoPaxHasCategoryCounts,
   noDriverNoPaxNoCategoryCounts,
   noDriverHasPaxHasCategoryCounts,
   hasDriverHasPaxHasCategoryCounts,
+  noDriverNoPaxNoCategoryAndNoUnknownCounts,
 };

--- a/src/routes/__tests__/TaskVersionsMode/SectionRenderer.test.jsx
+++ b/src/routes/__tests__/TaskVersionsMode/SectionRenderer.test.jsx
@@ -18,6 +18,7 @@ import {
   noDriverNoPaxNoCategoryCounts,
   hasDriverHasPaxHasCategoryCounts,
   noDriverHasPaxHasCategoryCounts,
+  noDriverNoPaxNoCategoryAndNoUnknownCounts,
 } from '../../__fixtures__/section-renderer/sectionRendererTaskDetails';
 
 describe('SectionRenderer', () => {
@@ -1624,7 +1625,8 @@ describe('SectionRenderer', () => {
       const passengersField = hasDriverNoPaxHasCategoryCounts.find(({ propName }) => propName === 'passengers');
       const passengersMetadata = hasDriverNoPaxHasCategoryCounts.find(({ propName }) => propName === 'occupants');
 
-      const section = renderOccupantCarrierCountsSection(driverField, passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
+      const section = renderOccupantCarrierCountsSection(driverField,
+        passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
 
       expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(
         <div className="govuk-task-details-counts-container">
@@ -1666,7 +1668,8 @@ describe('SectionRenderer', () => {
       const passengersField = noDriverNoPaxHasCategoryCounts.find(({ propName }) => propName === 'passengers');
       const passengersMetadata = noDriverNoPaxHasCategoryCounts.find(({ propName }) => propName === 'occupants');
 
-      const section = renderOccupantCarrierCountsSection(driverField, passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
+      const section = renderOccupantCarrierCountsSection(driverField,
+        passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
 
       expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(
         <div className="govuk-task-details-counts-container">
@@ -1709,7 +1712,8 @@ describe('SectionRenderer', () => {
       const passengersField = noDriverNoPaxNoCategoryCounts.find(({ propName }) => propName === 'passengers');
       const passengersMetadata = noDriverNoPaxNoCategoryCounts.find(({ propName }) => propName === 'occupants');
 
-      const section = renderOccupantCarrierCountsSection(driverField, passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
+      const section = renderOccupantCarrierCountsSection(driverField,
+        passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
 
       expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(
         <div className="govuk-task-details-counts-container">
@@ -1734,7 +1738,8 @@ describe('SectionRenderer', () => {
       const passengersField = hasDriverHasPaxHasCategoryCounts.find(({ propName }) => propName === 'passengers');
       const passengersMetadata = hasDriverHasPaxHasCategoryCounts.find(({ propName }) => propName === 'occupants');
 
-      const section = renderOccupantCarrierCountsSection(driverField, passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
+      const section = renderOccupantCarrierCountsSection(driverField,
+        passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
 
       expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(''));
     });
@@ -1744,9 +1749,21 @@ describe('SectionRenderer', () => {
       const passengersField = noDriverHasPaxHasCategoryCounts.find(({ propName }) => propName === 'passengers');
       const passengersMetadata = noDriverHasPaxHasCategoryCounts.find(({ propName }) => propName === 'occupants');
 
-      const section = renderOccupantCarrierCountsSection(driverField, passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
+      const section = renderOccupantCarrierCountsSection(
+        driverField, passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT,
+      );
 
       expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(''));
+    });
+
+    it('should not render category count section there is no driver, no passengers and unknown counts is null', () => {
+      const driverField = noDriverNoPaxNoCategoryAndNoUnknownCounts.find(({ propName }) => propName === 'driver');
+      const passengersField = noDriverNoPaxNoCategoryAndNoUnknownCounts.find(({ propName }) => propName === 'passengers');
+      const passengersMetadata = noDriverNoPaxNoCategoryAndNoUnknownCounts.find(({ propName }) => propName === 'occupants');
+
+      const section = renderOccupantCarrierCountsSection(driverField,
+        passengersField, passengersMetadata, RORO_ACCOMPANIED_FREIGHT);
+      expect(section).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Description
This PR handles the scenario where unknown counts could be null. Initially would display `Nan` if null. This fix does not render the section if this is the case.

## To Test
- Pull & run against dev
- In dev environment load this task [https://www.dev.cerberus.cop.homeoffice.gov.uk/tasks/COKAFOR-10-03-2022-RORO-Accompanied-Freight-NO-OCCUPANT-COUNTS-WITH-UNKNOWN-COUNT_391435:CMID=TEST](url)
- Locally load this task [http://localhost:8080/tasks/COKAFOR-10-03-2022-RORO-Accompanied-Freight-NO-OCCUPANT-COUNTS-WITH-UNKNOWN-COUNT_391435:CMID=TEST](url)

`Outcome`: If unknown count is null, it should not render the section all together.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
