### PR TITLE
COP-10250: Add tests for Aggregated counts in the task list

### DIFF
--- a/cypress/fixtures/RoRo-Freight-Accompanied.json
+++ b/cypress/fixtures/RoRo-Freight-Accompanied.json
@@ -525,7 +525,37 @@
                 },
                 "attributes": null,
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -579,7 +609,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               }
             ],
@@ -664,7 +724,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -747,7 +837,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 5,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 2,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -830,7 +950,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 2,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               }
             ],
@@ -1194,6 +1344,33 @@
                       "valueList": null,
                       "startTimestamp": null,
                       "endTimestamp": null
+                    },
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
                     }
                   }
                 },
@@ -1270,7 +1447,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 2,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -1344,7 +1551,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               }
             ],
@@ -1485,7 +1722,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 6,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null
@@ -1560,7 +1827,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null

--- a/cypress/fixtures/RoRo-Tourist-2-passengers.json
+++ b/cypress/fixtures/RoRo-Tourist-2-passengers.json
@@ -339,7 +339,37 @@
                 },
                 "attributes": null,
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -393,7 +423,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               }
             ],
@@ -478,7 +538,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -561,7 +651,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -644,7 +764,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               }
             ],
@@ -859,7 +1009,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -920,7 +1100,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               }
             ],
@@ -996,7 +1206,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -1070,7 +1310,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               },
               {
@@ -1124,6 +1394,7 @@
                 "url": null,
                 "vehicle": {
                   "type": "OBJVEHCTRL",
+                  "enrichmentCount": "2/-/1",
                   "make": null,
                   "model": null,
                   "vin": null,
@@ -1142,7 +1413,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "changeHistory": null
               }
             ],
@@ -1283,7 +1584,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null
@@ -1358,7 +1689,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null
@@ -1433,7 +1794,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null

--- a/cypress/fixtures/RoRo-Tourist-RBT-SBT.json
+++ b/cypress/fixtures/RoRo-Tourist-RBT-SBT.json
@@ -510,7 +510,7 @@
                     "value": null,
                     "valueList": {
                       "val": [
-                        "Ball|Darren|M|7379|GB|ST2447631|18659|null|PERPAS|ROROXML:P=75045e691849c3afe63cf1ec384bc14a|null"
+                        "Ball|Darren|M|7379|GB|ST2447631|18659|null|PERPAS|ROROXML:P=75045e691849c3afe63cf1ec384bc14a|null|3|2|0"
                       ]
                     },
                     "startTimestamp": null,
@@ -619,7 +619,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null
@@ -683,7 +713,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 7,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null
@@ -760,7 +820,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 1,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 4,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null
@@ -841,7 +931,37 @@
                   }
                 },
                 "matching": null,
-                "features": null,
+                "features": {
+                  "feats": {
+                    "EAB-SEIZURE-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "EAB-EXAMINATION-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 3,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    },
+                    "RORO-MOVEMENT-COUNT": {
+                      "id": null,
+                      "type": "TXE",
+                      "valueType": "INT",
+                      "value": 0,
+                      "valueList": null,
+                      "startTimestamp": null,
+                      "endTimestamp": null
+                    }
+                  }
+                },
                 "washResponses": null,
                 "matchMerge": null,
                 "changeHistory": null

--- a/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
+++ b/cypress/fixtures/RoRo-Unaccompanied-RBT-SBT.json
@@ -323,7 +323,37 @@
            }
           },
           "matching": null,
-          "features": null,
+          "features": {
+           "feats": {
+            "EAB-SEIZURE-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 2,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "EAB-EXAMINATION-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 0,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "RORO-MOVEMENT-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 3,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            }
+           }
+          },
           "washResponses": null,
           "matchMerge": null,
           "changeHistory": null
@@ -379,7 +409,37 @@
            }
           },
           "matching": null,
-          "features": null,
+          "features": {
+           "feats": {
+            "EAB-SEIZURE-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 0,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "EAB-EXAMINATION-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 3,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "RORO-MOVEMENT-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 1,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            }
+           }
+          },
           "washResponses": null,
           "matchMerge": null,
           "changeHistory": null
@@ -430,7 +490,37 @@
           },
           "attributes": null,
           "matching": null,
