### PR TITLE
COP-10876: Add tests for checking action buttons on task details page

### DIFF
--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -65,6 +65,46 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
+  it('Should see all the action buttons if task claimed by the same user', () => {
+    const actionItems = [
+      'Issue target',
+      'Assessment complete',
+      'Dismiss',
+    ];
+
+    cy.acceptPNRTerms();
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((response) => {
+        expect(response.movement.id).to.contain('AIRPAX');
+        cy.wait(4000);
+        cy.checkAirPaxTaskDisplayed(`${response.id}`);
+      });
+    });
+    cy.claimAirPaxTask();
+
+    cy.get('.task-actions--buttons button').each(($items, index) => {
+      expect($items.text()).to.equal(actionItems[index]);
+    });
+  });
+
+  it('Should verify all the action buttons not available for non-task owner', () => {
+    cy.acceptPNRTerms();
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((response) => {
+        expect(response.movement.id).to.contain('AIRPAX');
+        cy.wait(4000);
+        cy.claimAirPaxTaskWithUserId(response.id);
+        cy.checkAirPaxTaskDisplayed(`${response.id}`);
+      });
+    });
+
+    cy.get('.task-actions--buttons button').should('not.exist');
+  });
+
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1703,6 +1703,19 @@ Cypress.Commands.add('claimAirPaxTask', () => {
   });
 });
 
+Cypress.Commands.add('claimAirPaxTaskWithUserId', (taskId) => {
+  cy.request({
+    method: 'POST',
+    url: `https://${cerberusServiceUrl}/v2/targeting-tasks/${taskId}/claim`,
+    headers: { Authorization: `Bearer ${token}` },
+    body: {
+      'userId': 'boothi.palanisamy@digital.homeoffice.gov.uk',
+    },
+  }).then((response) => {
+    expect(response.status).to.eq(200);
+  });
+});
+
 Cypress.Commands.add('unClaimAirPaxTask', () => {
   cy.intercept('POST', '/v2/targeting-tasks/*/unclaim').as('unclaim');
   cy.contains('Unclaim task').click();


### PR DESCRIPTION
## Description
Add tests for checking action buttons on task details page.
Test added for following 2 scenarios

If the task is assigned to a user, only that user can see these buttons.
If the task is not assigned to a user, then the user cannot see these buttons.

## To Test
npm run cypress:runner

execute tests from spec `airpax-task-details.spec.js`
`Should see all the action buttons if task claimed by the same user`
`Should verify all the action buttons not available for non-task owner`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
