### PR TITLE
COP-10953 : Add test to validate UPDATE label is displayed when a task is updated

### DIFF
--- a/cypress/integration/airpax/task-list-page.spec.js
+++ b/cypress/integration/airpax/task-list-page.spec.js
@@ -141,8 +141,8 @@ describe('Airpax task list page', () => {
       });
     });
   });
-  
-    it.only('Should not display UPDATED label on a new task, but display UPDATED after a task has been updated with new details', () => {
+
+  it('Should not display UPDATED label on a new task, but display UPDATED after a task has been updated with new details', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('taskList');
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax-no-selectors.json').then((task) => {
@@ -153,11 +153,11 @@ describe('Airpax task list page', () => {
         let businessKey = taskResponse.id;
         let movementId = taskResponse.movement.id;
         cy.wait(3000);
-         cy.visit('/airpax/tasks');
-            cy.wait(3000);
-            cy.wait('@taskList').then(({ response }) => {
-              expect(response.statusCode).to.equal(200);
-            });
+        cy.visit('/airpax/tasks');
+        cy.wait(3000);
+        cy.wait('@taskList').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
         cy.get('.govuk-task-list-card').then(($taskListCard) => {
           if ($taskListCard.text().includes(businessKey)) {
             cy.get('.govuk-task-list-card').contains(businessKey).parents('.card-container').within(() => {
@@ -181,14 +181,14 @@ describe('Airpax task list page', () => {
                   cy.get('p.govuk-tag--updatedTarget').invoke('text').then((text) => {
                     expect(text).to.equal('Updated');
                   });
-               });
+                });
               }
-            });   
+            });
           });
         });
       });
-      });
     });
+  });
 
   afterEach(() => {
     cy.contains('Sign out').click();

--- a/cypress/integration/airpax/task-list-page.spec.js
+++ b/cypress/integration/airpax/task-list-page.spec.js
@@ -153,8 +153,7 @@ describe('Airpax task list page', () => {
         let businessKey = taskResponse.id;
         let movementId = taskResponse.movement.id;
         cy.wait(3000);
-        cy.visit('/airpax/tasks');
-        cy.wait(3000);
+        cy.visit('/airpax/tasks');one
         cy.wait('@taskList').then(({ response }) => {
           expect(response.statusCode).to.equal(200);
         });
@@ -170,7 +169,6 @@ describe('Airpax task list page', () => {
           cy.createAirPaxTask(updateTask).then((updateResponse) => {
             expect(updateResponse.movement.id).to.contain(movementId);
             expect(updateResponse.id).to.equal(businessKey);
-            console.log(updateResponse);
             cy.reload();
             cy.wait('@taskList').then(({ response }) => {
               expect(response.statusCode).to.equal(200);

--- a/cypress/integration/airpax/task-list-page.spec.js
+++ b/cypress/integration/airpax/task-list-page.spec.js
@@ -153,7 +153,7 @@ describe('Airpax task list page', () => {
         let businessKey = taskResponse.id;
         let movementId = taskResponse.movement.id;
         cy.wait(3000);
-        cy.visit('/airpax/tasks');one
+        cy.visit('/airpax/tasks');
         cy.wait('@taskList').then(({ response }) => {
           expect(response.statusCode).to.equal(200);
         });


### PR DESCRIPTION
## Description
Add test to validate UPDATE label is displayed, when a task is updated
https://support.cop.homeoffice.gov.uk/browse/COP-10953
## To Test run  - npm run cypress:test:local -- --spec cypress/integration/airpax/task-list-page.spec.js

Should not display UPDATED label on a new task, but display UPDATED after a task has been updated with new details

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
