### PR TITLE
COP-10838 - Updates Front end to render departure status

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -85,3 +85,26 @@ export const FORM_NAMES = {
   NOTE_CERBERUS: 'noteCerberus',
   TARGET_INFORMATION_SHEET: 'targetInformationSheet',
 };
+
+export const DEPARTURE_STATUS = {
+  DEPARTURE_CONFIRMED: {
+    classname: 'green',
+    description: 'Departure confirmed',
+    code: 'DC',
+  },
+  BOOKED_PASSENGER: {
+    classname: 'purple',
+    description: 'Booked passenger',
+    code: 'BP',
+  },
+  CHECKED_IN: {
+    classname: 'blue',
+    description: 'Checked-in',
+    code: 'CI',
+  },
+  DEPARTURE_EXCEPTION: {
+    classname: 'red',
+    description: 'Departure exception',
+    code: 'DX',
+  },
+};

--- a/src/routes/airpax/__fixtures__/targetListData.js
+++ b/src/routes/airpax/__fixtures__/targetListData.js
@@ -82,7 +82,7 @@ const targetListData = {
 
     ],
     flight: {
-      departureStatus: 'DC',
+      departureStatus: 'DEPARTURE_CONFIRMED',
       number: 'BA103',
       operator: 'BA',
       seatNumber: null,

--- a/src/routes/airpax/__fixtures__/taskData_AirPax_AssigneeCurrentUser.fixture.json
+++ b/src/routes/airpax/__fixtures__/taskData_AirPax_AssigneeCurrentUser.fixture.json
@@ -80,7 +80,7 @@
     },
     "otherPersons": [],
     "flight": {
-      "departureStatus": "DC",
+      "departureStatus": "DEPARTURE_CONFIRMED",
       "number": "BA103",
       "operator": "BA",
       "seatNumber": null

--- a/src/routes/airpax/__fixtures__/taskData_AirPax_AssigneeOtherUser.fixture.json
+++ b/src/routes/airpax/__fixtures__/taskData_AirPax_AssigneeOtherUser.fixture.json
@@ -86,7 +86,7 @@
     },
     "otherPersons": [],
     "flight": {
-      "departureStatus": "DC",
+      "departureStatus": "DEPARTURE_CONFIRMED",
       "number": "BA103",
       "operator": "BA",
       "seatNumber": null

--- a/src/routes/airpax/__fixtures__/taskData_AirPax_NoAssignee.fixture.json
+++ b/src/routes/airpax/__fixtures__/taskData_AirPax_NoAssignee.fixture.json
@@ -80,7 +80,7 @@
     },
     "otherPersons": [],
     "flight": {
-      "departureStatus": "DC",
+      "departureStatus": "DEPARTURE_CONFIRMED",
       "number": "BA103",
       "operator": "BA",
       "seatNumber": null

--- a/src/routes/airpax/__fixtures__/taskData_AirPax_TargetIssued.fixtures.json
+++ b/src/routes/airpax/__fixtures__/taskData_AirPax_TargetIssued.fixtures.json
@@ -86,7 +86,7 @@
     },
     "otherPersons": [],
     "flight": {
-      "departureStatus": "DC",
+      "departureStatus": "DEPARTURE_CONFIRMED",
       "number": "BA103",
       "operator": "BA",
       "seatNumber": null

--- a/src/routes/airpax/__fixtures__/taskData_AirPax_TaskComplete.fixture.json
+++ b/src/routes/airpax/__fixtures__/taskData_AirPax_TaskComplete.fixture.json
@@ -86,7 +86,7 @@
     },
     "otherPersons": [],
     "flight": {
-      "departureStatus": "DC",
+      "departureStatus": "DEPARTURE_CONFIRMED",
       "number": "BA103",
       "operator": "BA",
       "seatNumber": null

--- a/src/routes/airpax/__fixtures__/taskData_AirPax_TaskDetails.fixture.json
+++ b/src/routes/airpax/__fixtures__/taskData_AirPax_TaskDetails.fixture.json
@@ -91,7 +91,7 @@
       
     ],
     "flight": {
-      "departureStatus": "DC",
+      "departureStatus": "DEPARTURE_CONFIRMED",
       "number": "BA103",
       "operator": "BA",
       "seatNumber": null

--- a/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
+++ b/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
@@ -614,7 +614,7 @@ exports[`TaskVersions should render task versions 1`] = `
                       <p
                         className="govuk-!-margin-bottom-0 font__bold"
                       >
-                        Wed 3 Oct 2018 at 19:32
+                        Wed 3 Oct 2018 at 18:32
                       </p>
                     </div>
                     <div
@@ -647,7 +647,7 @@ exports[`TaskVersions should render task versions 1`] = `
                       <p
                         className="govuk-!-margin-bottom-0 font__bold"
                       >
-                        Wed 3 Oct 2018 at 22:19
+                        Wed 3 Oct 2018 at 21:19
                       </p>
                     </div>
                     <div
@@ -729,7 +729,7 @@ exports[`TaskVersions should render task versions 1`] = `
                         className="dot__light"
                       />
                        
-                      Wed 3 Oct 2018 at 12:00
+                      Wed 3 Oct 2018 at 11:00
                     </div>
                     <div
                       className="font__light"
@@ -750,7 +750,7 @@ exports[`TaskVersions should render task versions 1`] = `
                        
                       Arrival
                        
-                      3 Oct 2018 at 14:05
+                      3 Oct 2018 at 13:05
                     </div>
                   </div>
                   <div
@@ -784,7 +784,7 @@ exports[`TaskVersions should render task versions 1`] = `
                         className="dot__light"
                       />
                        
-                      Wed 3 Oct 2018 at 17:05
+                      Wed 3 Oct 2018 at 16:05
                     </div>
                     <div
                       className="font__light"
@@ -805,7 +805,7 @@ exports[`TaskVersions should render task versions 1`] = `
                        
                       Arrival
                        
-                      3 Oct 2018 at 19:16
+                      3 Oct 2018 at 18:16
                     </div>
                   </div>
                   <div
@@ -839,7 +839,7 @@ exports[`TaskVersions should render task versions 1`] = `
                         className="dot__light"
                       />
                        
-                      Wed 3 Oct 2018 at 19:32
+                      Wed 3 Oct 2018 at 18:32
                     </div>
                     <div
                       className="font__light"
@@ -860,7 +860,7 @@ exports[`TaskVersions should render task versions 1`] = `
                        
                       Arrival
                        
-                      3 Oct 2018 at 22:19
+                      3 Oct 2018 at 21:19
                     </div>
                   </div>
                 </div>

--- a/src/routes/airpax/__tests__/builder/Itinerary.test.jsx
+++ b/src/routes/airpax/__tests__/builder/Itinerary.test.jsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import config from '../../../../config';
-import { LONDON_TIMEZONE } from '../../../../constants';
 
 import Itinerary from '../../TaskDetails/builder/Itinerary';
 import taskDetailsData from '../../__fixtures__/taskData_AirPax_TaskDetails.fixture.json';
 
 describe('Itinerary', () => {
-  beforeEach(() => {
-    config.dayjsConfig.timezone = LONDON_TIMEZONE;
-  });
   it('should render the itinerary component', () => {
     const tree = renderer.create(<Itinerary version={taskDetailsData.versions[1]} />).toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/routes/airpax/__tests__/builder/Passenger.test.jsx
+++ b/src/routes/airpax/__tests__/builder/Passenger.test.jsx
@@ -20,7 +20,7 @@ describe('Passenger', () => {
         frequentFlyerNumber: 123456,
       },
       flight: {
-        departureStatus: 'DC',
+        departureStatus: 'DEPARTURE_CONFIRMED',
       },
     },
   };

--- a/src/routes/airpax/__tests__/builder/__snapshots__/Itinerary.test.jsx.snap
+++ b/src/routes/airpax/__tests__/builder/__snapshots__/Itinerary.test.jsx.snap
@@ -38,7 +38,7 @@ exports[`Itinerary should render the itinerary component 1`] = `
         className="dot__light"
       />
        
-      Wed 19 Sep 2018 at 19:25
+      Wed 19 Sep 2018 at 18:25
     </div>
     <div
       className="font__light"
@@ -59,7 +59,7 @@ exports[`Itinerary should render the itinerary component 1`] = `
        
       Arrival
        
-      19 Sep 2018 at 11:00
+      19 Sep 2018 at 10:00
     </div>
   </div>
   <div
@@ -93,7 +93,7 @@ exports[`Itinerary should render the itinerary component 1`] = `
         className="dot__light"
       />
        
-      Wed 3 Oct 2018 at 12:00
+      Wed 3 Oct 2018 at 11:00
     </div>
     <div
       className="font__light"
@@ -114,7 +114,7 @@ exports[`Itinerary should render the itinerary component 1`] = `
        
       Arrival
        
-      3 Oct 2018 at 14:05
+      3 Oct 2018 at 13:05
     </div>
   </div>
   <div
@@ -148,7 +148,7 @@ exports[`Itinerary should render the itinerary component 1`] = `
         className="dot__light"
       />
        
-      Wed 3 Oct 2018 at 17:05
+      Wed 3 Oct 2018 at 16:05
     </div>
     <div
       className="font__light"
@@ -169,7 +169,7 @@ exports[`Itinerary should render the itinerary component 1`] = `
        
       Arrival
        
-      3 Oct 2018 at 19:16
+      3 Oct 2018 at 18:16
     </div>
   </div>
 </div>

--- a/src/routes/airpax/__tests__/utils/BookingUtil.test.js
+++ b/src/routes/airpax/__tests__/utils/BookingUtil.test.js
@@ -132,7 +132,7 @@ describe('BookingUtil', () => {
   it('should return formatted check-in text if check-in time is present within the booking', () => {
     booking.checkInAt = '2020-08-07T17:15:00Z';
     const output = BookingUtil.toCheckInText(booking);
-    expect(output).toEqual('Check-in 18:15');
+    expect(output).toEqual('Check-in 17:15');
   });
 
   it('should return default formatted error text if check-in time is not present within the booking', () => {

--- a/src/routes/airpax/__tests__/utils/DateTimeUtil.test.js
+++ b/src/routes/airpax/__tests__/utils/DateTimeUtil.test.js
@@ -1,16 +1,10 @@
 import { DateTimeUtil } from '../../utils';
-import { LONDON_TIMEZONE, LONG_DATE_FORMAT } from '../../../../constants';
-
-import config from '../../../../config';
+import { LONG_DATE_FORMAT } from '../../../../constants';
 
 describe('DateTimeUtil', () => {
-  beforeEach(() => {
-    config.dayjsConfig.timezone = LONDON_TIMEZONE;
-  });
-
   it('should format the date if present', () => {
     const date = '1966-05-13T00:00:00Z'; // UTC
-    const expected = '13 May 1966 at 01:00';
+    const expected = '13 May 1966 at 00:00';
 
     const output = DateTimeUtil.format(date, LONG_DATE_FORMAT);
 

--- a/src/routes/airpax/__tests__/utils/MovementUtil.test.js
+++ b/src/routes/airpax/__tests__/utils/MovementUtil.test.js
@@ -2,9 +2,7 @@ import { render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 
 import { MovementUtil } from '../../utils';
-import { LONDON_TIMEZONE, UNKNOWN_TEXT, UNKNOWN_TIME_DATA } from '../../../../constants';
-
-import config from '../../../../config';
+import { UNKNOWN_TEXT, UNKNOWN_TIME_DATA } from '../../../../constants';
 
 describe('MovementUtil', () => {
   let targetTaskMin;
@@ -55,8 +53,6 @@ describe('MovementUtil', () => {
   ];
 
   beforeEach(() => {
-    config.dayjsConfig.timezone = LONDON_TIMEZONE;
-
     targetTaskMin = {
       movement: {
         id: 'AIRPAXTSV:CMID=9c19fe74233c057f25e5ad333672c3f9/2b4a6b5b08ea434880562d6836b1111',
@@ -97,7 +93,7 @@ describe('MovementUtil', () => {
           duration: 10000000,
         },
         flight: {
-          departureStatus: 'DC',
+          departureStatus: 'DEPARTURE_CONFIRMED',
           number: 'BA103',
           operator: 'BA',
           seatNumber: null,
@@ -166,7 +162,7 @@ describe('MovementUtil', () => {
 
   it('should return a formatted departure date and time if present', () => {
     const output = MovementUtil.formatDepartureTime(targetTaskMin.movement.journey);
-    expect(output).toEqual('7 Aug 2020 at 18:15');
+    expect(output).toEqual('7 Aug 2020 at 17:15');
   });
 
   it('should return a formatted arrival date and time if present', () => {

--- a/src/routes/airpax/__tests__/utils/__snapshots__/MovementUtil.test.js.snap
+++ b/src/routes/airpax/__tests__/utils/__snapshots__/MovementUtil.test.js.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MovementUtil should render the departure status if present 1`] = `
-<strong
-  className="hods-tag hods-tag--green airpax-status"
->
-  DC
-</strong>
-`;
-
-
 exports[`MovementUtil should render the departure status and details if present 1`] = `
 Array [
   <span>
@@ -21,4 +12,12 @@ Array [
     DC
   </strong>,
 ]
+`;
+
+exports[`MovementUtil should render the departure status if present 1`] = `
+<strong
+  className="hods-tag hods-tag--green airpax-status"
+>
+  DC
+</strong>
 `;

--- a/src/routes/airpax/utils/datetimeUtil.js
+++ b/src/routes/airpax/utils/datetimeUtil.js
@@ -1,14 +1,10 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-import config from '../../../config';
 
 dayjs.extend(utc);
-dayjs.extend(timezone);
 
 const getFormattedDate = (date, dateFormat) => {
-  const tz = config.dayjsConfig.timezone || dayjs.tz.guess();
-  return dayjs.utc(date).tz(tz).format(dateFormat);
+  return dayjs.utc(date).format(dateFormat);
 };
 
 const toDateTimeList = (dateOne, dateTwo) => {

--- a/src/routes/airpax/utils/movementUtil.jsx
+++ b/src/routes/airpax/utils/movementUtil.jsx
@@ -9,7 +9,8 @@ import { UNKNOWN_TEXT,
   MOVEMENT_MODE_AIR_PASSENGER,
   MOVEMENT_MODE_AIR_CREW,
   UNKNOWN_TIME_DATA,
-  LATER_TEXT } from '../../../constants';
+  LATER_TEXT,
+  DEPARTURE_STATUS } from '../../../constants';
 
 import { getFormattedDate, toDateTimeList } from './datetimeUtil';
 import { getTotalNumberOfPersons } from './personUtil';
@@ -194,24 +195,12 @@ const getAirlineOperator = (flight) => {
 
 const getDepartureStatus = (targetTask, taskDetails = false) => {
   const departureStatus = targetTask?.movement?.flight?.departureStatus;
-  const DEPARTURE_CLASSES = {
-    DC: 'green',
-    BP: 'purple',
-    CI: 'blue',
-    DX: 'red',
-  };
-  const DEPARTURE_DESCRIPTIONS = {
-    DC: 'Departure confirmed',
-    BP: 'Booked passenger ',
-    CI: 'Checked-in',
-    DX: 'Departure exception',
-  };
   if (departureStatus) {
     return (
       <>
-        {taskDetails && <span>{DEPARTURE_DESCRIPTIONS[departureStatus] || UNKNOWN_TEXT} </span>}
-        <Tag className="airpax-status" classModifiers={DEPARTURE_CLASSES[departureStatus]}>
-          {departureStatus}
+        {taskDetails && <span>{DEPARTURE_STATUS[departureStatus].description || UNKNOWN_TEXT} </span>}
+        <Tag className="airpax-status" classModifiers={DEPARTURE_STATUS[departureStatus].classname}>
+          {DEPARTURE_STATUS[departureStatus].code}
         </Tag>
       </>
     );


### PR DESCRIPTION
## Description
This PR refactors the frontend code to properly render the departure status.

> Supplemental
This PR also refactors the datetime utils to use UTC timezone instead of BST timezone.

A **majority** of this PR is just code updates due to time changes as well as the change to the departure status due to how it is now returned from the backend. Nothing new has been added.

## To Test

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
