### PR TITLE
COP-10949 - Handle form cancellation

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -7,6 +7,7 @@ import { Form, Formio } from 'react-formio';
 
 // Local imports
 import config from '../config';
+import { FORM_ACTION_CANCEL } from '../constants';
 import ErrorSummary from '../govuk/ErrorSummary';
 import useAxiosInstance from '../utils/axiosInstance';
 import FormUtils, { Renderers } from '../utils/Form';
@@ -164,7 +165,10 @@ const RenderForm = ({ formName, form: _form, renderer: _renderer, onSubmit, onCa
               hooks={{
                 onRequest: (req) => FormUtils.formHooks.onRequest(req, keycloak.token),
                 onGetComponent,
-                onSubmit: async (_, payload, onSuccess) => {
+                onSubmit: async (type, payload, onSuccess) => {
+                  if (type === FORM_ACTION_CANCEL) {
+                    onCancel();
+                  }
                   setLoaderVisibility(true);
                   try {
                     const { businessKey, submissionPayload } = await FormUtils.setupSubmission(

--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -167,7 +167,7 @@ const RenderForm = ({ formName, form: _form, renderer: _renderer, onSubmit, onCa
                 onGetComponent,
                 onSubmit: async (type, payload, onSuccess) => {
                   if (type === FORM_ACTION_CANCEL) {
-                    onCancel();
+                    return onCancel();
                   }
                   setLoaderVisibility(true);
                   try {

--- a/src/components/__tests__/RenderForm.test.jsx
+++ b/src/components/__tests__/RenderForm.test.jsx
@@ -1,0 +1,38 @@
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import '../../__mocks__/keycloakMock';
+
+import RenderForm from '../RenderForm';
+
+import dismissTask from '../../cop-forms/dismissTaskCerberus';
+import { Renderers } from '../../utils/Form';
+
+describe('RenderForm', () => {
+  const mockAxios = new MockAdapter(axios);
+  const FUNCTION_CALLS = [];
+
+  const ON_CANCEL = (action) => {
+    FUNCTION_CALLS.push(action);
+  };
+
+  beforeEach(() => {
+    FUNCTION_CALLS.length = 0;
+  });
+
+  it('should call the cancel function when the cancel button is clicked', () => {
+    render(<RenderForm
+      form={dismissTask}
+      onSubmit={jest.fn()}
+      onCancel={ON_CANCEL}
+      renderer={Renderers.REACT}
+    />);
+
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(FUNCTION_CALLS).toHaveLength(1);
+    expect(mockAxios.history.post).toHaveLength(1);
+  });
+});

--- a/src/components/__tests__/RenderForm.test.jsx
+++ b/src/components/__tests__/RenderForm.test.jsx
@@ -1,8 +1,6 @@
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
 import '../../__mocks__/keycloakMock';
 
 import RenderForm from '../RenderForm';
@@ -11,15 +9,14 @@ import dismissTask from '../../cop-forms/dismissTaskCerberus';
 import { Renderers } from '../../utils/Form';
 
 describe('RenderForm', () => {
-  const mockAxios = new MockAdapter(axios);
-  const FUNCTION_CALLS = [];
+  const ON_CANCEL_CALLS = [];
 
   const ON_CANCEL = (action) => {
-    FUNCTION_CALLS.push(action);
+    ON_CANCEL_CALLS.push(action);
   };
 
   beforeEach(() => {
-    FUNCTION_CALLS.length = 0;
+    ON_CANCEL_CALLS.length = 0;
   });
 
   it('should call the cancel function when the cancel button is clicked', () => {
@@ -32,7 +29,21 @@ describe('RenderForm', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    expect(FUNCTION_CALLS).toHaveLength(1);
-    expect(mockAxios.history.post).toHaveLength(1);
+    expect(ON_CANCEL_CALLS).toHaveLength(1);
+  });
+
+  it('should submit the form', () => {
+    render(<RenderForm
+      form={dismissTask}
+      onSubmit={jest.fn()}
+      onCancel={ON_CANCEL}
+      renderer={Renderers.REACT}
+    />);
+
+    userEvent.click(screen.getByRole('radio', { name: 'Vessel arrived' }));
+    userEvent.click(screen.getByRole('button', { name: 'Next' }));
+    userEvent.click(screen.getByRole('button', { name: 'Submit form' }));
+
+    expect(ON_CANCEL_CALLS).toHaveLength(0);
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -216,3 +216,5 @@ export const TAB_STATUS_MAPPING = {
   issued: 'ISSUED',
   complete: 'COMPLETE',
 };
+
+export const FORM_ACTION_CANCEL = 'cancel';

--- a/src/cop-forms/dismissTaskCerberus.js
+++ b/src/cop-forms/dismissTaskCerberus.js
@@ -58,7 +58,7 @@ export default {
       ],
       actions: [
         {
-          type: 'close',
+          type: 'cancel',
           label: 'Cancel',
           classModifiers: 'secondary',
         },

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -96,7 +96,7 @@ const TaskDetailsPage = () => {
   }, [refreshNotesForm]);
 
   const onCancel = () => {
-    history.go(0);
+    setDismissTaskFormOpen();
   };
 
   if (isLoading) {

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -95,6 +95,10 @@ const TaskDetailsPage = () => {
     getTaskData();
   }, [refreshNotesForm]);
 
+  const onCancel = () => {
+    history.go(0);
+  };
+
   if (isLoading) {
     return <LoadingSpinner><br /><br /><br /></LoadingSpinner>;
   }
@@ -163,6 +167,7 @@ const TaskDetailsPage = () => {
                   setSubmitted(true);
                 }
               }
+              onCancel={onCancel}
               form={dismissTask}
               renderer={Renderers.REACT}
             />


### PR DESCRIPTION
## Description
As form renderer does not have a mechanism of cancelling a form, this PR adds an implementation of cancelling the dismiss a task form.

## To Test
- Pull and run against dev.
- Claim an airpax task
- Click on the **`Dismiss`** action button
- Clicking on the **`Cancel`** button will cause the page to reload, exiting the form.

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
