### PR TITLE
OP-10255 - Replaces field names for date and time & check-in

### DIFF
--- a/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
+++ b/src/routes/TaskDetails/TaskVersionsMode/SectionRenderer.jsx
@@ -23,6 +23,17 @@ import {
   hasCarrierCounts,
 } from '../../../utils/roroDataUtil';
 
+const replaceFieldName = (fieldName) => {
+  switch (true) {
+    case fieldName === 'Date and time':
+      return 'Booking date and time';
+    case fieldName === 'Check-in':
+      return 'Check-in date and time';
+    default:
+      return fieldName;
+  }
+};
+
 const discardDriver = (passengersField) => {
   const passengers = passengersField;
   const passengersWithNoDriver = passengers.childSets.slice(1);
@@ -50,7 +61,7 @@ const renderFields = (
         <div className={className} key={uuidv4()}>
           <ul>
             <li className="govuk-grid-key font__light">
-              {formatKey(content.type, content.fieldName)}
+              {formatKey(content.type, replaceFieldName(content.fieldName))}
             </li>
             <li className="govuk-grid-value font__bold">
               {link
@@ -110,6 +121,7 @@ const renderGoodsSection = (fieldSet) => {
 const renderBookingSection = (fieldSet) => {
   return renderVersionSection(fieldSet);
 };
+
 const applyHighlightLabel = (name, dob, gender, nationality) => {
   if (
     dob?.type.includes('-CHANGED')

--- a/src/routes/__tests__/TaskVersionsMode/SectionRenderer.test.jsx
+++ b/src/routes/__tests__/TaskVersionsMode/SectionRenderer.test.jsx
@@ -122,6 +122,94 @@ describe('SectionRenderer', () => {
         </div>,
       ));
     });
+
+    it('should render replaced field name for date and time and check-in', () => {
+      const input = {
+        fieldSetName: 'field-set-name',
+        contents: [
+          {
+            fieldName: 'Date and time',
+            type: 'STRING',
+            content: 'value 1',
+            versionLastUpdated: null,
+            propName: 'field1',
+          },
+          {
+            fieldName: 'Check-in',
+            type: 'STRING',
+            content: 'value 2',
+            versionLastUpdated: null,
+            propName: 'field2',
+          },
+        ],
+      };
+
+      const section = renderBookingSection(input);
+
+      expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(
+        <div className="task-details-container bottom-border-thick">
+          <h3 className="title-heading">field-set-name</h3>
+          <div>
+            <div className="govuk-task-details-grid-item">
+              <ul>
+                <li className="govuk-grid-key font__light"><span className="govuk-grid-key font__light">Booking date and time</span></li>
+                <li className="govuk-grid-value font__bold">value 1</li>
+              </ul>
+            </div>
+            <div className="govuk-task-details-grid-item">
+              <ul>
+                <li className="govuk-grid-key font__light"><span className="govuk-grid-key font__light">Check-in date and time</span></li>
+                <li className="govuk-grid-value font__bold">value 2</li>
+              </ul>
+            </div>
+          </div>
+        </div>,
+      ));
+    });
+
+    it('should leave field name for date and time and check-in untouched if not a match', () => {
+      const input = {
+        fieldSetName: 'field-set-name',
+        contents: [
+          {
+            fieldName: 'Date and timee',
+            type: 'STRING',
+            content: 'value 1',
+            versionLastUpdated: null,
+            propName: 'field1',
+          },
+          {
+            fieldName: 'Check-inn',
+            type: 'STRING',
+            content: 'value 2',
+            versionLastUpdated: null,
+            propName: 'field2',
+          },
+        ],
+      };
+
+      const section = renderBookingSection(input);
+
+      expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(
+        <div className="task-details-container bottom-border-thick">
+          <h3 className="title-heading">field-set-name</h3>
+          <div>
+            <div className="govuk-task-details-grid-item">
+              <ul>
+                <li className="govuk-grid-key font__light"><span className="govuk-grid-key font__light">Date and timee</span></li>
+                <li className="govuk-grid-value font__bold">value 1</li>
+              </ul>
+            </div>
+            <div className="govuk-task-details-grid-item">
+              <ul>
+                <li className="govuk-grid-key font__light"><span className="govuk-grid-key font__light">Check-inn</span></li>
+                <li className="govuk-grid-value font__bold">value 2</li>
+              </ul>
+            </div>
+          </div>
+        </div>,
+      ));
+    });
   });
 
   describe('renderVehicleSection', () => {


### PR DESCRIPTION
## Description
This PR replaces the field name displayed in the Booking & check-in section of any movement mode.

## To Test
- Pull & run against dev.
- Select any task, regardless of it's movement mode.
- Verify that the fields highlighted in the image shown below now says
- **FOR:** `Date and time` **REPLACED WITH:** `Booking date and time`
- **FOR:** `Check-in` **REPLACED WITH:** `Check-in date and time`

![Booking   Check-in](https://user-images.githubusercontent.com/19333750/158770244-49a748e4-c7fc-46eb-9b87-fecd554a6568.png)


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
