### PR TITLE
COP-10219: Allow missing upload service url

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = {
       KEYCLOAK_CLIENT_ID: 'cerberus',
       KEYCLOAK_REALM: 'cop-dev',
       FORM_API_URL: undefined,
-      FILE_UPLOAD_API_URL: undefined,
+      FILE_UPLOAD_API_URL: '',
       REFDATA_API_URL: undefined,
     }),
     new HtmlWebpackPlugin({ template: './src/index.html' }),


### PR DESCRIPTION
## Description
The application will fail to start without specifying a `FILE_UPLOAD_API_URL` parameter when attempting to run it. This defaults the value to an empty string, which will allow it to start up locally without an issue, although, obviously, files will not successfully be uploaded.

Related to https://support.cop.homeoffice.gov.uk/browse/COP-10219.

## To Test
Try running the application locally without specifying a `FILE_UPLOAD_API_URL` parameter. If it starts up fine, it can be considered to have passed the test.

## Developer Checklist

\* Required

- [x] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [x] All reviewer comments resolved/answered? \*
