### PR TITLE
COP-10625: fixes occupants counts not showing up

### DIFF
--- a/src/utils/__tests__/roroDataUtil.test.jsx
+++ b/src/utils/__tests__/roroDataUtil.test.jsx
@@ -2,6 +2,7 @@ import { modifyRoRoPassengersTaskList,
   hasCheckinDate,
   hasEta,
   hasCarrierCounts,
+  hasTaskVersionPassengers,
   extractTaskVersionsBookingField,
   modifyCountryCodeIfPresent } from '../roroDataUtil';
 
@@ -213,5 +214,149 @@ describe('RoRoData Util', () => {
     };
     const result = modifyCountryCodeIfPresent(bookingFieldMinified);
     expect(result.contents?.find(({ propName }) => propName === 'country').content).toBeFalsy();
+  });
+
+  it('should return false for absence of a valid passenger when not found', () => {
+    const given = {
+      fieldSetName: 'Passengers',
+      hasChildSet: true,
+      contents: [],
+      childSets: [
+        {
+          fieldSetName: '',
+          hasChildSet: false,
+          contents: [
+            {
+              fieldName: 'Name',
+              type: 'STRING',
+              content: null,
+              versionLastUpdated: null,
+              propName: 'name',
+            },
+            {
+              fieldName: 'Date of birth',
+              type: 'SHORT_DATE',
+              content: null,
+              versionLastUpdated: null,
+              propName: 'dob',
+            },
+            {
+              fieldName: 'Enrichment count',
+              type: 'HIDDEN',
+              content: '-/-/-',
+              versionLastUpdated: null,
+              propName: 'enrichmentCount',
+            },
+          ],
+          type: 'null',
+          propName: '',
+        },
+        {
+          fieldSetName: '',
+          hasChildSet: false,
+          contents: [
+            {
+              fieldName: 'Name',
+              type: 'STRING',
+              content: null,
+              versionLastUpdated: null,
+              propName: 'name',
+            },
+            {
+              fieldName: 'Date of birth',
+              type: 'SHORT_DATE',
+              content: null,
+              versionLastUpdated: null,
+              propName: 'dob',
+            },
+            {
+              fieldName: 'Enrichment count',
+              type: 'HIDDEN',
+              content: '-/-/1',
+              versionLastUpdated: null,
+              propName: 'enrichmentCount',
+            },
+          ],
+          type: 'null',
+          propName: '',
+        },
+      ],
+      type: 'STANDARD',
+      propName: 'passengers',
+    };
+    const outcome = hasTaskVersionPassengers(given);
+    expect(outcome).toEqual(false);
+  });
+
+  it('should return true for presence of a valid passenger when found', () => {
+    const given = {
+      fieldSetName: 'Passengers',
+      hasChildSet: true,
+      contents: [],
+      childSets: [
+        {
+          fieldSetName: '',
+          hasChildSet: false,
+          contents: [
+            {
+              fieldName: 'Name',
+              type: 'STRING',
+              content: 'JOE BLOGGS',
+              versionLastUpdated: null,
+              propName: 'name',
+            },
+            {
+              fieldName: 'Date of birth',
+              type: 'SHORT_DATE',
+              content: null,
+              versionLastUpdated: null,
+              propName: 'dob',
+            },
+            {
+              fieldName: 'Enrichment count',
+              type: 'HIDDEN',
+              content: '-/-/-',
+              versionLastUpdated: null,
+              propName: 'enrichmentCount',
+            },
+          ],
+          type: 'null',
+          propName: '',
+        },
+        {
+          fieldSetName: '',
+          hasChildSet: false,
+          contents: [
+            {
+              fieldName: 'Name',
+              type: 'STRING',
+              content: 'JOHN CHEESE',
+              versionLastUpdated: null,
+              propName: 'name',
+            },
+            {
+              fieldName: 'Date of birth',
+              type: 'SHORT_DATE',
+              content: null,
+              versionLastUpdated: null,
+              propName: 'dob',
+            },
+            {
+              fieldName: 'Enrichment count',
+              type: 'HIDDEN',
+              content: '-/-/-',
+              versionLastUpdated: null,
+              propName: 'enrichmentCount',
+            },
+          ],
+          type: 'null',
+          propName: '',
+        },
+      ],
+      type: 'STANDARD',
+      propName: 'passengers',
+    };
+    const outcome = hasTaskVersionPassengers(given);
+    expect(outcome).toEqual(true);
   });
 });

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -62,17 +62,15 @@ const hasDepartureTime = (departureTime) => {
   return departureTime !== null && departureTime !== undefined && departureTime !== '';
 };
 
+// Checks for presence of at least a valid passenger
 const hasTaskVersionPassengers = (passengers) => {
-  let hasValidPassengers = false;
   for (const passengerChildSets of passengers.childSets) {
-    for (const passenger of passengerChildSets.contents) {
-      if (passenger.content !== null) {
-        hasValidPassengers = true;
-        break;
-      }
+    const passengerName = passengerChildSets.contents.find(({ propName }) => propName === 'name').content;
+    if (passengerName) {
+      return true;
     }
   }
-  return hasValidPassengers;
+  return false;
 };
 
 const isTaskDetailsPassenger = (passenger) => {


### PR DESCRIPTION
## Description
This PR displays the category counts on a task in task details. This information is rendered for either a RoRo Accompanied Freight | RoRo Tourist movement.

## To Test
The category are rendered based on the following conditions:

Scenario 1
Has driver: FALSE
Has passenger(s): FALSE
Has category counts: TRUE
Outcome: SHOW CATEGORY COUNTS

Scenario 2
Has driver: TRUE
Has passenger(s): FALSE
Has category counts: TRUE
Outcome: SHOW CATEGORY COUNTS

Scenario 3
Has driver: FALSE
Has passenger(s): FALSE
Has category counts: FALSE
Outcome: SHOW UNKNOWN COUNTS ONLY

Scenario 4
Has driver: TRUE
Has passenger(s): TRUE
Has category counts: TRUE | FALSE
Outcome: DO NOT SHOW CATEGORY COUNTS

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [*] All reviewer comments resolved/answered? \*
