### PR TITLE
Pnr access request (bug fix)

### DIFF
--- a/src/context/PnrAccessContext.jsx
+++ b/src/context/PnrAccessContext.jsx
@@ -1,0 +1,20 @@
+import React, { useState, createContext } from 'react';
+
+import { PNR_USER_SESSION_ID } from '../constants';
+
+const PnrAccessContext = createContext({});
+
+const PnrAccessProvider = ({ children }) => {
+  const storedUserSession = JSON.parse(localStorage.getItem(PNR_USER_SESSION_ID));
+  const [canViewPnrData, setCanViewPnrData] = useState(storedUserSession?.requested);
+
+  const setViewPnrData = (viewData) => setCanViewPnrData(viewData);
+
+  return (
+    <PnrAccessContext.Provider value={{ canViewPnrData, setViewPnrData }}>
+      {children}
+    </PnrAccessContext.Provider>
+  );
+};
+
+export { PnrAccessContext, PnrAccessProvider };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,13 +3,16 @@ import { render } from 'react-dom';
 import AppRouter from './routes';
 import { KeycloakProvider } from './utils/keycloak';
 import { TaskSelectedTabProvider } from './context/TaskSelectedTabContext';
+import { PnrAccessProvider } from './context/PnrAccessContext';
 import './__assets__/index.scss';
 
 render(
   <KeycloakProvider>
-    <TaskSelectedTabProvider>
-      <AppRouter />
-    </TaskSelectedTabProvider>
+    <PnrAccessProvider>
+      <TaskSelectedTabProvider>
+        <AppRouter />
+      </TaskSelectedTabProvider>
+    </PnrAccessProvider>
   </KeycloakProvider>,
   document.getElementById('root'),
 );

--- a/src/routes/access/PnrAccessRequest.jsx
+++ b/src/routes/access/PnrAccessRequest.jsx
@@ -1,8 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import config from '../../config';
 import { Renderers } from '../../utils/Form';
 import { useKeycloak } from '../../utils/keycloak';
 import useAxiosInstance from '../../utils/axiosInstance';
+
+import { PnrAccessContext } from '../../context/PnrAccessContext';
 
 import { PNR_USER_SESSION_ID } from '../../constants';
 
@@ -19,6 +21,7 @@ import viewPnrData from '../../cop-forms/viewPnrData';
 const PnrAccessRequest = ({ children }) => {
   const [isSubmitted, setSubmitted] = useState(false);
   const [displayForm, setDisplayForm] = useState(false);
+  const { setViewPnrData } = useContext(PnrAccessContext);
 
   const keycloak = useKeycloak();
   const taskApiClient = useAxiosInstance(keycloak, config.taskApiUrl);
@@ -76,6 +79,7 @@ const PnrAccessRequest = ({ children }) => {
                           },
                         );
                         storeSession(PNR_USER_SESSION_ID, response.data.user.sessionId, response.data.requested);
