### PR TITLE
COP-10847: Add tests to claim and unClaim Airpax tasks from tasks overview page

### DIFF
--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -45,11 +45,7 @@ describe('Verify AirPax task details of different sections', () => {
       });
     });
     cy.get('#note').should('not.exist');
-    cy.intercept('POST', '/v2/targeting-tasks/*/claim').as('claim');
-    cy.contains('Claim').click({ force: true });
-    cy.wait('@claim').then(({ response }) => {
-      expect(response.statusCode).to.equal(200);
-    });
+    cy.claimAirPaxTask();
     cy.get('.govuk-label').invoke('text').then(($text) => {
       expect($text).to.equal('Add a new note');
     });
@@ -60,12 +56,8 @@ describe('Verify AirPax task details of different sections', () => {
     cy.get('@taskActivity').then(($activityText) => {
       expect($activityText).includes(textNote);
     });
-    cy.intercept('POST', '/v2/targeting-tasks/*/unclaim').as('unclaim');
     cy.get('.govuk-caption-xl').invoke('text').as('taskId');
-    cy.contains('Unclaim task').click();
-    cy.wait('@unclaim').then(({ response }) => {
-      expect(response.statusCode).to.equal(200);
-    });
+    cy.unClaimAirPaxTask();
     cy.get('@taskId').then((businessKey) => {
       cy.visit(`/airpax/tasks/${businessKey}`);
       cy.wait(3000);

--- a/cypress/integration/airpax/airpax-task-overview-page.spec.js
+++ b/cypress/integration/airpax/airpax-task-overview-page.spec.js
@@ -1,0 +1,79 @@
+describe('AirPax Tasks overview Page - Should check All user journeys', () => {
+  beforeEach(() => {
+    cy.login(Cypress.env('userName'));
+  });
+
+  it('Should Claim and Unclaimed AirPax task', () => {
+    cy.acceptPNRTerms();
+    const nextPage = 'a[data-test="next"]';
+    cy.intercept('POST', 'v2/targeting-tasks/*/claim').as('claim');
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((response) => {
+        expect(response.movement.id).to.contain('AIRPAX');
+        cy.wait(4000);
+        let businessKey = response.id;
+        cy.intercept('POST', '/v2/targeting-tasks/pages').as('airpaxTask');
+        cy.visit('/airpax/tasks');
+        cy.wait('@airpaxTask').then(({ pageResponse }) => {
+          expect(pageResponse.statusCode).to.be.equal(200);
+        });
+        cy.log(Cypress.$(nextPage).length);
+        cy.get('body').then(($el) => {
+          if ($el.find(nextPage).length > 0) {
+            cy.findTaskInAllThePages(`${businessKey}`, 'Claim', null).then((returnValue) => {
+              expect(returnValue).to.equal(true);
+              cy.wait('@claim').then(({ claimResponse }) => {
+                expect(claimResponse.statusCode).to.equal(200);
+              });
+            });
+          } else {
+            cy.findTaskInSinglePage(`${businessKey}`, 'Claim', null).then((returnValue) => {
+              expect(returnValue).to.equal(true);
+              cy.wait('@claim').then(({ claimResponse }) => {
+                expect(claimResponse.statusCode).to.equal(200);
+              });
+            });
+          }
+        });
+      });
+      cy.wait(2000);
+
+      cy.get('.govuk-caption-xl').invoke('text').as('taskName');
+
+      cy.contains('Back to task list').click();
+
+      cy.get('a[href="#inProgress"]').click();
+
+      cy.reload();
+
+      cy.get('a[href="#inProgress"]').click();
+
+      cy.get('@taskName').then((value) => {
+        cy.intercept('POST', 'v2/targeting-tasks/*/unclaim').as('unclaim');
+        cy.get('body').then(($el) => {
+          if ($el.find(nextPage).length > 0) {
+            cy.findTaskInAllThePages(value, 'Unclaim', null).then((returnValue) => {
+              expect(returnValue).to.equal(true);
+              cy.wait('@unclaim').then(({ unClaimResponse }) => {
+                expect(unClaimResponse.statusCode).to.equal(200);
+              });
+            });
+          } else {
+            cy.findTaskInSinglePage(value, 'Unclaim', null).then((returnValue) => {
+              expect(returnValue).to.equal(true);
+              cy.wait('@unclaim').then(({ unClaimResponse }) => {
+                expect(unClaimResponse.statusCode).to.equal(200);
+              });
+            });
+          }
+        });
+      });
+    });
+  });
+  after(() => {
+    cy.contains('Sign out').click();
+    cy.url().should('include', Cypress.env('auth_realm'));
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1694,3 +1694,19 @@ Cypress.Commands.add('doNotAcceptPNRTerms', () => {
   cy.get('h1.govuk-heading-l').should('have.text', 'Continue without viewing PNR data');
   cy.contains('button', 'Continue').click();
 });
+
+Cypress.Commands.add('claimAirPaxTask', () => {
+  cy.intercept('POST', '/v2/targeting-tasks/*/claim').as('claim');
+  cy.contains('Claim').click({ force: true });
+  cy.wait('@claim').then(({ response }) => {
+    expect(response.statusCode).to.equal(200);
+  });
+});
+
+Cypress.Commands.add('unClaimAirPaxTask', () => {
+  cy.intercept('POST', '/v2/targeting-tasks/*/unclaim').as('unclaim');
+  cy.contains('Unclaim task').click();
+  cy.wait('@unclaim').then(({ response }) => {
+    expect(response.statusCode).to.equal(200);
+  });
+});


### PR DESCRIPTION
## Description
Add tests to claim and unClaim Airpax tasks from tasks overview page

## To Test
npm run cypress:runner

run test `Should Claim and Unclaimed AirPax task` from spec `airpax-task-overview-page.spec.js`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