-          "features": null,
+          "features": {
+           "feats": {
+            "EAB-SEIZURE-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 1,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "EAB-EXAMINATION-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 3,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "RORO-MOVEMENT-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 0,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            }
+           }
+          },
           "changeHistory": null
          }
         ],
@@ -508,6 +598,33 @@
           "matching": null,
           "features": {
            "feats": {
+            "EAB-SEIZURE-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 1,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "EAB-EXAMINATION-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 3,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "RORO-MOVEMENT-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 4,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
             "EMPTY-TRAILER-ON-ROUND-TRIP": {
              "id": null,
              "type": null,
@@ -598,7 +715,37 @@
            }
           },
           "matching": null,
-          "features": null,
+          "features": {
+           "feats": {
+            "EAB-SEIZURE-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 4,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "EAB-EXAMINATION-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 3,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "RORO-MOVEMENT-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 2,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            }
+           }
+          },
           "washResponses": null,
           "matchMerge": null,
           "changeHistory": null
@@ -747,7 +894,37 @@
            }
           },
           "matching": null,
-          "features": null,
+          "features": {
+           "feats": {
+            "EAB-SEIZURE-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 1,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "EAB-EXAMINATION-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 3,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            },
+            "RORO-MOVEMENT-COUNT": {
+             "id": null,
+             "type": "TXE",
+             "valueType": "INT",
+             "value": 4,
+             "valueList": null,
+             "startTimestamp": null,
+             "endTimestamp": null
+            }
+           }
+          },
           "washResponses": null,
           "matchMerge": null,
           "changeHistory": null