+                        setViewPnrData(response.data.requested);
                       } catch (e) {
                         setSubmitted(false);
                       } finally {

--- a/src/routes/airpax/TaskLists/TaskListPage.jsx
+++ b/src/routes/airpax/TaskLists/TaskListPage.jsx
@@ -51,7 +51,6 @@ const TaskListPage = () => {
   const [isLoading, setLoading] = useState(true);
   const [appliedFilters, setAppliedFilters] = useState(DEFAULT_APPLIED_AIRPAX_FILTER_STATE);
   const [rulesOptions, setRulesOptions] = useState([]);
-  const [canViewPnr, setCanViewPnr] = useState(true);
   const { taskManagementTabIndex, selectTaskManagementTabIndex, selectTabIndex } = useContext(TaskSelectedTabContext);
 
   const getRulesOptions = async () => {
@@ -249,8 +248,6 @@ const TaskListPage = () => {
                       filtersToApply={appliedFilters}
                       setError={setError}
                       targetTaskCount={taskCountsByStatus?.new}
-                      canViewPnr={canViewPnr}
-                      setCanViewPnr={setCanViewPnr}
                     />
                   </>
                 ),
@@ -266,8 +263,6 @@ const TaskListPage = () => {
                       filtersToApply={appliedFilters}
                       setError={setError}
                       targetTaskCount={taskCountsByStatus?.inProgress}
-                      canViewPnr={canViewPnr}
-                      setCanViewPnr={setCanViewPnr}
                     />
                   </>
                 ),
@@ -283,8 +278,6 @@ const TaskListPage = () => {
                       filtersToApply={appliedFilters}
                       setError={setError}
                       targetTaskCount={taskCountsByStatus?.issued}
-                      canViewPnr={canViewPnr}
-                      setCanViewPnr={setCanViewPnr}
                     />
                   </>
                 ),
@@ -300,8 +293,6 @@ const TaskListPage = () => {
                       filtersToApply={appliedFilters}
                       setError={setError}
                       targetTaskCount={taskCountsByStatus?.complete}
-                      canViewPnr={canViewPnr}
-                      setCanViewPnr={setCanViewPnr}
                     />
                   </>
                 ),

--- a/src/routes/airpax/TaskLists/TasksTab.jsx
+++ b/src/routes/airpax/TaskLists/TasksTab.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Button } from '@ukhomeoffice/cop-react-components';
 import { useInterval } from 'react-use';
 import { useLocation } from 'react-router-dom';
@@ -22,13 +22,13 @@ import Pagination from '../../../components/Pagination';
 import TaskListCard from './TaskListCard';
 import { STATUS_CODES, PNR_USER_SESSION_ID, TASK_STATUS_MAPPING } from '../../../constants';
 
+import { PnrAccessContext } from '../../../context/PnrAccessContext';
+
 const TasksTab = ({
   taskStatus,
   filtersToApply = { taskStatuses: [], movementModes: ['AIR_PASSENGER'], selectors: 'ANY' },
   setError,
   targetTaskCount = 0,
-  canViewPnr,
-  setCanViewPnr,
 }) => {
   dayjs.extend(relativeTime);
   dayjs.extend(utc);
@@ -39,6 +39,8 @@ const TasksTab = ({
   const apiClient = useAxiosInstance(keycloak, config.taskApiUrl);
   const refDataClient = useAxiosInstance(keycloak, config.refdataApiUrl);
   const source = axios.CancelToken.source();
+
+  const { canViewPnrData } = useContext(PnrAccessContext);
 
   const [activePage, setActivePage] = useState(0);
   const [targetTasks, setTargetTasks] = useState([]);
@@ -90,8 +92,6 @@ const TasksTab = ({
     } catch (e) {
       if (!e.message.endsWith(STATUS_CODES.FORBIDDEN)) {
         setError(e.message);
-      } else if (e.message.endsWith(STATUS_CODES.FORBIDDEN)) {
-        setCanViewPnr(false);
       }
       setTargetTasks([]);
     } finally {
@@ -152,7 +152,7 @@ const TasksTab = ({
     return <LoadingSpinner />;
   }
 
-  if (!canViewPnr) {
+  if (!canViewPnrData) {
     const formattedStatus = TASK_STATUS_MAPPING[taskStatus];
     return (
       <>
@@ -168,7 +168,7 @@ const TasksTab = ({
     );
   }
 
-  if (targetTasks.length === 0 && canViewPnr) {
+  if (targetTasks.length === 0 && canViewPnrData) {
     return <p className="govuk-body-l">There are no {TASK_STATUS_MAPPING[taskStatus]} tasks</p>;
   }
 

--- a/src/routes/airpax/__tests__/TaskListPage.test.jsx
+++ b/src/routes/airpax/__tests__/TaskListPage.test.jsx
@@ -5,12 +5,15 @@ import MockAdapter from 'axios-mock-adapter';
 import '../../../__mocks__/keycloakMock';
 // Components/Pages
 import { TaskSelectedTabContext } from '../../../context/TaskSelectedTabContext';
+import { PnrAccessContext } from '../../../context/PnrAccessContext';
+
 import TaskListPage from '../TaskLists/TaskListPage';
 
 import { TASK_STATUS_COMPLETED,
   TASK_STATUS_IN_PROGRESS,
   TASK_STATUS_NEW,
-  TASK_STATUS_TARGET_ISSUED } from '../../../constants';
+  TASK_STATUS_TARGET_ISSUED,
+  PNR_USER_SESSION_ID } from '../../../constants';
 
 // Fixture
 import dataCurrentUser from '../__fixtures__/taskData_AirPax_AssigneeCurrentUser.fixture.json';
@@ -26,6 +29,8 @@ describe('TaskListPage', () => {
   let defaultPostPagesParams;
 
   let tabData = {};
+
+  let pnrData = {};
 
   const countsFiltersAndSelectorsResponse = [
     {
@@ -123,6 +128,12 @@ describe('TaskListPage', () => {
       selectTabIndex: jest.fn(),
       selectTaskManagementTabIndex: jest.fn(),
     };
+
+    pnrData = {
+      canViewPnrData: true,
+      setViewPnrData: jest.fn(),
+    };
+
     mockAxios.reset();
 
     defaultPostPagesParams = {
@@ -148,15 +159,18 @@ describe('TaskListPage', () => {
     };
   });
 
-  const setTabAndTaskValues = (value, taskStatus = 'new') => {
+  const setTabAndTaskValues = (tabValue, pnrValue, taskStatus = 'new') => {
     return (
-      <TaskSelectedTabContext.Provider value={value}>
-        <TaskListPage taskStatus={taskStatus} />
-      </TaskSelectedTabContext.Provider>
+      <PnrAccessContext.Provider value={pnrValue}>
+        <TaskSelectedTabContext.Provider value={tabValue}>
+          <TaskListPage taskStatus={taskStatus} />
+        </TaskSelectedTabContext.Provider>
+      </PnrAccessContext.Provider>
     );
   };
 
   it('should render a message related to the tab clicked, on click', async () => {
+    localStorage.setItem(PNR_USER_SESSION_ID, JSON.stringify({ sessionId: '123-456', requested: true }));
     mockAxios
       .onPost('/targeting-tasks/pages')
       .reply(200, [])
@@ -167,7 +181,7 @@ describe('TaskListPage', () => {
       .onGet('/filters/rules')
       .reply(200, []);
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'new')));
 
     expect(screen.queryByText('You are not authorised to view these tasks.')).not.toBeInTheDocument();
     expect(screen.getByText('New tasks')).toBeInTheDocument();
@@ -201,7 +215,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'new')));
 
     expect(screen.getByText('Single passenger')).toBeInTheDocument();
     expect(screen.getByText('DC')).toBeInTheDocument();
@@ -237,7 +251,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'new')));
 
     expect(JSON.parse(mockAxios.history.post[0].data)).toMatchObject(EXPECTED_POST_PARAM);
   });
@@ -249,7 +263,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'new')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'new')));
     expect(screen.getByText('Claim')).toBeInTheDocument();
   });
 
@@ -260,7 +274,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'inProgress')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'inProgress')));
     expect(screen.getByText('Assigned to you')).toBeInTheDocument();
     expect(screen.getByText('Unclaim task')).toBeInTheDocument();
   });
