### PR TITLE
COP-10474: Add tests for dismissing  Airpax task

### DIFF
--- a/cypress/fixtures/airpax/task-airpax-latest.json
+++ b/cypress/fixtures/airpax/task-airpax-latest.json
@@ -1,0 +1,697 @@
+{
+  "data": {
+    "movementId": "APIPNR:S=c85b5c5426a6696b24ac6ca7851f0977",
+    "riskSubmissionId": 213295,
+    "riskCreatedDate": "2022-05-26T11:00:31.779414Z",
+    "riskType": "Pre-Arrival",
+    "matchedRules": [
+      {
+        "ruleId": 11470,
+        "ruleName": "PNR-Number in Party",
+        "ruleType": "Pre-arrival",
+        "ruleVersion": 2,
+        "ruleDescription": "Test",
+        "securityLabels": [
+          "null",
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-05-26T11:00:31Z",
+        "rulePriority": "Tier 1",
+        "indicatorMatches": [
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Freight, Air Passenger, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+          },
+          {
+            "entity": "Booking",
+            "descriptor": "numInParty",
+            "operator": "greater_or_equal",
+            "value": "1"
+          }
+        ],
+        "abuseTypes": [
+          "Cash including AVTCs"
+        ]
+      }
+    ],
+    "matchedSelectors": [],
+    "movement": {
+      "cerberusMovementId": "APIPNR:S=c85b5c5426a6696b24ac6ca7851f0977",
+      "firstCerberusTimestamp": 1653562817371,
+      "cerberusTimestamp": 1653562817371,
+      "latestMessageType": "RUN_LOG",
+      "cerberusInternalLabels": [
+        "incomplete_wash",
+        "incomplete_travel-history-enrichment",
+        "needs_travel-history"
+      ],
+      "messageAnalysis": {
+        "messageMatches": [
+          {
+            "sourceMessageVersion": 1,
+            "expectedMatches": 4,
+            "countOfMatches": 0,
+            "sourceMsgEnriches": 0
+          }
+        ],
+        "countOfSourceMessages": 1,
+        "countOfSnapshots": 0,
+        "countOfNoStateChanges": 0,
+        "countOfWashes": 0,
+        "countOfEnrichments": 0,
+        "firstRunlogTimestamp": 1653562817371,
+        "lastRunlogTimestamp": 1653562817371,
+        "firstSnapshotTimestamp": 0,
+        "lastSnapshotTimestamp": 0,
+        "firstNSCTimestamp": 0,
+        "lastNSCTimestamp": 0,
+        "firstWashTimestamp": 0,
+        "lastWashTimestamp": 0,
+        "firstEnrichTimestamp": 0,
+        "lastEnrichTimestamp": 0,
+        "matchesComplete": false,
+        "latestVersion": "1.0"
+      },
+      "serviceMovement": {
+        "metadata": {
+          "identityRecord": {
+            "poleId": {
+              "v2": {
+                "id": "APIPNR:S=c85b5c5426a6696b24ac6ca7851f0977"
+              },
+              "v1": null
+            },
+            "type": "S"
+          },
+          "sourceRecord": {
+            "name": "APIPNR",
+            "shortName": null,
+            "location": null,
+            "id": null,
+            "audit": {
+              "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+              "createdTimestamp": 1563637415000,
+              "updatedBy": null,
+              "updatedTimestamp": null,
+              "deletedBy": null,
+              "deletedTimestamp": null
+            }
+          },
+          "complianceRecord": {
+            "visibility": "UNKNOWN",
+            "gscMarker": null,
+            "retentionMarkerDays": -1
+          },
+          "mappingRecord": {
+            "name": "APIPNR-Service-Movement",
+            "version": "1"
+          }
+        },
+        "type": "MOVEMENT",
+        "effectiveFromTimestamp": 1563727200000,
+        "effectiveToTimestamp": 1563734100000,
+        "dueTimestamp": null,
+        "status": null,
+        "movement": {
+          "type": "Pre-Arrival",
+          "businessIdentifier": null,
+          "mode": "Air Passenger",
+          "source": "BA",
+          "actualDepartureTimestamp": null
+        },
+        "attributes": {
+          "attrs": {
+            "commonAPIPlus.SourceData.0.subject": "BA103;LHR;2019-07-21;PONQVFT",
+            "commonAPIPlus.SourceData.0.source": "PNRGOV",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.1.pnrPassengerRef": "3",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.checkinDateTime": "2019-07-20 16:43:35",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.bookingDateTime": "2022-05-20 16:43:35",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.1.membershipLevel": "BRNZ",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.seatNumber": "34A",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.0.pnrPassengerRef": "2",
+            "commonAPIPlus.manifestDetails.datetimeReceived": "2019-07-20T15:43:35Z",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.0.uniquePassengerId": "20058AB300012AD5",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.0.membershipLevel": "GOLD",
+            "commonAPIPlus.SourceData.0.component": "PNRGovMessageHandler",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.pnrLocator": "PONQVFT",
+            "commonAPIPlus.manifestDetails.paxCount": "178",
+            "commonAPIPlus.manifestDetails.manifestGUID": "502992e4-f319-4422-ac26-09dbdcda5f58",
+            "commonAPIPlus.SourceData.0.type": "PNR",
+            "commonAPIPlus.manifestDetails.protocol": "MQ",
+            "commonAPIPlus.manifestDetails.dataType": "PNR",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.1.uniquePassengerId": "20058AB300012AD6"
+          }
+        },
+        "features": {
+          "feats": {
+            "EU-HOSTED-DATA": {
+              "id": null,
+              "type": null,
+              "valueType": "BOOL",
+              "value": false,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:movementId": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "voyage,pnrLocator,passportNumber,familyName,givenName (1st 3 chars),dateOfBirth",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:checkInLeadTimeMilliseconds": {
+              "id": null,
+              "type": null,
+              "valueType": "LONG",
+              "value": 86185000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:bookingIntentHours": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 1,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:lastReportedStatus": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "DC",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            }
+          }
+        },
+        "changeHistory": null
+      },
+      "persons": [
+        {
+          "metadata": {
+            "identityRecord": {
+              "poleId": {
+                "v2": {
+                  "id": "PNR:P=dab092daf6d33e8fd2bfe5e2bcff8750"
+                },
+                "v1": null
+              },
+              "type": "P"
+            },
+            "sourceRecord": {
+              "name": "PNR",
+              "shortName": "PNR",
+              "location": "MT2-PNR1.xml",
+              "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+              "audit": {
+                "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+                "createdTimestamp": 1563637415000,
+                "updatedBy": null,
+                "updatedTimestamp": null,
+                "deletedBy": null,
+                "deletedTimestamp": null
+              }
+            },
+            "complianceRecord": null,
+            "mappingRecord": {
+              "name": "Passenger (dcs)",
+              "version": "1.0"
+            }
+          },
+          "type": "PERSON",
+          "person": {
+            "type": "PERPAS",
+            "title": null,
+            "familyName": "BATZ STOUP",
+            "givenName": "ZUES CARLO",
+            "fullName": "ZUES CARLO BATZ STOUP",
+            "dateOfBirth": 2535,
+            "dateOfDeath": null,
+            "gender": "M",
+            "nationality": "GBR",
+            "yearOfBirth": 1976,
+            "monthOfBirth": 12,
+            "dayOfBirth": 10,
+            "countryOfBirth": null,
+            "placeOfBirth": null,
+            "ethnicity": null,
+            "maritalStatus": null,
+            "religion": null,
+            "passportNumber": "119039375"
+          },
+          "attributes": {
+            "attrs": {
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.freqFlyerNumber": "680419104BA"
+            }
+          },
+          "matching": null,
+          "features": null,
+          "washResponses": null,
+          "matchMerge": null,
+          "changeHistory": null
+        }
+      ],
+      "organisations": [
+        {
+          "metadata": {
+            "identityRecord": {
+              "poleId": {
+                "v2": {
+                  "id": "PNR:P=5051a10ebfaabae6df5655be104b24ec"
+                },
+                "v1": null
+              },
+              "type": "P"
+            },
+            "sourceRecord": {
+              "name": "PNR",
+              "shortName": "PNR",
+              "location": "MT2-PNR1.xml",
+              "id": "890534932",
+              "audit": {
+                "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+                "createdTimestamp": 1563637415000,
+                "updatedBy": null,
+                "updatedTimestamp": null,
+                "deletedBy": null,
+                "deletedTimestamp": null
+              }
+            },
+            "complianceRecord": null,
+            "mappingRecord": {
+              "name": "Travel Agent",
+              "version": "1.0"
+            }
+          },
+          "type": "ORGANISATION",
+          "organisation": {
+            "type": "ORGTRVL",
+            "name": "890534932",
+            "registrationNumber": null,
+            "vatNumber": null,
+            "industrySector": null,
+            "numberOfEmployees": null
+          },
+          "attributes": {
+            "attrs": {
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentCountryCode": "GB",
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.freqFlyerNumber": "8767876",
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentCityCode": "LHR",
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentType": "A"
+            }
+          },
+          "matching": null,
+          "features": null,
+          "washResponses": null,
+          "matchMerge": null,
+          "changeHistory": null
+        }
+      ],
+      "documents": [
+        {
+          "metadata": {
+            "identityRecord": {
+              "poleId": {
+                "v2": {
+                  "id": "PNR:P=dab092daf6d33e8fd2bfe5e2bcff8750,O=bec77b0b7613e0d05ff1a7421f6abcf4"
+                },
+                "v1": null
+              },
+              "type": "O"
+            },
+            "sourceRecord": {
+              "name": "PNR",
+              "shortName": "PNR",
+              "location": "MT2-PNR1.xml",
+              "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+              "audit": {
+                "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+                "createdTimestamp": 1563637415000,
+                "updatedBy": null,
+                "updatedTimestamp": null,
+                "deletedBy": null,
+                "deletedTimestamp": null
+              }
+            },
+            "complianceRecord": null,
+            "mappingRecord": {
+              "name": "TDI (dcs)",
+              "version": "1.0"
+            }
+          },
+          "type": "DOCUMENT",
+          "party": {
+            "poleId": {
+              "v2": {
+                "id": "PNR:P=dab092daf6d33e8fd2bfe5e2bcff8750"
+              },
+              "v1": null
+            },
+            "type": "P"
+          },
+          "role": "PTOOUSES",
+          "startTimestamp": null,
+          "endTimestamp": null,
+          "name": null,
+          "description": null,
+          "additionalInformation": null,
+          "url": null,
+          "document": {
+            "type": "OBJDOCPAS",
+            "value": "119039375",
+            "subject": null,
+            "category": null,
+            "status": null,
+            "placeOfIssue": "GBR",
+            "countryOfIssue": null,
+            "dateOfIssue": null,
+            "validFromDate": 17648,
+            "expiryDate": 19473
+          },
+          "attributes": {
+            "attrs": {
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.itinerary.travelSegment.dcsDetails.dcsData.dcsRecord.1.travelDocument.0.travelDocType": "P"
+            }
+          },
+          "matching": null,
+          "features": null,
+          "washResponses": null,
+          "matchMerge": null,
+          "changeHistory": null
+        }
+      ],
+      "vehicles": null,
+      "vessel": null,
+      "addresses": null,
+      "contacts": null,
+      "voyage": {
+        "metadata": {
+          "identityRecord": {
+            "poleId": {
+              "v2": {
+                "id": "PNR:S=7b6ca8653ee18febc78bdb22aa572889"
+              },
+              "v1": null
+            },
+            "type": "S"
+          },
+          "sourceRecord": {
+            "name": "PNR",
+            "shortName": "PNR",
+            "location": "MT2-PNR1.xml",
+            "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+            "audit": {
+              "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+              "createdTimestamp": 1563637415000,
+              "updatedBy": null,
+              "updatedTimestamp": null,
+              "deletedBy": null,
+              "deletedTimestamp": null
+            }
+          },
+          "complianceRecord": null,
+          "mappingRecord": {
+            "name": "Voyage",
+            "version": "1.0"
+          }
+        },
+        "type": "VOYAGE",
+        "effectiveFromTimestamp": 1563727200000,
+        "effectiveToTimestamp": 1563734100000,
+        "dueTimestamp": null,
+        "status": null,
+        "voyage": {
+          "type": "FLIGHT",
+          "voyageType": null,
+          "departureLocation": "LHR",
+          "departureCountry": null,
+          "scheduledDepartureTimestamp": 1563727200000,
+          "actualDepartureTimestamp": null,
+          "arrivalLocation": "YYC",
+          "arrivalCountry": null,
+          "scheduledArrivalTimestamp": 1563734100000,
+          "actualArrivalTimestamp": null,
+          "intermediateLocations": null,
+          "passengerCount": 178,
+          "crewCount": null,
+          "durationMinutes": null,
+          "routeId": "BA0103",
+          "carrier": "BA",
+          "craftId": null
+        },
+        "attributes": {
+          "attrs": {
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureAirport": "LHR",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureDate": "2019-07-21",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalTime": "1835",
+            "commonAPIPlus.pnrDetails.flightSummary.airlineCode": "BA",
+            "journeyHash": "7b6ca8653ee18febc78bdb22aa572889",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureTime": "1640",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalDate": "2019-07-21",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalAirport": "YYC",
+            "commonAPIPlus.pnrDetails.flightSummary.flightCode": "BA103"
+          }
+        },
+        "features": {
+          "feats": {
+            "PNR-EU-MOVEMENT": {
+              "id": null,
+              "type": null,
+              "valueType": "BOOL",
+              "value": false,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            }
+          }
+        },
+        "changeHistory": null
+      },
+      "consolidation": null,
+      "consignments": null,
+      "booking": {
+        "metadata": {
+          "identityRecord": {
+            "poleId": {
+              "v2": {
+                "id": "PNR:S=PONQVFT7b6ca8653ee18febc78bdb22aa572889"
+              },
+              "v1": null
+            },
+            "type": "S"
+          },
+          "sourceRecord": {
+            "name": "PNR",
+            "shortName": "PNR",
+            "location": "MT2-PNR1.xml",
+            "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+            "audit": {
+              "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+              "createdTimestamp": 1563637415000,
+              "updatedBy": null,
+              "updatedTimestamp": null,
+              "deletedBy": null,
+              "deletedTimestamp": null
+            }
+          },
+          "complianceRecord": null,
+          "mappingRecord": {
+            "name": "Booking",
+            "version": "1.0"
+          }
+        },
+        "type": "BOOKING",
+        "effectiveFromTimestamp": 1563721620000,
+        "effectiveToTimestamp": null,
+        "dueTimestamp": null,
+        "status": null,
+        "booking": {
+          "type": "PNR",
+          "pnrData": {
+            "locator": "PONQVFT",
+            "masterLocator": null,
+            "split": null,
+            "raw": null,
+            "history": null
+          },
+          "accompaniedByInfant": false,
+          "unaccompaniedMinor": null,
+          "contacts": [
+            {
+              "type": "76",
+              "text": "PASSENGER ADDRESS DETAILS",
+              "countryCode": null
+            },
+            {
+              "type": "CTCA",
+              "text": "65, LONDON ROAD BELFAST BF5 6TG",
+              "countryCode": null
+            },
+            {
+              "type": "RM",
+              "text": "NO AUTO CANCELLATION MESSAGE SENT FOR BA0048/16JUL19/SEA-SMALL IMPACT SCHEDULE CHANGE",
+              "countryCode": null
+            },
+            {
+              "type": "28",
+              "text": "CREG OWVE000109282232",
+              "countryCode": null
+            },
+            {
+              "type": "CTCE",
+              "text": "ZEUS.BATZSTOUP@ABC.COM",
+              "countryCode": null
+            },
+            {
+              "type": "CTCP",
+              "text": "0208 0001112-H",
+              "countryCode": null
+            },
+            {
+              "type": "CTCH",
+              "text": "44770001110001-M",
+              "countryCode": null
+            },
+            {
+              "type": "DOCA",
+              "text": "/R/GBR",
+              "countryCode": null
+            },
+            {
+              "type": "RM",
+              "text": "NOTIFY PASSENGER PRIOR TO TICKET PURCHASE & CHECK-IN: FEDERAL LAWS FOR BID THE CARRIAGE OF HAZARDOUS MATERIALS - GGMAUSHAZ",
+              "countryCode": null
+            },
+            {
+              "type": "RX",
+              "text": "ADDITIONAL BAGGAGE ALLOWANCE/1/PIECES/GOLD",
+              "countryCode": null
+            }
+          ],
+          "itineraryTravel": null,
+          "payments": [
+            {
+              "type": "CA",
+              "amount": null,
+              "cardNumber": null,
+              "cardExpiryDate": null,
+              "data": null,
+              "vendorCode": null
+            },
+            {
+              "type": "CA",
+              "amount": null,
+              "cardNumber": null,
+              "cardExpiryDate": null,
+              "data": null,
+              "vendorCode": null
+            }
+          ],
+          "tickets": [
+            {
+              "number": "8888000991",
+              "issueDate": 17724,
+              "priceType": null,
+              "currencyCode": null,
+              "paymentAmount": null
+            },
+            {
+              "number": "8888000992",
+              "issueDate": 17724,
+              "priceType": null,
+              "currencyCode": null,
+              "paymentAmount": null
+            }
+          ],
+          "requests": [
+            {
+              "type": "FQTV",
+              "data": "SRR+FQTV:HK::BA'"
+            },
+            {
+              "type": "RQST",
+              "data": "SSR+RQST:HK:2:BA:::LHR:YYC+13A::3+13B::3'"
+            },
+            {
+              "type": "RQST",
+              "data": "SSR+ZVTS:HK:2:BA:::LHR:YYC+13A::3+13B::3'"
+            },
+            {
+              "type": "FQTR",
+              "data": "SSR+FQTR:HK:1:BA:::LHR:YYC+::3'"
+            }
+          ],
+          "excessBaggage": [],
+          "history": []
+        },
+        "attributes": {
+          "attrs": {
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureAirport": "LHR",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureDate": "2019-07-21",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalTime": "1835",
+            "commonAPIPlus.pnrDetails.flightSummary.airlineCode": "BA",
+            "journeyHash": "7b6ca8653ee18febc78bdb22aa572889",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureTime": "1640",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalDate": "2019-07-21",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalAirport": "YYC",
+            "commonAPIPlus.pnrDetails.flightSummary.flightCode": "BA103"
+          }
+        },
+        "features": {
+          "feats": {
+            "STANDARDISED:legTimestampDifferenceMilliseconds[1]": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 360000000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:durationWholeTripMilliseconds": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 429300000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:durationStayMilliseconds": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 360000000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:ticketType": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "ONE-WAY",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            }
+          }
+        },
+        "changeHistory": null
+      },
+      "seizure": null,
+      "detainment": null
+    }
+  }
+}