--- a/cypress/fixtures/accompanied-task-2-passengers-details.json
+++ b/cypress/fixtures/accompanied-task-2-passengers-details.json
@@ -1,67 +1,105 @@
 {
-  "vehicle": {
-    "Vehicle registration": "IR-9688",
-    "Type": "HGV",
-    "Make": "BMW",
-    "Model": "520D",
-    "Country of registration": "GB",
-    "Colour": "Red"
+  "vehicle-details": {
+    "vehicle": {
+      "Vehicle registration": "IR-9688",
+      "Type": "HGV",
+      "Make": "BMW",
+      "Model": "520D",
+      "Country of registration": "GB",
+      "Colour": "Red"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "4",
+      "Examinations": "0",
+      "Seizures": "1"
+    }
   },
-  "account": {
-    "Full name": "Product of France Wines",
-    "Short name": "Prod of Fr Wines",
-    "Reference number": "PF-6653",
-    "Address": "Unit 82 Central Docks Calais",
-    "Telephone": "0333 637851",
-    "Mobile": "",
-    "Email": ""
+  "account-details": {
+    "account": {
+      "Full name": "Product of France Wines",
+      "Short name": "Prod of Fr Wines",
+      "Reference number": "PF-6653",
+      "Address": "Unit 82 Central Docks Calais",
+      "Telephone": "0333 637851",
+      "Mobile": "Unknown",
+      "Email": "Unknown"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "4",
+      "Examinations": "1",
+      "Seizures": "0"
+    }
   },
-  "haulier":{
-    "Name": "Gondrand UK",
-    "Address": "Unit 82 Central Docks, Canary Wharf, East London, E16 2SR",
-    "Telephone": "020 89637851",
-    "Mobile": ""
+  "haulier-details": {
+    "haulier": {
+      "Name": "Gondrand UK",
+      "Address": "Unit 82 Central Docks, Canary Wharf, East London, E16 2SR",
+      "Telephone": "020 89637851",
+      "Mobile": "Unknown"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "4",
+      "Examinations": "1",
+      "Seizures": "0"
+    }
   },
   "Occupants": [
       {
         "Driver": "Isiaih FordMale, born 09 Oct 1991, DK"
       },
       {
-        "Passport": "566746DL",
+        "Passport": "566746DLUnknown (Unknown)",
         "Validity2 years after travel": "Expires 29 Oct 20232 years after travel"
       },
       {
         "Occupant": "Fred FlintstoneFemale, born 15 Jul 1991, DE"
       },
       {
-        "Passport": "875786876",
+        "Passport": "875786876Germany (DE)",
         "Validity5 days before travel": "Expires 22 Mar 20225 days before travel"
       },
       {
         "Occupant": "Barney RubbleMale, born 12 Jul 1991, GB"
       },
       {
-        "Passport": "244746NL",
+        "Passport": "244746NLUnited Kingdom (GB)",
         "ValidityA year before travel": "Expires 01 Feb 2021A year before travel"
       }
   ],
+  "Occupant-EnrichmentCount": [
+    {
+      "Previous RoRo movements": "4",
+      "Examinations": "3",
+      "Seizures": "1"
+    },
+    {
+      "Previous RoRo movements": "2",
+      "Examinations": "5",
+      "Seizures": "0"
+    }
+  ],
+  "Occupant-hiddenPassenger": {
+    "Previous RoRo movements": "2",
+    "Examinations": "0",
+    "Seizures": "1"
+  },
   "goods": {
     "Description": "Wine",
     "Is cargo hazardous?": "No",
-    "Weight of goods": ""
+    "Weight of goods": "Unknown"
   },
   "Booking-and-check-in": {
     "Reference": "AA123412781",
     "Ticket number": "1234567",
     "Type": "R",
-    "Name": "",
-    "Address": "",
-    "Date and time": "1 Mar 2021 at 15:50, a month before travel",
-    "Country": "GB",
+    "Name": "Unknown",
+    "Address": "Unknown",
+    "Booking date and time": "1 Mar 2021 at 15:50, a month before travel",
+    "Country": "United Kingdom (GB)",
     "Payment method": "CQ",
-    "Ticket price": "",
+    "Ticket price": "Unknown",
     "Ticket type": "Return",
-    "Check-in": ""
+    "Check-in date and time": "Unknown"
   },
   "rules": {
     "Rule name": "Paid by Cash",

--- a/cypress/fixtures/tourist-task-co-travellers.json
+++ b/cypress/fixtures/tourist-task-co-travellers.json
@@ -1,0 +1,58 @@
+{
+  "vehicle-details": {
+    "vehicle": {
+      "Vehicle registration": "HL09YXR",
+      "Type": "HGV",
+      "Make": "Ford",
+      "Model": "Fiesta",
+      "Country of registration": "GB",
+      "Colour": "Unknown"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "0",
+      "Examinations": "3",
+      "Seizures": "0"
+    }
+  },
+  "Occupants": [
+    {
+      "Driver": "Daisy FlowerFemale, born 13 May 1978, GB"
+    },
+    {
+      "Passport": "ST453786United Kingdom (GB)",
+      "Validity2 years after travel": "Expires 01 Feb 20212 years after travel"
+    },
+    {
+      "Occupant": "Darren BallMale, born 16 Mar 1990, GB"
+    },
+    {
+      "Passport": "18659Unknown (Unknown)",
+      "ValidityUnknown": "UnknownUnknown"
+    }
+  ],
+  "Occupant-EnrichmentCount": [
+    {
+      "Previous RoRo movements": "4",
+      "Examinations": "3",
+      "Seizures": "0"
+    },
+    {
+      "Previous RoRo movements": "3",
+      "Examinations": "2",
+      "Seizures": "0"
+    }
+  ],
+  "Booking-and-check-in": {
+    "Reference": "DFDS347376",
+    "Ticket number": "DFDS-1000974",
+    "Type": "Online",
+    "Name": "Dean Fulton",
+    "Address": "Unknown",
+    "Booking date and time": "3 Aug 2020 at 11:25, a day before travel",
+    "Country": "Unknown",
+    "Payment method": "Other",
+    "Ticket price": "Unknown",
+    "Ticket type": "Single",
+    "Check-in date and time": "4 Aug 2020 at 18:40, an hour before travel"
+  }
+}

--- a/cypress/fixtures/tourist-task-details.json
+++ b/cypress/fixtures/tourist-task-details.json
@@ -1,46 +1,70 @@
 {
-  "vehicle": {
-    "Vehicle registration": "IR-9688",
-    "Type": "HGV",
-    "Make": "AUDI",
-    "Model": "V9",
-    "Country of registration": "GB",
-    "Colour": "WHITE"
+  "vehicle-details": {
+    "vehicle": {
+      "Vehicle registration": "IR-9688",
+      "Type": "HGV",
+      "Make": "AUDI",
+      "Model": "V9",
+      "Country of registration": "GB",
+      "Colour": "WHITE"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "4",
+      "Examinations": "3",
+      "Seizures": "1"
+    }
   },
   "Occupants": [
     {
       "Driver": "Isiaih FordMale, born 13 Oct 1991, AUS"
     },
     {
-      "Passport": "566746DL",
+      "Passport": "566746DLUnknown (Unknown)",
       "Validity2 years after travel": "Expires 29 Oct 20232 years after travel"
     },
     {
       "Occupant": "Fred FlintstoneFemale, born 22 Nov 1991, DE"
     },
     {
-      "Passport": "875786876",
+      "Passport": "875786876Germany (DE)",
       "Validity5 days before travel": "Expires 22 Mar 20225 days before travel"
     },
     {
       "Occupant": "Barney RubbleMale, born 01 Mar 1989, GB"
     },
     {
-      "Passport": "244746NL",
+      "Passport": "244746NLUnited Kingdom (GB)",
       "ValidityA year before travel": "Expires 01 Feb 2021A year before travel"
     }
   ],
+  "Occupant-EnrichmentCount": [
+    {
+      "Previous RoRo movements": "4",
+      "Examinations": "3",
+      "Seizures": "1"
+    },
+    {
+      "Previous RoRo movements": "4",
+      "Examinations": "3",
+      "Seizures": "1"
+    }
+  ],
+  "Occupant-hiddenPassenger": {
+    "Previous RoRo movements": "4",
+    "Examinations": "3",
+    "Seizures": "1"
+  },
   "Booking-and-check-in": {
     "Reference": "AB555412781",
     "Ticket number": "1234567",
     "Type": "R",
-    "Name": "",
-    "Address": "",
-    "Date and time": "2 Aug 2020 at 15:50, 5 days before travel",
-    "Country": "GB",
+    "Name": "Unknown",
+    "Address": "Unknown",
+    "Booking date and time": "2 Aug 2020 at 15:50, 5 days before travel",
+    "Country": "United Kingdom (GB)",
     "Payment method": "CQ",
-    "Ticket price": "",
+    "Ticket price": "Unknown",
     "Ticket type": "Return",
-    "Check-in": ""
+    "Check-in date and time": "Unknown"
   }
 }

--- a/cypress/fixtures/unaccompanied-task-details.json
+++ b/cypress/fixtures/unaccompanied-task-details.json
@@ -1,44 +1,65 @@
 {
-  "vehicle": {
-    "Trailer registration number": "GB07GYT",
-    "Trailer type": "Tanker",
-    "Trailer country of registration": "DK",
-    "Empty or loaded": "Empty",
-    "Trailer length": "36m",
-    "Trailer height": "3.6m"
+  "trailer-details": {
+    "trailer": {
+      "Trailer registration number": "GB07GYT",
+      "Trailer type": "Tanker",
+      "Trailer country of registration": "DK",
+      "Empty or loaded": "Empty",
+      "Trailer length": "36m",
+      "Trailer height": "3.6m"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "4",
+      "Examinations": "3",
+      "Seizures": "1"
+    }
   },
-  "account": {
-    "Full name": "DPE logistics",
-    "Short name": "",
-    "Reference number": "000524557",
-    "Address": "John Tranums Vei Esjerg DK",
-    "Telephone": "045 76 12 1493",
-    "Mobile": "",
-    "Email": ""
+  "account-details": {
+    "account": {
+      "Full name": "DPE logistics",
+      "Short name": "Unknown",
+      "Reference number": "000524557",
+      "Address": "John Tranums Vei Esjerg DK",
+      "Telephone": "045 76 12 1493",
+      "Mobile": "Unknown",
+      "Email": "Unknown"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "1",
+      "Examinations": "3",
+      "Seizures": "0"
+    }
   },
-  "haulier": {
-    "Name": "Haulier Auto Test UK",
-    "Address": "Unit 82 Central Docks, Canary Wharf, East London, E16 2SR",
-    "Mobile": "",
-    "Telephone": ""
+  "haulier-details": {
+    "haulier": {
+      "Name": "Haulier Auto Test UK",
+      "Address": "Unit 82 Central Docks, Canary Wharf, East London, E16 2SR",
+      "Telephone": "Unknown",
+      "Mobile": "Unknown"
+    },
+    "enrichmentCount": {
+      "Previous RoRo movements": "0",
+      "Examinations": "3",
+      "Seizures": "1"
+    }
   },
   "goods": {
     "Description": "Corkscrews",
     "Is cargo hazardous?": "No",
-    "Weight of goods": ""
+    "Weight of goods": "Unknown"
   },
   "Booking-and-check-in": {
     "Reference": "AA000000006",
     "Ticket number": "ST-34560",
-    "Type": "",
+    "Type": "Unknown",
     "Name": "Susan Tower",
-    "Address": "",
-    "Date and time": "4 Mar 2022 at 09:15, a year ago",
-    "Country": "GB",
-    "Payment method": "",
-    "Ticket price": "",
+    "Address": "Unknown",
+    "Booking date and time": "4 Mar 2022 at 09:15, a year ago",
+    "Country": "United Kingdom (GB)",
+    "Payment method": "Unknown",
+    "Ticket price": "Unknown",
     "Ticket type": "Single",
-    "Check-in": "2 Mar 2022 at 11:05, a year ago"
+    "Check-in date and time": "2 Mar 2022 at 11:05, a year ago"
   },
   "vessel": {
     "name": "NORMANDIE",

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -70,6 +70,38 @@ describe('Create task with different payload from Cerberus', () => {
         cy.checkTaskDisplayed(`${response.businessKey}`);
         cy.checkTaskSummary(registrationNumber, taskCreationDateTime);
       });
+
+      cy.fixture('tourist-task-co-travellers.json').then((expectedDetails) => {
+        cy.contains('h3', 'Vehicle').nextAll().within((elements) => {
+          cy.getEnrichmentCounts(elements).then((count) => {
+            expect(count).to.deep.equal(expectedDetails['vehicle-details'].enrichmentCount);
+          });
+          cy.getVehicleDetails(elements).then((details) => {
+            expect(details).to.deep.equal(expectedDetails['vehicle-details'].vehicle);
+          });
+        });
+
+        cy.get('[id$=-content-1]').within(() => {
+          cy.get('.govuk-task-details-col-3').within(() => {
+            cy.get('.task-details-container').each((occupant, index) => {
+              cy.wrap(occupant).find('.enrichment-counts').within((elements) => {
+                cy.getEnrichmentCounts(elements).then((count) => {
+                  expect(count).to.deep.equal(expectedDetails['Occupant-EnrichmentCount'][index]);
+                });
+              });
+            });
+            cy.getOccupantDetails().then((actualoccupantDetails) => {
+              expect(actualoccupantDetails).to.deep.equal(expectedDetails.Occupants);
+            });
+          });
+        });
+
+        cy.contains('h3', 'Booking and check-in').next().within(() => {
+          cy.getTaskDetails().then((details) => {
+            expect(details).to.deep.equal(expectedDetails['Booking-and-check-in']);
+          });
+        });
+      });
     });
   });
 
@@ -183,7 +215,7 @@ describe('Create task with different payload from Cerberus', () => {
       'bookedOn': 'Booked on 02/08/2020',
       'booked': 'Booked 5 days before travel',
       'travellers': [
-        'None',
+        ' ',
       ],
     };
 

--- a/cypress/integration/cerberus/task-version-details.spec.js
+++ b/cypress/integration/cerberus/task-version-details.spec.js
@@ -44,23 +44,31 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.expandTaskDetails(0);
 
     cy.fixture('unaccompanied-task-details.json').then((expectedDetails) => {
-      cy.contains('h3', 'Account details').next().within(() => {
+      cy.contains('h3', 'Account details').nextAll().within((elements) => {
+        cy.getEnrichmentCounts(elements).then((count) => {
+          expect(count).to.deep.equal(expectedDetails['account-details'].enrichmentCount);
+        });
         cy.getTaskDetails().then((details) => {
           console.log(expectedDetails.account);
-          console.log('actual', details);
-          expect(expectedDetails.account).to.deep.equal(details);
+          expect(details).to.deep.equal(expectedDetails['account-details'].account);
         });
       });
 
-      cy.contains('h3', 'Trailer').next().within((elements) => {
+      cy.contains('h3', 'Trailer').nextAll().within((elements) => {
+        cy.getEnrichmentCounts(elements).then((count) => {
+          expect(count).to.deep.equal(expectedDetails['trailer-details'].enrichmentCount);
+        });
         cy.getVehicleDetails(elements).then((details) => {
-          expect(details).to.deep.equal(expectedDetails.vehicle);
+          expect(details).to.deep.equal(expectedDetails['trailer-details'].trailer);
         });
       });
 
-      cy.contains('h3', 'Haulier details').next().within(() => {
+      cy.contains('h3', 'Haulier details').nextAll().within((elements) => {
+        cy.getEnrichmentCounts(elements).then((count) => {
+          expect(count).to.deep.equal(expectedDetails['haulier-details'].enrichmentCount);
+        });
         cy.getTaskDetails().then((details) => {
-          expect(expectedDetails.haulier).to.deep.equal(details);
+          expect(details).to.deep.equal(expectedDetails['haulier-details'].haulier);
         });
       });
 
@@ -259,14 +267,33 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.expandTaskDetails(0);
 
     cy.fixture('tourist-task-details.json').then((expectedDetails) => {
-      cy.contains('h3', 'Vehicle').next().within((elements) => {
+      cy.contains('h3', 'Vehicle').nextAll().within((elements) => {
+        cy.getEnrichmentCounts(elements).then((count) => {
+          console.log(count);
+          expect(count).to.deep.equal(expectedDetails['vehicle-details'].enrichmentCount);
+        });
         cy.getVehicleDetails(elements).then((details) => {
-          expect(details).to.deep.equal(expectedDetails.vehicle);
+          expect(details).to.deep.equal(expectedDetails['vehicle-details'].vehicle);
         });
       });
 
       cy.get('[id$=-content-1]').within(() => {
         cy.get('.govuk-task-details-col-3').within(() => {
+          cy.get('.task-details-container').each((occupant, index) => {
+            cy.wrap(occupant).find('.enrichment-counts').within((elements) => {
+              cy.getEnrichmentCounts(elements).then((count) => {
+                console.log(count);
+                expect(count).to.deep.equal(expectedDetails['Occupant-EnrichmentCount'][index]);
+              });
+            });
+          });
+
+          cy.get('.govuk-hidden-passengers').find('.enrichment-counts').within((elements) => {
+            cy.getEnrichmentCounts(elements).then((count) => {
+              console.log(count);
+              expect(count).to.deep.equal(expectedDetails['Occupant-hiddenPassenger']);
+            });
+          });
           cy.getOccupantDetails().then((actualoccupantDetails) => {
             console.log(actualoccupantDetails);
             expect(actualoccupantDetails).to.deep.equal(expectedDetails.Occupants);
@@ -303,26 +330,53 @@ describe('Task Details of different tasks on task details Page', () => {
     cy.expandTaskDetails(0);
 
     cy.fixture('accompanied-task-2-passengers-details.json').then((expectedDetails) => {
-      cy.contains('h3', 'Vehicle').next().within((elements) => {
+      cy.contains('h3', 'Vehicle').nextAll().within((elements) => {
+        cy.getEnrichmentCounts(elements).then((count) => {
+          console.log(count);
+          expect(count).to.deep.equal(expectedDetails['vehicle-details'].enrichmentCount);
+        });
         cy.getVehicleDetails(elements).then((details) => {
-          expect(details).to.deep.equal(expectedDetails.vehicle);
+          expect(details).to.deep.equal(expectedDetails['vehicle-details'].vehicle);
         });
       });
 
-      cy.contains('h3', 'Account details').next().within(() => {
+      cy.contains('h3', 'Account details').nextAll().within((elements) => {
+        cy.getEnrichmentCounts(elements).then((count) => {
+          console.log(count);
+          expect(count).to.deep.equal(expectedDetails['account-details'].enrichmentCount);
+        });
         cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.account);
+          expect(details).to.deep.equal(expectedDetails['account-details'].account);
         });
       });
 
-      cy.contains('h3', 'Haulier details').next().within(() => {
+      cy.contains('h3', 'Haulier details').nextAll().within((elements) => {
+        cy.getEnrichmentCounts(elements).then((count) => {
+          console.log(count);
+          expect(count).to.deep.equal(expectedDetails['haulier-details'].enrichmentCount);
+        });
         cy.getTaskDetails().then((details) => {
-          expect(details).to.deep.equal(expectedDetails.haulier);
+          expect(details).to.deep.equal(expectedDetails['haulier-details'].haulier);
         });
       });
 
       cy.get('[id$=-content-1]').within(() => {
         cy.get('.govuk-task-details-col-3').within(() => {
+          cy.get('.task-details-container').each((occupant, index) => {
+            cy.wrap(occupant).find('.enrichment-counts').within((elements) => {
+              cy.getEnrichmentCounts(elements).then((count) => {
+                console.log(count);
+                expect(count).to.deep.equal(expectedDetails['Occupant-EnrichmentCount'][index]);
+              });
+            });
+          });
+
+          cy.get('.govuk-hidden-passengers').find('.enrichment-counts').within((elements) => {
+            cy.getEnrichmentCounts(elements).then((count) => {
+              console.log(count);
+              expect(count).to.deep.equal(expectedDetails['Occupant-hiddenPassenger']);
+            });
+          });
           cy.getOccupantDetails().then((actualoccupantDetails) => {
             console.log(actualoccupantDetails);
             expect(actualoccupantDetails).to.deep.equal(expectedDetails.Occupants);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -472,7 +472,7 @@ Cypress.Commands.add('getTargetIndicatorDetails', () => {
 
 Cypress.Commands.add(('getVehicleDetails'), (elements) => {
   const obj = {};
-  cy.wrap(elements).each((item) => {
+  cy.wrap(elements).eq(1).each((item) => {
     cy.wrap(item).find('div ul').each((detail) => {
       cy.wrap(detail).find('span.govuk-grid-key').invoke('text').then((key) => {
         cy.wrap(detail).find('.govuk-grid-value').invoke('text').then((value) => {
@@ -485,10 +485,35 @@ Cypress.Commands.add(('getVehicleDetails'), (elements) => {
   });
 });
 
+Cypress.Commands.add(('getEnrichmentCounts'), (elements) => {
+  let obj = {};
+  const keys = [];
+  const values = [];
+  cy.wrap(elements).eq(0).within(() => {
+    cy.get('.labels .govuk-grid-column-one-third').each((item) => {
+      cy.wrap(item).find('span.font__light').invoke('text').then((key) => {
+        keys.push(key);
+      });
+    });
+    cy.get('.values .govuk-grid-column-one-third').each((value) => {
+      cy.wrap(value).find('span.font__bold').invoke('text').then((count) => {
+        values.push(count);
+      });
+    });
+  }).then(() => {
+    keys.forEach((k, i) => {
+      obj[k] = values[i];
+    });
+  })
+    .then(() => {
+      return obj;
+    });
+});
+
 Cypress.Commands.add(('getOccupantDetails'), () => {
   const occupantArray = [];
   cy.get('.task-details-container').each((occupant) => {
-    cy.wrap(occupant).find('.govuk-grid-row').each((item) => {
+    cy.wrap(occupant).find('.govuk-grid-row:not(.enrichment-counts)').each((item) => {
       let obj = {};
       cy.wrap(item).find('.govuk-grid-column-full').each((detail) => {
         cy.wrap(detail).find('.font__light').invoke('text').then((key) => {


### PR DESCRIPTION
## Description
Add tests for checking Enrichment count for different modes of tasks

Scenario 1: Entity in Task details with previous movements
GIVEN an entity has had previous movements
WHEN the entity is displayed in the task details
THEN the number of previous movements/Examinations/Seizures is displayed under the heading

An entity can be an Driver/Lead passenger, Occupant, Vehicle, Trailer, Haulier, Account

## To Test
run the following tests from spec `task-version-details.spec.js`

`Should verify task version details of unaccompanied task on task details page`
`Should verify task version details of tourist task on task details page`
`Should verify task version details of accompanied task with 2 passengers on task details page`

run the following test from `create-tasks.spec.js` to check the counts of a task with Co-travellers
`Should create a task with a payload contains RoRo Tourist from RBT & SBT`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
