### PR TITLE
COP-10677 - movement mode icon mismatch

### DIFF
--- a/src/routes/roro/TaskDetails/TaskSummary.jsx
+++ b/src/routes/roro/TaskDetails/TaskSummary.jsx
@@ -4,7 +4,7 @@ import utc from 'dayjs/plugin/utc';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { LONG_DATE_FORMAT, RORO_TOURIST, INDIVIDUAL_ICON, GROUP_ICON } from '../../../constants';
 import getMovementModeIcon from '../../../utils/getVehicleModeIcon';
-import { modifyRoRoPassengersTaskList, hasVehicle, hasTrailer, hasDriver } from '../../../utils/roroDataUtil';
+import { modifyRoRoPassengersTaskList, hasVehicle, hasTrailer, hasDriver, filterKnownPassengers } from '../../../utils/roroDataUtil';
 import { formatMovementModeIconText } from '../../../utils/stringConversion';
 
 import '../__assets__/TaskDetailsPage.scss';
@@ -19,7 +19,8 @@ const getCaptionText = (movementModeIcon) => {
 };
 
 const getSummaryFirstHalf = (movementMode, roroData) => {
-  const movementModeIcon = getMovementModeIcon(movementMode, roroData.vehicle, roroData.passengers);
+  const actualPassengers = filterKnownPassengers(roroData.passengers);
+  const movementModeIcon = getMovementModeIcon(movementMode, roroData.vehicle, actualPassengers);
   if (movementMode === RORO_TOURIST) {
     if (movementModeIcon === INDIVIDUAL_ICON || movementModeIcon === GROUP_ICON) {
       const captionText = getCaptionText(movementModeIcon);
@@ -27,8 +28,8 @@ const getSummaryFirstHalf = (movementMode, roroData) => {
         <li>
           <span className="govuk-caption-m">{captionText}</span>
           <h3 className="govuk-heading-s">
-            {roroData.passengers.length === 1 && <span className="govuk-!-font-weight-bold">1 foot passenger</span>}
-            {roroData.passengers.length > 1 && <span className="govuk-!-font-weight-bold">{roroData.passengers.length} foot passengers</span>}
+            {actualPassengers.length === 1 && <span className="govuk-!-font-weight-bold">1 foot passenger</span>}
+            {actualPassengers.length > 1 && <span className="govuk-!-font-weight-bold">{actualPassengers.length} foot passengers</span>}
           </h3>
         </li>
       );

--- a/src/routes/roro/TaskLists/TaskListMode.jsx
+++ b/src/routes/roro/TaskLists/TaskListMode.jsx
@@ -7,7 +7,7 @@ import * as constants from '../../../constants';
 // Utils
 import calculateTimeDifference from '../../../utils/calculateDatetimeDifference';
 import formatGender from '../../../utils/genderFormatter';
-import { hasVehicleMake, hasVehicleModel, hasVehicle, hasTrailer } from '../../../utils/roroDataUtil';
+import { hasVehicleMake, hasVehicleModel, hasVehicle, hasTrailer, filterKnownPassengers } from '../../../utils/roroDataUtil';
 
 const getMovementModeTypeText = (movementModeIcon) => {
   switch (movementModeIcon) {
@@ -24,6 +24,7 @@ const getMovementModeTypeText = (movementModeIcon) => {
 };
 
 const getMovementModeTypeContent = (roroData, movementModeIcon, passengers) => {
+  const actualPassengers = filterKnownPassengers(passengers);
   switch (movementModeIcon) {
     case constants.RORO_TOURIST_CAR_ICON: {
       return !roroData.vehicle.registrationNumber ? '\xa0' : roroData.vehicle.registrationNumber.toUpperCase();
@@ -32,7 +33,7 @@ const getMovementModeTypeContent = (roroData, movementModeIcon, passengers) => {
       return '1 foot passenger';
     }
     default: {
-      return passengers !== undefined ? `${passengers.length} foot passengers` : '0';
+      return actualPassengers ? `${actualPassengers.length} foot passengers` : '0';
     }
   }
 };

--- a/src/utils/__tests__/roroDataUtil.test.jsx
+++ b/src/utils/__tests__/roroDataUtil.test.jsx
@@ -4,7 +4,9 @@ import { modifyRoRoPassengersTaskList,
   hasCarrierCounts,
   hasTaskVersionPassengers,
   extractTaskVersionsBookingField,
-  modifyCountryCodeIfPresent } from '../roroDataUtil';
+  modifyCountryCodeIfPresent,
+  isSinglePassenger,
+  filterKnownPassengers } from '../roroDataUtil';
 
 import { testRoroData } from '../__fixtures__/roroData.fixture';
 
@@ -358,5 +360,191 @@ describe('RoRoData Util', () => {
     };
     const outcome = hasTaskVersionPassengers(given);
     expect(outcome).toEqual(true);
+  });
+
+  it('should return true when there is only one passenger', () => {
+    const passengers = [
+      {
+        name: 'JIMS CHEESES',
+        dob: '',
+      },
+      {
+        name: '',
+        dob: '',
+      },
+    ];
+
+    const outcome = isSinglePassenger(passengers);
+    expect(outcome).toBeTruthy();
+  });
+
+  it('should return false when there is more than one passenger', () => {
+    const passengers = [
+      {
+        name: 'JIMS CHEESE',
+        dob: '',
+      },
+      {
+        name: 'ISIAH FORD',
+        dob: '',
+      },
+    ];
+
+    const outcome = isSinglePassenger(passengers);
+    expect(outcome).toBeFalsy();
+  });
+
+  it('should return only one actual passenger', () => {
+    const passengers = [
+      {
+        name: 'JIMS CHEESES',
+        dob: '',
+      },
+      {
+        name: '',
+        dob: '',
+      },
+    ];
+
+    const expected = [
+      {
+        name: 'JIMS CHEESES',
+        dob: '',
+      },
+    ];
+
+    const outcome = filterKnownPassengers(passengers);
+    expect(outcome).toEqual(expected);
+  });
+
+  it('should return two actual passengers', () => {
+    const passengers = [
+      {
+        name: 'JIMS CHEESES',
+        dob: '',
+      },
+      {
+        name: 'ISIAH FORD',
+        dob: '',
+      },
+    ];
+
+    const expected = [
+      {
+        name: 'JIMS CHEESES',
+        dob: '',
+      },
+      {
+        name: 'ISIAH FORD',
+        dob: '',
+      },
+    ];
+
+    const outcome = filterKnownPassengers(passengers);
+    expect(outcome).toEqual(expected);
+  });
+
+  it('should return true when there is only one task details passenger)', () => {
+    const passengers = [
+      {
+        fieldSetName: '',
+        hasChildSet: false,
+        contents: [
+          {
+            fieldName: 'Name',
+            type: 'STRING',
+            content: 'Isiah Ford',
+            versionLastUpdated: null,
+            propName: 'name',
+          },
+          {
+            fieldName: 'Date of birth',
+            type: 'SHORT_DATE',
+            content: null,
+            versionLastUpdated: null,
+            propName: 'dob',
+          },
+        ],
+        type: 'null',
+        propName: '',
+      },
+      {
+        fieldSetName: '',
+        hasChildSet: false,
+        contents: [
+          {
+            fieldName: 'Name',
+            type: 'STRING',
+            content: null,
+            versionLastUpdated: null,
+            propName: 'name',
+          },
+          {
+            fieldName: 'Date of birth',
+            type: 'SHORT_DATE',
+            content: null,
+            versionLastUpdated: null,
+            propName: 'dob',
+          },
+        ],
+        type: 'null',
+        propName: '',
+      },
+    ];
+
+    const outcome = isSinglePassenger(passengers);
+    expect(outcome).toBeTruthy();
+  });
+
+  it('should return false when there is more than one task details passengers)', () => {
+    const passengers = [
+      {
+        fieldSetName: '',
+        hasChildSet: false,
+        contents: [
+          {
+            fieldName: 'Name',
+            type: 'STRING',
+            content: 'Isiah Ford',
+            versionLastUpdated: null,
+            propName: 'name',
+          },
+          {
+            fieldName: 'Date of birth',
+            type: 'SHORT_DATE',
+            content: null,
+            versionLastUpdated: null,
+            propName: 'dob',
+          },
+        ],
+        type: 'null',
+        propName: '',
+      },
+      {
+        fieldSetName: '',
+        hasChildSet: false,
+        contents: [
+          {
+            fieldName: 'Name',
+            type: 'STRING',
+            content: 'JOHN CHEESE',
+            versionLastUpdated: null,
+            propName: 'name',
+          },
+          {
+            fieldName: 'Date of birth',
+            type: 'SHORT_DATE',
+            content: null,
+            versionLastUpdated: null,
+            propName: 'dob',
+          },
+        ],
+        type: 'null',
+        propName: '',
+      },
+    ];
+
+    const outcome = isSinglePassenger(passengers);
+    expect(outcome).toBeFalsy();
   });
 });

--- a/src/utils/getVehicleModeIcon.jsx
+++ b/src/utils/getVehicleModeIcon.jsx
@@ -1,13 +1,11 @@
 import { RORO_ACCOMPANIED_ICON, RORO_NO_ICON, RORO_TOURIST, RORO_TOURIST_CAR_ICON, GROUP_ICON,
   INDIVIDUAL_ICON, RORO_UNACCOMPANIED_ICON, RORO_VAN_ICON } from '../constants';
 
+import { isSinglePassenger } from './roroDataUtil';
+
 const isVehiclePresent = (vehicle) => {
   return vehicle?.registrationNumber && vehicle?.registrationNumber !== ''
     && vehicle?.registrationNumber !== null && vehicle?.registrationNumber !== undefined;
-};
-
-const isIndividualPassenger = (passengers) => {
-  return passengers && passengers?.length === 1;
 };
 
 const hasTrailer = (vehicle) => {
@@ -20,7 +18,7 @@ const getTouristIcon = (vehicle, passengers) => {
     return RORO_TOURIST_CAR_ICON;
   }
 
-  if (!isVehiclePresent(vehicle) && isIndividualPassenger(passengers)) {
+  if (!isVehiclePresent(vehicle) && isSinglePassenger(passengers)) {
     return INDIVIDUAL_ICON;
   }
 

--- a/src/utils/roroDataUtil.jsx
+++ b/src/utils/roroDataUtil.jsx
@@ -62,6 +62,37 @@ const hasDepartureTime = (departureTime) => {
   return departureTime !== null && departureTime !== undefined && departureTime !== '';
 };
 
+const getNamedPassenger = (passenger) => {
+  if (passenger?.contents) {
+    let hasName = false;
+    passenger.contents.map(({ propName, content }) => {
+      if (propName === 'name') {
+        hasName = !!content;
+      }
+    });
+    return hasName && passenger;
+  }
+};
+
+const filterKnownPassengers = (passengers) => {
+  return passengers.filter((passenger) => {
+    if (passenger?.name) {
+      return passenger;
+    }
+    return getNamedPassenger(passenger);
+  });
+};
+
+const isSinglePassenger = (passengers) => {
+  const filteredPassengers = passengers.filter((passenger) => {
+    if (passenger?.name) {
+      return passenger;
+    }
+    return getNamedPassenger(passenger);
+  });
+  return filteredPassengers && filteredPassengers?.length === 1;
+};
+
 // Checks for presence of at least a valid passenger
 const hasTaskVersionPassengers = (passengers) => {
   for (const passengerChildSets of passengers.childSets) {
@@ -183,4 +214,6 @@ export { modifyRoRoPassengersTaskList,
   extractTaskVersionsBookingField,
   getTaskDetailsTotalOccupants,
   hasCarrierCounts,
-  modifyCountryCodeIfPresent };
+  modifyCountryCodeIfPresent,
+  isSinglePassenger,
+  filterKnownPassengers };


### PR DESCRIPTION
## Description
This PR address an bug where within a movement, we would get 2 persons however, one of them just has empty fields which was throwing off the logic that generated which icon that was to be displayed.

## To Test
- Pull and run against dev
- Locate any RoRo foot passenger/ passengers task.
- The movement mode icon should match the number of people in the movement (the information displayed on the task list card on task list page e.g. `Single passenger` & `1 foot passenger` should match with that which is also displayed within the `TaskSummary` block on task details page)
-  **AND** it should also match with the number of people within that movement.
- A good example of the bug is this task https://www.dev.cerberus.cop.homeoffice.gov.uk/tasks/CERB-MRUOCCO-PASSENGER-TEST-1 which actually has only 1 person in the movement.


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