--- a/cypress/fixtures/airpax/task-airpax.json
+++ b/cypress/fixtures/airpax/task-airpax.json
@@ -325,7 +325,11 @@
             "commonAPIPlus.manifestDetails.protocol": "MQ",
             "commonAPIPlus.manifestDetails.dataType": "PNR",
             "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.1.uniquePassengerId": "20058AB300012AD6",
-            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.ticketNumber": "AL12345"
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.ticketNumber": "AL12345",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.baggageDetails.0.tagNumber": "739238",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.baggageDetails.1.tagNumber": "739239",
+            "checkedInCount": "1",
+            "checkedInWeight": "23kg"
           }
         },
         "features": {
@@ -442,6 +446,69 @@
           "washResponses": null,
           "matchMerge": null,
           "changeHistory": null
+        },
+        {
+          "metadata": {
+            "identityRecord": {
+              "poleId": {
+                "v2": {
+                  "id": "PNR:P=dab092daf6d33e8fd2bfe5e2bcff8750"
+                },
+                "v1": null
+              },
+              "type": "P"
+            },
+            "sourceRecord": {
+              "name": "PNR",
+              "shortName": "PNR",
+              "location": "MT2-PNR1.xml",
+              "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+              "audit": {
+                "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+                "createdTimestamp": 1563637415000,
+                "updatedBy": null,
+                "updatedTimestamp": null,
+                "deletedBy": null,
+                "deletedTimestamp": null
+              }
+            },
+            "complianceRecord": null,
+            "mappingRecord": {
+              "name": "Passenger (dcs)",
+              "version": "1.0"
+            }
+          },
+          "type": "PERSON",
+          "person": {
+            "type": "PERPAS",
+            "title": null,
+            "familyName": "Testing FamilyName",
+            "givenName": "Testing GivenName",
+            "fullName": "FamilyName GivenName",
+            "dateOfBirth": 2555,
+            "dateOfDeath": null,
+            "gender": "F",
+            "nationality": "AUS",
+            "yearOfBirth": 1982,
+            "monthOfBirth": 11,
+            "dayOfBirth": 9,
+            "countryOfBirth": null,
+            "placeOfBirth": null,
+            "ethnicity": null,
+            "maritalStatus": null,
+            "religion": null,
+            "passportNumber": "119039399"
+          },
+          "attributes": {
+            "attrs": {
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.freqFlyerNumber": "680419104BA"
+            }
+          },
+          "matching": null,
+          "features": null,
+          "washResponses": null,
+          "matchMerge": null,
+          "changeHistory": null
         }
       ],
       "organisations": [
@@ -488,7 +555,7 @@
           "attributes": {
             "attrs": {
               "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentCountryCode": "GB",
-              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.freqFlyerNumber": "8767876",
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.freqFlyerNumber": "8767844",
               "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentCityCode": "LHR",
               "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentType": "A"
             }

--- a/cypress/integration/airpax/airpax-task-overview-page.spec.js
+++ b/cypress/integration/airpax/airpax-task-overview-page.spec.js
@@ -217,6 +217,9 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
 
     const expectedActivity = 'task dismissed, reason: other reason for testing, note: This is for testing';
 
+    const dateFormat = 'D MMM YYYY [at] HH:mm';
+    let taskCreationDateTime = Cypress.dayjs().utc().format(dateFormat);
+
     cy.acceptPNRTerms();
     cy.intercept('POST', 'v2/targeting-tasks/*/claim').as('claim');
     const taskName = 'AIRPAX';
@@ -243,6 +246,18 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
           cy.wrap(reason)
             .should('contain.text', reasons[index]).and('be.visible');
         });
