### PR TITLE
COP-10248 - Changes heading under rule matched in task versions

### DIFF
--- a/src/routes/TaskDetails/TaskVersions.jsx
+++ b/src/routes/TaskDetails/TaskVersions.jsx
@@ -81,6 +81,7 @@ const sortRulesByThreat = (rulesArray) => {
 };
 
 const renderRulesSection = (version) => {
+  const risksTableHeaders = ['Entity type', 'Attribute', 'Operator', 'Value (s)'];
   let rules = version.find(({ propName }) => propName === 'rules').childSets;
   rules = (rules && rules.length > 1) ? sortRulesByThreat(rules) : rules;
   if (rules.length > 0) {
@@ -132,7 +133,7 @@ const renderRulesSection = (version) => {
                       firstRule.childSets.length > 0
                         && (
                           <Table
-                            headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
+                            headings={risksTableHeaders}
                             rows={translateRiskIndicators(firstRule.childSets)}
                           />
                         )
@@ -199,7 +200,7 @@ const renderRulesSection = (version) => {
                             rule.childSets.length > 0
                               && (
                                 <Table
-                                  headings={['Type', 'Condition 1', 'Expression', 'Condition 2']}
+                                  headings={risksTableHeaders}
                                   rows={translateRiskIndicators(rule.childSets)}
                                 />
                               )

--- a/src/routes/__tests__/TaskVersions.test.jsx
+++ b/src/routes/__tests__/TaskVersions.test.jsx
@@ -254,4 +254,20 @@ describe('TaskVersions', () => {
 
     expect(ReactDOMServer.renderToString(section)).toEqual(ReactDOMServer.renderToString(''));
   });
+
+  it('should render table headers when rules matched data is present', () => {
+    const expected = ['Entity type', 'Attribute', 'Operator', 'Value (s)'];
+
+    const { container } = render(<TaskVersions
+      taskSummaryBasedOnTIS={taskSummaryBasedOnTISData}
+      taskVersions={taskSingleVersion}
+      taskVersionDifferencesCounts={[0]}
+      movementMode="RORO Accompanied Freight"
+    />);
+
+    const rulesMatchedElement = container.querySelectorAll('.govuk-table__header');
+    for (let i = 0; i < expected.length - 1; i += 1) {
+      expect(rulesMatchedElement[i].textContent).toEqual(expected[i]);
+    }
+  });
 });


### PR DESCRIPTION
## Description
This PR changes the headers used within the `Rules Matched` section in task details page.

## To Test
- Pull & run against dev
- Find a task with rules matched e.g. [http://localhost:8080/tasks/Shakir-Demo-15-02-2022-Selector-different-versions-task_541666:CMID=TEST](url) and open it

Anywhere we have  headers: **`Type`** | **`Condition 1`** | **`Expression`** | **`Condition 2`**
![image](https://user-images.githubusercontent.com/19333750/159291924-f2a4cddd-da5e-451f-82e1-9931d6f51d2d.png)


Will now be replaced with the following headers: **`Entity Type`** | **`Attribute`** | **`Operation`** | **`Value(s)`**


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