@@ -272,7 +286,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'inProgress')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'inProgress')));
     expect(screen.getByText('Assigned to notcurrentuser')).toBeInTheDocument();
     expect(screen.getByText('Unclaim task')).toBeInTheDocument();
   });
@@ -284,7 +298,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'issued')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'issued')));
     expect(screen.queryByText('Assigned to you')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to notcurrentuser')).not.toBeInTheDocument();
     expect(screen.queryByText('Claim')).not.toBeInTheDocument();
@@ -298,7 +312,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, 'complete')));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, 'complete')));
     expect(screen.queryByText('Assigned to you')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to notcurrentuser')).not.toBeInTheDocument();
     expect(screen.queryByText('Claim')).not.toBeInTheDocument();
@@ -313,7 +327,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, TASK_STATUS_NEW)));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, TASK_STATUS_NEW)));
 
     expect(JSON.parse(mockAxios.history.post[0].data)).toMatchObject(EXPECTED_POST_PARAM);
   });
@@ -329,7 +343,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, TASK_STATUS_IN_PROGRESS)));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, TASK_STATUS_IN_PROGRESS)));
 
     expect(JSON.parse(mockAxios.history.post[0].data)).toMatchObject(EXPECTED_POST_PARAM);
   });
@@ -344,7 +358,7 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, TASK_STATUS_TARGET_ISSUED)));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, TASK_STATUS_TARGET_ISSUED)));
 
     expect(JSON.parse(mockAxios.history.post[0].data)).toMatchObject(EXPECTED_POST_PARAM);
   });
@@ -359,41 +373,78 @@ describe('TaskListPage', () => {
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, TASK_STATUS_COMPLETED)));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, TASK_STATUS_COMPLETED)));
 
     expect(JSON.parse(mockAxios.history.post[0].data)).toMatchObject(EXPECTED_POST_PARAM);
   });
 