+
+        cy.contains('Cancel').click();
+
+        cy.on('window:confirm', (str) => {
+          expect(str).to.equal('Are you sure you want to cancel?');
+        });
+
+        cy.on('window:confirm', () => true);
+
+        cy.get('.task-versions .task-versions--left').should('contain.text', taskCreationDateTime);
+
+        cy.contains('Dismiss').click();
 
         cy.contains('Next').click();
 

--- a/cypress/integration/airpax/airpax-task-overview-page.spec.js
+++ b/cypress/integration/airpax/airpax-task-overview-page.spec.js
@@ -207,6 +207,140 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     });
   });
 
+  it('Should dismiss a task with a reason', () => {
+    const reasons = [
+      'Vessel arrived',
+      'False rule match',
+      'Resource redirected',
+      'Other',
+    ];
+
+    const expectedActivity = 'task dismissed, reason: other reason for testing, note: This is for testing';
+
+    cy.acceptPNRTerms();
+    cy.intercept('POST', 'v2/targeting-tasks/*/claim').as('claim');
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((taskResponse) => {
+        expect(taskResponse.movement.id).to.contain('AIRPAX');
+        cy.wait(4000);
+        let businessKey = taskResponse.id;
+        cy.intercept('POST', '/v2/targeting-tasks/pages').as('airpaxTask');
+        cy.visit('/airpax/tasks');
+        cy.wait('@airpaxTask').then(({ response }) => {
+          expect(response.statusCode).to.be.equal(200);
+        });
+        cy.checkAirPaxTaskDisplayed(businessKey);
+
+        cy.claimAirPaxTask();
+
+        cy.wait(2000);
+
+        cy.contains('Dismiss').click();
+
+        cy.get('div[id="reasonForDismissing"] .govuk-radios__item label').each((reason, index) => {
+          cy.wrap(reason)
+            .should('contain.text', reasons[index]).and('be.visible');
+        });
+
+        cy.contains('Next').click();
+
+        cy.get('span[id="reasonForDismissing-error"]').should('contain.text', 'You must indicate at least one reason for dismissing the task');
+
+        cy.get('div[id="reasonForDismissing"] .govuk-radios__item')
+          .contains('Other')
+          .closest('div')
+          .find('input')
+          .click({ force: true });
+
+        cy.get('input[name="otherReasonToDismiss"]').type('other reason for testing');
+
+        cy.contains('Next').click();
+
+        cy.waitForNoErrors();
+
+        cy.get('textarea[id="addANote"]').type('This is for testing');
+
+        cy.contains('Submit form').click();
+
+        cy.verifySuccessfulSubmissionHeader('Task has been dismissed');
+
+        cy.visit(`/airpax/tasks/${businessKey}`);
+      });
+
+      cy.getActivityLogs().then((activities) => {
+        expect(activities).to.contain(expectedActivity);
+        expect(activities).not.to.contain('Property delete changed from false to true');
+      });
+    });
+  });
+
+  it('Should dismiss a task with a reason and without notes', () => {
+    const reasons = [
+      'Vessel arrived',
+      'False rule match',
+      'Resource redirected',
+      'Other',
+    ];
+
+    const expectedActivity = 'task dismissed, reason: false rule match';
+
+    cy.acceptPNRTerms();
+    cy.intercept('POST', 'v2/targeting-tasks/*/claim').as('claim');
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((taskResponse) => {
+        expect(taskResponse.movement.id).to.contain('AIRPAX');
+        cy.wait(4000);
+        let businessKey = taskResponse.id;
+        cy.intercept('POST', '/v2/targeting-tasks/pages').as('airpaxTask');
+        cy.visit('/airpax/tasks');
+        cy.wait('@airpaxTask').then(({ response }) => {
+          expect(response.statusCode).to.be.equal(200);
+        });
+        cy.checkAirPaxTaskDisplayed(businessKey);
+
+        cy.claimAirPaxTask();
+
+        cy.wait(2000);
+
+        cy.contains('Dismiss').click();
+
+        cy.get('div[id="reasonForDismissing"] .govuk-radios__item label').each((reason, index) => {
+          cy.wrap(reason)
+            .should('contain.text', reasons[index]).and('be.visible');
+        });
+
+        cy.contains('Next').click();
+
+        cy.get('span[id="reasonForDismissing-error"]').should('contain.text', 'You must indicate at least one reason for dismissing the task');
+
+        cy.get('div[id="reasonForDismissing"] .govuk-radios__item')
+          .contains('False rule match')
+          .closest('div')
+          .find('input')
+          .click({ force: true });
+
+        cy.contains('Next').click();
+
+        cy.waitForNoErrors();
+
+        cy.contains('Submit form').click();
+
+        cy.verifySuccessfulSubmissionHeader('Task has been dismissed');
+
+        cy.visit(`/airpax/tasks/${businessKey}`);
+      });
+
+      cy.getActivityLogs().then((activities) => {
+        expect(activities).to.contain(expectedActivity);
+        expect(activities).not.to.contain('Property delete changed from false to true');
+      });
+    });
+  });
+
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));


### PR DESCRIPTION
## Description
Add tests to verify User journey of dismissing an airpax task.

## To Test
npm run cypress:runner

run the tests from spec `airpax-task-overview-page.spec.js`

`Should dismiss a task with a reason`
`Should dismiss a task with a reason and without notes`

Note:  Test `Should dismiss a task with a reason` is failing at the moment because clicking on `Cancel` button during dismiss not taking back to the task details page & returns 500 error response.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
