### PR TITLE
COP-9803: Add tests to verify option to alert the frontline if the vehicle may appear in either lane

### DIFF
--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -128,6 +128,12 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.verifySelectDropdown('teamToReceiveTheTarget', targetInfo.groups);
 
       cy.selectDropDownValue('teamToReceiveTheTarget', targetInfo.groups[Math.floor(Math.random() * targetInfo.groups.length)]);
+
+      cy.get('.formio-component-informFreightAndTourist').find('input').should('not.be.checked');
+
+      cy.get('input[name="data[informFreightAndTourist]"]').click();
+
+      cy.get('.formio-component-informFreightAndTourist').find('input').should('be.checked');
     });
 
     cy.clickSubmit();
@@ -479,6 +485,12 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.waitForNoErrors();
 
       cy.selectDropDownValue('teamToReceiveTheTarget', targetInfo.groups[Math.floor(Math.random() * targetInfo.groups.length)]);
+
+      cy.get('.formio-component-informFreightAndTourist').find('input').should('not.be.checked');
+
+      cy.get('input[name="data[informFreightAndTourist]"]').click();
+
+      cy.get('.formio-component-informFreightAndTourist').find('input').should('be.checked');
     });
 
     cy.clickSubmit();
@@ -613,6 +625,12 @@ describe('Issue target from cerberus UI using target sheet information form', ()
       cy.waitForNoErrors();
 
       cy.selectDropDownValue('teamToReceiveTheTarget', targetInfo.groups[Math.floor(Math.random() * targetInfo.groups.length)]);
+
+      cy.get('.formio-component-informFreightAndTourist').find('input').should('not.be.checked');
+
+      cy.get('input[name="data[informFreightAndTourist]"]').click();
+
+      cy.get('.formio-component-informFreightAndTourist').find('input').should('be.checked');
     });
 
     cy.clickSubmit();

--- a/cypress/integration/cerberus/issue-a-target.spec.js
+++ b/cypress/integration/cerberus/issue-a-target.spec.js
@@ -129,11 +129,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
       cy.selectDropDownValue('teamToReceiveTheTarget', targetInfo.groups[Math.floor(Math.random() * targetInfo.groups.length)]);
 
-      cy.get('.formio-component-informFreightAndTourist').find('input').should('not.be.checked');
-
-      cy.get('input[name="data[informFreightAndTourist]"]').click();
-
-      cy.get('.formio-component-informFreightAndTourist').find('input').should('be.checked');
+      cy.SelectInformBothFreightAndTouristOption('informFreightAndTourist');
     });
 
     cy.clickSubmit();
@@ -486,11 +482,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
       cy.selectDropDownValue('teamToReceiveTheTarget', targetInfo.groups[Math.floor(Math.random() * targetInfo.groups.length)]);
 
-      cy.get('.formio-component-informFreightAndTourist').find('input').should('not.be.checked');
-
-      cy.get('input[name="data[informFreightAndTourist]"]').click();
-
-      cy.get('.formio-component-informFreightAndTourist').find('input').should('be.checked');
+      cy.SelectInformBothFreightAndTouristOption('informFreightAndTourist');
     });
 
     cy.clickSubmit();
@@ -626,11 +618,7 @@ describe('Issue target from cerberus UI using target sheet information form', ()
 
       cy.selectDropDownValue('teamToReceiveTheTarget', targetInfo.groups[Math.floor(Math.random() * targetInfo.groups.length)]);
 
-      cy.get('.formio-component-informFreightAndTourist').find('input').should('not.be.checked');
-
-      cy.get('input[name="data[informFreightAndTourist]"]').click();
-
-      cy.get('.formio-component-informFreightAndTourist').find('input').should('be.checked');
+      cy.SelectInformBothFreightAndTouristOption('informFreightAndTourist');
     });
 
     cy.clickSubmit();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -545,30 +545,6 @@ Cypress.Commands.add(('getTaskVersionDetailsDifferenceWithOccupants'), (version,
     console.log(difference);
     return difference;
   });
-  //
-  //
-  //
-  //
-  //
-  //
-  // const occupantArray = [];
-  // cy.get('.task-details-container').each((occupant) => {
-  //   cy.wrap(occupant).find('.govuk-grid-row').each((item) => {
-  //     let obj = {};
-  //     cy.wrap(item).find('.govuk-grid-column-full').each((detail) => {
-  //       cy.wrap(detail).find('.font__light').invoke('text').then((key) => {
-  //         cy.wrap(detail).find('.font__light').nextAll().invoke('text')
-  //             .then((value) => {
-  //               obj[key] = value;
-  //             });
-  //       });
-  //     }).then(() => {
-  //       occupantArray.push(obj);
-  //     });
-  //   });
-  // }).then(() => {
-  //   return occupantArray;
-  // });
 });
 
 Cypress.Commands.add(('getOccupantCounts'), () => {
@@ -960,17 +936,6 @@ Cypress.Commands.add('verifyTaskDetailAllSections', (expectedDetails, versionInR
       });
     });
   }
-  // if (Object.prototype.hasOwnProperty.call(expectedDetails, 'selectorMatch')) {
-  //   let regex = new RegExp('^[0-9]+ selector matches$', 'g');
-  //   cy.get(`[id$=-content-${versionInRow}]`).within(() => {
-  //     cy.contains('h2', regex).then((locator) => {
-  //       cy.getAllRuleMatches(locator).then((actualSelectorMatches) => {
-  //         expect(actualSelectorMatches).to.deep.equal(expectedDetails.selectorMatch);
-  //       });
-  //     });
-  //   });
-  // }
-
   if (Object.prototype.hasOwnProperty.call(expectedDetails, 'TargetingIndicators')) {
     cy.get(`[id$=-content-${versionInRow}]`).within(() => {
       cy.contains('h3', 'Targeting indicators').nextAll().within((elements) => {
@@ -1171,7 +1136,6 @@ Cypress.Commands.add('applyModesFilter', (filterOptions, taskType) => {
   }
 
   cy.contains('Apply filters').click();
-
   cy.wait(2000);
   cy.get(`a[href='#${taskType}']`).invoke('text').then((targets) => {
     return parseInt(targets.match(/\d+/)[0], 10);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1506,3 +1506,11 @@ Cypress.Commands.add('getSelectorGroupInformation', (elements) => {
     return actualSelectorGroupDetails;
   });
 });
+
+Cypress.Commands.add('SelectInformBothFreightAndTouristOption', (elementName) => {
+  cy.get(`${formioComponent}${elementName}`).find('input').should('not.be.checked');
+
+  cy.get(`input[name="data[${elementName}]"]`).click();
+
+  cy.get(`${formioComponent}${elementName}`).find('input').should('be.checked');
+});


### PR DESCRIPTION
## Description
Add tests to verify the following scenario

Scenario 1: Issue target
GIVEN I am completing the Target Information Sheet
WHEN I view the "Recipient Details" page
THEN there is an option to alert the frontline if the vehicle may appear in either lane - "Inform both Freight and Tourist"

## To Test
npm run cypress:runner

run the following tests from spec `issue-a-target.spec.js`

`Should submit a target successfully from a RoRo-Tourist task and it should be moved to target issued tab`
`Should submit a target successfully from a RoRo-accompanied task and it should be moved to target issued tab`
`Should submit a target successfully from a RoRo-Unaccompanied only with Trailer task and it should be moved to target issued tab`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