-  it('should render the button to request PNR access when the user does not have access to PNR data (new tab)', async () => {
+  it('should render button to request PNR access when has no access to PNR data across tabs', async () => {
+    pnrData.canViewPnrData = false;
+    localStorage.setItem(PNR_USER_SESSION_ID, JSON.stringify({ sessionId: '123-456', requested: false }));
     defaultPostPagesParams.filterParams.taskStatuses = [TASK_STATUS_NEW.toUpperCase()];
+
     mockAxios
       .onPost('/targeting-tasks/pages')
       .reply(403, dataNoAssignee)
       .onGet('/v2/entities/carrierlist')
       .reply(200, { data: airlineCodes });
 
-    await waitFor(() => render(setTabAndTaskValues(tabData, TASK_STATUS_NEW)));
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, TASK_STATUS_NEW)));
 
     expect(screen.getByText(/You do not have access to view new PNR data/)).toBeInTheDocument();
     expect(screen.getByText(/To view new PNR data, you will need to request access/)).toBeInTheDocument();
     expect(screen.getByText(/Request access to new PNR data/)).toBeInTheDocument();
-  });
-
-  it('should render the button to request PNR access when the user does not have access to PNR data (in progress tab)', async () => {
-    defaultPostPagesParams.filterParams.taskStatuses = [TASK_STATUS_IN_PROGRESS.toUpperCase()];
-
-    mockAxios
-      .onPost('/targeting-tasks/pages')
-      .reply(403, dataNoAssignee)
-      .onGet('/v2/entities/carrierlist')
-      .reply(200, { data: airlineCodes });
-
-    await waitFor(() => render(setTabAndTaskValues(tabData, TASK_STATUS_IN_PROGRESS)));
 
     await waitFor(() => fireEvent.click(screen.getByRole('link', { name: 'In progress (0)' })));
 
     expect(screen.getByText(/You do not have access to view in progress PNR data/)).toBeInTheDocument();
     expect(screen.getByText(/To view in progress PNR data, you will need to request access/)).toBeInTheDocument();
     expect(screen.getByText(/Request access to in progress PNR data/)).toBeInTheDocument();
+
+    await waitFor(() => fireEvent.click(screen.getByRole('link', { name: 'Issued (0)' })));
+
+    expect(screen.getByText(/You do not have access to view issued PNR data/)).toBeInTheDocument();
+    expect(screen.getByText(/To view issued PNR data, you will need to request access/)).toBeInTheDocument();
+    expect(screen.getByText(/Request access to issued PNR data/)).toBeInTheDocument();
+
+    await waitFor(() => fireEvent.click(screen.getByRole('link', { name: 'Complete (0)' })));
+    expect(screen.getByText(/You do not have access to view complete PNR data/)).toBeInTheDocument();
+    expect(screen.getByText(/To view complete PNR data, you will need to request access/)).toBeInTheDocument();
+    expect(screen.getByText(/Request access to complete PNR data/)).toBeInTheDocument();
+  });
+
+  it('should render button to request PNR access when user has no access to PNR data and api returns an empty tasks array', async () => {
+    pnrData.canViewPnrData = false;
+    localStorage.setItem(PNR_USER_SESSION_ID, JSON.stringify({ sessionId: '123-456', requested: false }));
+    defaultPostPagesParams.filterParams.taskStatuses = [TASK_STATUS_IN_PROGRESS.toUpperCase()];
+
+    mockAxios
+      .onPost('/targeting-tasks/pages')
+      .reply(403, [])
+      .onGet('/v2/entities/carrierlist')
+      .reply(200, { data: airlineCodes });
+
+    await waitFor(() => render(setTabAndTaskValues(tabData, pnrData, TASK_STATUS_NEW)));
+
+    expect(screen.getByText(/You do not have access to view new PNR data/)).toBeInTheDocument();
+    expect(screen.getByText(/To view new PNR data, you will need to request access/)).toBeInTheDocument();
+    expect(screen.getByText(/Request access to new PNR data/)).toBeInTheDocument();
+
+    await waitFor(() => fireEvent.click(screen.getByRole('link', { name: 'In progress (0)' })));
+
+    expect(screen.getByText(/You do not have access to view in progress PNR data/)).toBeInTheDocument();
+    expect(screen.getByText(/To view in progress PNR data, you will need to request access/)).toBeInTheDocument();
+    expect(screen.getByText(/Request access to in progress PNR data/)).toBeInTheDocument();
+
+    await waitFor(() => fireEvent.click(screen.getByRole('link', { name: 'Issued (0)' })));
+
+    expect(screen.getByText(/You do not have access to view issued PNR data/)).toBeInTheDocument();
+    expect(screen.getByText(/To view issued PNR data, you will need to request access/)).toBeInTheDocument();
+    expect(screen.getByText(/Request access to issued PNR data/)).toBeInTheDocument();
+
+    await waitFor(() => fireEvent.click(screen.getByRole('link', { name: 'Complete (0)' })));
+    expect(screen.getByText(/You do not have access to view complete PNR data/)).toBeInTheDocument();
+    expect(screen.getByText(/To view complete PNR data, you will need to request access/)).toBeInTheDocument();
+    expect(screen.getByText(/Request access to complete PNR data/)).toBeInTheDocument();
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,9 @@ module.exports = {
         pathRewrite: { '^/v2': '' },
         secure: false,
         changeOrigin: true,
+        onProxyReq(request) {
+          request.setHeader('origin', process.env.TARGETING_API_URL);
+        },
       },
     },
   },


### PR DESCRIPTION
## Description
This PR address a minor bug where if the `cop-targeting-api` returns an empty array when the user has said they do not want to view PNR data, the button which allows the user to resubmit a justification is not rendered.