### PR TITLE
COP-10463 - Hides the movement details link displayed next other travellers

### DIFF
--- a/src/routes/airpax/TaskDetails/builder/CoTraveller.jsx
+++ b/src/routes/airpax/TaskDetails/builder/CoTraveller.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as pluralise from 'pluralise';
-import { Link } from '@ukhomeoffice/cop-react-components';
+import { Link, VisuallyHidden } from '@ukhomeoffice/cop-react-components';
 import Table from '../../../../components/Table';
 
 import { CO_TRAVELLERS_TABLE_HEADERS,
@@ -93,7 +93,10 @@ const toMovementDetailsColumnContent = (index) => {
   return (
     <>
       {index === 0 && <div className="font__light">This movement</div>}
-      {index !== 0 && <Link href="/" target="_blank">Movement detail</Link>}
+      {/* Line below has been intentionally hidden */}
+      <VisuallyHidden>
+        {index !== 0 && <Link href="/airpax/tasks" target="_blank">Movement detail</Link>}
+      </VisuallyHidden>
     </>
   );
 };

--- a/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
+++ b/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
@@ -1225,14 +1225,6 @@ exports[`TaskVersions should render task versions 1`] = `
                       >
                         
                       </span>
-                      <a
-                        className="govuk-link"
-                        data-module="govuk-link"
-                        href="/"
-                        target="_blank"
-                      >
-                        Movement detail
-                      </a>
                     </td>
                   </tr>
                   <tr
@@ -1364,14 +1356,6 @@ exports[`TaskVersions should render task versions 1`] = `
                       >
                         
                       </span>
-                      <a
-                        className="govuk-link"
-                        data-module="govuk-link"
-                        href="/"
-                        target="_blank"
-                      >
-                        Movement detail
-                      </a>
                     </td>
                   </tr>
                   <tr
@@ -1503,14 +1487,6 @@ exports[`TaskVersions should render task versions 1`] = `
                       >
                         
                       </span>
-                      <a
-                        className="govuk-link"
-                        data-module="govuk-link"
-                        href="/"
-                        target="_blank"
-                      >
-                        Movement detail
-                      </a>
                     </td>
                   </tr>
                 </tbody>

--- a/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
+++ b/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
@@ -1094,6 +1094,9 @@ exports[`TaskVersions should render task versions 1`] = `
                       >
                         This movement
                       </div>
+                      <span
+                        className="govuk-visually-hidden"
+                      />
                     </td>
                   </tr>
                   <tr
@@ -1224,6 +1227,18 @@ exports[`TaskVersions should render task versions 1`] = `
                         className="hods-table__heading"
                       >
                         
+                      </span>
+                      <span
+                        className="govuk-visually-hidden"
+                      >
+                        <a
+                          className="govuk-link"
+                          data-module="govuk-link"
+                          href="/airpax/tasks"
+                          target="_blank"
+                        >
+                          Movement detail
+                        </a>
                       </span>
                     </td>
                   </tr>
@@ -1356,6 +1371,18 @@ exports[`TaskVersions should render task versions 1`] = `
                       >
                         
                       </span>
+                      <span
+                        className="govuk-visually-hidden"
+                      >
+                        <a
+                          className="govuk-link"
+                          data-module="govuk-link"
+                          href="/airpax/tasks"
+                          target="_blank"
+                        >
+                          Movement detail
+                        </a>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -1486,6 +1513,18 @@ exports[`TaskVersions should render task versions 1`] = `
                         className="hods-table__heading"
                       >
                         
+                      </span>
+                      <span
+                        className="govuk-visually-hidden"
+                      >
+                        <a
+                          className="govuk-link"
+                          data-module="govuk-link"
+                          href="/airpax/tasks"
+                          target="_blank"
+                        >
+                          Movement detail
+                        </a>
                       </span>
                     </td>
                   </tr>


### PR DESCRIPTION
## Description
This PR hides the movement details URL normally rendered along other co-travellers

**BEFORE:**
![image](https://user-images.githubusercontent.com/19333750/172894692-fbf2a596-46c6-46bf-bf5d-6ba9c7aa0007.png)


**AFTER:**
![image](https://user-images.githubusercontent.com/19333750/172894355-b627b680-339d-4fde-a6ed-aa4b0a6dc850.png)


## To Test

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
