### PR TITLE
COP-10419: No warnings and Warning currently unavailable are being shown from warningStatus

### DIFF
--- a/src/routes/TaskDetails/TaskVersionsMode/SelectorMatchesTaskVersion.jsx
+++ b/src/routes/TaskDetails/TaskVersionsMode/SelectorMatchesTaskVersion.jsx
@@ -74,14 +74,19 @@ const SelectorMatchesTaskVersion = ({ version }) => {
                 contents = selector?.childSets[0].contents;
                 warnings = selector.contents.find(({ propName }) => propName === 'selectorWarnings')?.content;
                 groupNumber = selector.contents.find(({ propName }) => propName === 'groupNumber').content;
+                const warningStatus = selector.contents.find(({ propName }) => propName === 'warningStatus')?.content;
                 const warningSplit = warnings?.split(',');
                 const containsOther = warningSplit?.indexOf('O') > -1;
-                if (warningSplit?.length > 1 || containsOther || warningCodesMapping[warnings]) {
-                  if (containsOther) {
-                    warningDetails = selector.contents.find(({ propName }) => propName === 'warningDetails').content;
+                if (warningStatus === 'Yes') {
+                  if (warningSplit?.length > 1 || containsOther || warningCodesMapping[warnings]) {
+                    if (containsOther) {
+                      warningDetails = selector.contents.find(({ propName }) => propName === 'warningDetails').content;
+                    }
+                    warnings = warningSplit.map((v) => (v === 'O' ? warningDetails?.substring(0, 500) : warningCodesMapping[v])).join(',');
                   }
-                  warnings = warningSplit.map((v) => (v === 'O' ? warningDetails?.substring(0, 500) : warningCodesMapping[v])).join(',');
                 }
+                if (warningStatus === 'No') warnings = 'No warnings';
+                if (warningStatus === 'Currently unavailable') warnings = 'Warnings currently unavailable';
                 return (
                   <TabPanel key={selectorIndex}>
                     <div className="govuk-grid-row govuk-!-margin-top-1">


### PR DESCRIPTION
## Description
No warnings and Warning currently unavailable are being shown from warningStatus

## To Test
Search for task contains warnings with warningStatus "No" and "Currently unavailable"
For selectors that have warningStatus "No" then **No warnings** message would be shown
For selectors that have warningStatus "Currently unavailable" then **Warnings currently unavailable** message would be shown

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [*] All reviewer comments resolved/answered? \*
