### PR TITLE
COP-10463: Add tests to verify Co-travellers details of AirPax task

### DIFF
--- a/cypress/fixtures/airpax/airpax-task-expected-details.json
+++ b/cypress/fixtures/airpax/airpax-task-expected-details.json
@@ -121,4 +121,25 @@
       "CA → GB  Arrival 3 Oct 2018 at 21:19": "XZ0123  YYC → LHR  Wed 3 Oct 2018 at 18:32"
     }
   ]
+  ],
+  "Co-travellers": [
+      {
+        "Traveller": "TravellerTESTING FAMILYNAME, Testing GivenName DCFemale, 30 Dec 1976, Australia (AU)",
+        "Age": "Age45",
+        "Check-in": "Check-in12 Jun 2022 at 13:00a month before departure",
+        "Seat": "Seat34A",
+        "Document": "DocumentPASSPORTIssued by GB",
+        "Checked baggage": "Checked baggage23kg",
+        "": "This movement"
+      },
+      {
+        "Traveller": "TravellerBATZ STOUP, ZUES CARLO DCMale, 10 Dec 1976, United Kingdom (GB)",
+        "Age": "Age45",
+        "Check-in": "Check-in12 Jun 2022 at 13:00a month before departure",
+        "Seat": "Seat34A",
+        "Document": "DocumentPASSPORTIssued by GB",
+        "Checked baggage": "Checked baggage23kg",
+        "": "Movement detail"
+      }
+    ]
 }

--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -455,6 +455,25 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
+  it('Should verify Co-traveller details of an AirPax task on task details page', () => {
+    cy.acceptPNRTerms();
+    const taskName = 'AUTOTEST';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((response) => {
+        cy.wait(4000);
+        cy.checkAirPaxTaskDisplayed(`${response.id}`);
+        cy.fixture('airpax/airpax-task-expected-details.json').then((expectedDetails) => {
+          cy.get('.co-travellers-container').within(() => {
+            cy.get('table').getTable().then((tableData) => {
+              expectedDetails['Co-travellers'].forEach((traveller) => expect(tableData).to.deep.include(traveller));
+            });
+          });
+        });
+      });
+    });
+  });
+
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));


### PR DESCRIPTION
## Description
Add tests to verify Co-travellers details of AirPax task

## To Test
npm run cypress:runner

run the test from spec `airpax-task-details.spec.js`

`Should verify Co-traveller details of an AirPax task on task details page`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
