### PR TITLE
Fixes RoRo relative time bug on task summary

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -51,6 +51,12 @@ export const FONT_CLASSES = {
   0: 'font__bold',
   1: 'font__light',
 };
+
+export const OPERATION = {
+  ADD: 'ADD',
+  SUBTRACT: 'SUBTRACT',
+};
+
 export const UNKNOWN_TIME_DATA = { h: null, m: null, s: null };
 export const CO_TRAVELLERS_TABLE_HEADERS = [
   'Traveller',

--- a/src/routes/airpax/TaskDetails/builder/Booking.jsx
+++ b/src/routes/airpax/TaskDetails/builder/Booking.jsx
@@ -12,7 +12,7 @@ import {
 } from '../../utils';
 
 import renderBlock from './helper/common';
-import calculateTimeDifference from '../../../../utils/calculateDatetimeDifference';
+import { calculateTimeDifference } from '../../../../utils/DatetimeUtil';
 
 const toBookingTimeDiference = (booking, version) => {
   const journey = MovementUtil.movementJourney(version);

--- a/src/routes/airpax/TaskDetails/builder/CoTraveller.jsx
+++ b/src/routes/airpax/TaskDetails/builder/CoTraveller.jsx
@@ -9,7 +9,7 @@ import { CO_TRAVELLERS_TABLE_HEADERS,
   UNKNOWN_TEXT } from '../../../../constants';
 
 import { PersonUtil, MovementUtil, BookingUtil, DateTimeUtil, DocumentUtil, BaggageUtil } from '../../utils';
-import calculateTimeDifference from '../../../../utils/calculateDatetimeDifference';
+import { calculateTimeDifference } from '../../../../utils/DatetimeUtil';
 import '../../../../components/__assets__/Table.scss';
 
 const isValid = (value) => {

--- a/src/routes/airpax/utils/bookingUtil.jsx
+++ b/src/routes/airpax/utils/bookingUtil.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import lookup from 'country-code-lookup';
 import { getFormattedDate, toDateTimeList } from './datetimeUtil';
-import calculateTimeDifference from '../../../utils/calculateDatetimeDifference';
+import { calculateTimeDifference } from '../../../utils/DatetimeUtil';
 
 import {
   UNKNOWN_TEXT,

--- a/src/routes/airpax/utils/datetimeUtil.js
+++ b/src/routes/airpax/utils/datetimeUtil.js
@@ -23,8 +23,7 @@ const toRelativeTime = (date) => {
     return UNKNOWN_TEXT;
   }
   const dateTimeStart = dayjs.utc(date);
-  const currentDatetime = getDate(true);
-  return dateTimeStart.from(currentDatetime);
+  return dateTimeStart.fromNow();
 };
 
 const isInPast = (date) => {

--- a/src/routes/airpax/utils/movementUtil.jsx
+++ b/src/routes/airpax/utils/movementUtil.jsx
@@ -20,7 +20,7 @@ import DateTimeUtil from './datetimeUtil';
 import { getTotalNumberOfPersons } from './personUtil';
 
 import { isNotNumber } from '../../../utils/roroDataUtil';
-import calculateTimeDifference from '../../../utils/calculateDatetimeDifference';
+import { calculateTimeDifference } from '../../../utils/DatetimeUtil';
 
 const toVoyageText = (dateTime, isTaskDetails = false, prefix = '') => {
   const time = DateTimeUtil.relativeTime(dateTime);

--- a/src/routes/roro/TaskDetails/TaskSummary.jsx
+++ b/src/routes/roro/TaskDetails/TaskSummary.jsx
@@ -5,7 +5,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { LONG_DATE_FORMAT, RORO_TOURIST, INDIVIDUAL_ICON, GROUP_ICON } from '../../../constants';
 import getMovementModeIcon from '../../../utils/getVehicleModeIcon';
 import { modifyRoRoPassengersTaskList, hasVehicle, hasTrailer, hasDriver, filterKnownPassengers } from '../../../utils/roroDataUtil';
-import { formatMovementModeIconText } from '../../../utils/stringConversion';
+import { formatMovementModeIconText, formatVoyageText } from '../../../utils/stringConversion';
 
 import '../__assets__/TaskDetailsPage.scss';
 
@@ -82,7 +82,7 @@ const TaskSummary = ({ movementMode, taskSummaryData }) => {
                     </span> <span className="font__bold">{roroData.arrivalLocation && `${roroData.arrivalLocation} `} </span>{'  '}
                     <span className="dot" />  {!roroData.eta ? 'unknown' : dayjs.utc(roroData.eta).format(LONG_DATE_FORMAT)}
                   </li>
-                  <li><span>Arrival {!roroData.eta ? 'unknown' : (dayjs.utc(roroData.eta).fromNow())}</span></li>
+                  <li><span>{!roroData.eta ? 'unknown' : formatVoyageText(roroData.eta)}</span></li>
                 </ul>
               </div>
             </div>

--- a/src/routes/roro/TaskLists/TaskListMode.jsx
+++ b/src/routes/roro/TaskLists/TaskListMode.jsx
@@ -5,10 +5,11 @@ import { v4 as uuidv4 } from 'uuid';
 import * as pluralise from 'pluralise';
 import * as constants from '../../../constants';
 // Utils
-import calculateTimeDifference from '../../../utils/calculateDatetimeDifference';
+import { calculateTimeDifference } from '../../../utils/DatetimeUtil';
 import formatGender from '../../../utils/genderFormatter';
 import { hasVehicleMake, hasVehicleModel, hasVehicle, hasTrailer, filterKnownPassengers } from '../../../utils/roroDataUtil';
 import EnrichmentCount from './TaskListEnrichmentCount';
+import { formatVoyageText } from '../../../utils/stringConversion';
 
 const getMovementModeTypeText = (movementModeIcon) => {
   switch (movementModeIcon) {
@@ -104,7 +105,11 @@ const renderRoroVoyageSection = (roroData) => {
   return (
     <div className="govuk-grid-column-three-quarters govuk-!-padding-right-7 align-right">
       <i className="c-icon-ship" />
-      <p className="content-line-one govuk-!-padding-right-2">{roroData.vessel.company && `${roroData.vessel.company} voyage of `}{roroData.vessel.name}{', '}arrival {!roroData.eta ? 'unknown' : dayjs.utc(roroData.eta).fromNow()}</p>
+      <p className="content-line-one govuk-!-padding-right-2">
+        {roroData.vessel.company
+        && `${roroData.vessel.company} voyage of ${roroData.vessel.name}, 
+        ${!roroData.eta ? 'unknown' : formatVoyageText(roroData.eta)}`}
+      </p>
       <p className="govuk-body-s content-line-two govuk-!-padding-right-2">
         {!roroData.departureTime ? 'unknown' : dayjs.utc(roroData.departureTime).format(constants.LONG_DATE_FORMAT)}{' '}
         <span className="dot" />

--- a/src/utils/DatetimeUtil.js
+++ b/src/utils/DatetimeUtil.js
@@ -12,6 +12,21 @@ dayjs.extend(relativeTime);
 dayjs.extend(updateLocale);
 dayjs.updateLocale('en', { relativeTime: config.dayjsConfig.relativeTime });
 
+const toRelativeTime = (date) => {
+  if (!date) {
+    return UNKNOWN_TEXT;
+  }
+  const dateTimeStart = dayjs.utc(date);
+  return dateTimeStart.fromNow();
+};
+
+const isInPast = (date) => {
+  if (date && date !== UNKNOWN_TEXT) {
+    return toRelativeTime(date)?.endsWith(AGO_TEXT);
+  }
+  return UNKNOWN_TEXT;
+};
+
 const calculateDifference = (startDate, endDate, prefix = '', suffix = '') => {
   const formattedPrefix = prefix ? `${prefix} ` : '';
   const dateTimeStart = dayjs.utc(startDate);
@@ -42,4 +57,12 @@ const calculateTimeDifference = (dateTimeArray, prefix = '', suffix = '') => {
   return calculateDifference(dateTimeArray[0], dateTimeArray[1], prefix, suffix);
 };
 
-export default calculateTimeDifference;
+const DateTimeUtil = {
+  calculateTimeDifference,
+  isPast: isInPast,
+  relativeTime: toRelativeTime,
+};
+
+export default DateTimeUtil;
+
+export { calculateTimeDifference, isInPast, toRelativeTime };

--- a/src/utils/__tests__/stringConversion.test.js
+++ b/src/utils/__tests__/stringConversion.test.js
@@ -1,10 +1,33 @@
-import { RORO_ACCOMPANIED_FREIGHT, RORO_TOURIST, RORO_UNACCOMPANIED_FREIGHT } from '../../constants';
-import { capitalizeFirstLetter, formatMovementModeIconText, escapeJSON } from '../stringConversion';
-import { testRoroDataTouristWithVehicle, testRoroDataAccompaniedFreight, testRoroDataUnaccompaniedFreight,
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+import { OPERATION,
+  RORO_ACCOMPANIED_FREIGHT,
+  RORO_TOURIST,
+  RORO_UNACCOMPANIED_FREIGHT,
+  UNKNOWN_TEXT } from '../../constants';
+
+import { capitalizeFirstLetter,
+  formatMovementModeIconText,
+  escapeJSON,
+  formatVoyageText } from '../stringConversion';
+
+import { testRoroDataTouristWithVehicle,
+  testRoroDataAccompaniedFreight,
+  testRoroDataUnaccompaniedFreight,
   testRoroDataAccompaniedFreightNoTrailer,
   testRoroDataAccompaniedFreightNoVehicleNoTrailer } from '../__fixtures__/roroData.fixture';
 
 describe('String Conversion', () => {
+  dayjs.extend(utc);
+
+  const getDate = (value, unit, op) => {
+    if (op === OPERATION.ADD) {
+      return dayjs.utc().add(value, unit).format();
+    }
+    return dayjs.utc().subtract(value, unit).format();
+  };
+
   it('should capitalise first letter of given', () => {
     const output = capitalizeFirstLetter('hello');
     expect(output.charAt(0)).toEqual('H');
@@ -59,5 +82,22 @@ describe('String Conversion', () => {
     const GIVEN = 0;
     const EXPECTED = '0';
     expect(escapeJSON(GIVEN)).toEqual(EXPECTED);
+  });
+
+  it('should return a relative formatted time text for a past activity', () => {
+    const EXPECTED = 'arrived a day ago';
+    const TIME = getDate(1, 'day', OPERATION.SUBTRACT);
+    expect(formatVoyageText(TIME)).toEqual(EXPECTED);
+  });
+
+  it('should return a relative formatted time text for a present/future activity', () => {
+    const EXPECTED = 'arriving in a day';
+    const TIME = getDate(1, 'day', OPERATION.ADD);
+    expect(formatVoyageText(TIME)).toEqual(EXPECTED);
+  });
+
+  it('should return unknown for an invalid datetime range', () => {
+    const INVALID_DATESTIMES = [undefined, null, ''];
+    INVALID_DATESTIMES.forEach((datetime) => expect(formatVoyageText(datetime)).toEqual(UNKNOWN_TEXT));
   });
 });

--- a/src/utils/stringConversion.js
+++ b/src/utils/stringConversion.js
@@ -1,8 +1,22 @@
-import { RORO_TOURIST } from '../constants';
+import { BEFORE_TRAVEL_TEXT, RORO_TOURIST, UNKNOWN_TEXT } from '../constants';
+
 import { hasVehicle, hasTrailer } from './roroDataUtil';
+import DateTimeUtil from './DatetimeUtil';
 
 const capitalizeFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+const formatVoyageText = (dateTime) => {
+  const time = DateTimeUtil.relativeTime(dateTime);
+  const isPastDate = DateTimeUtil.isPast(dateTime);
+  if (isPastDate !== UNKNOWN_TEXT) {
+    if (isPastDate) {
+      return `arrived ${time}`.trim();
+    }
+    return `arriving in ${time.replace(BEFORE_TRAVEL_TEXT, '')}`.trim();
+  }
+  return UNKNOWN_TEXT;
 };
 
 const formatMovementModeIconText = (roroData, movementMode) => {
@@ -28,4 +42,4 @@ const escapeJSON = (input) => {
     .replace(/"/g, '\\"');
 };
 
-export { capitalizeFirstLetter, formatMovementModeIconText, escapeJSON };
+export { capitalizeFirstLetter, formatMovementModeIconText, escapeJSON, formatVoyageText };


### PR DESCRIPTION
## Description
This PR fixes the relative time text bug on the roro task details and task list page. The appropriate text is returned along with the time calculated by `dayjs` library.

## To Test
- Pull and run against dev.
- On the task list page, if a task has already arrived, part of the summary text will say `...arrived 3 years ago`.
- On the task list page, if a task is due to arrive, part of the summary text will say `...arriving in 3 years`.
- The above applies to task details page task summary.