### PR TITLE
COP-10478: Add tests to verify the PNS access control message

### DIFF
--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -24,20 +24,57 @@ describe('Verify AirPax task details of different sections', () => {
   });
 
   it('Should check airPax task not visible if User not agreed for PNR terms', () => {
+    const expectedText = 'You do not have access to view new PNR data. \n'
+        + '          To view new PNR data, \n'
+        + '          you will need to request access.';
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('airpaxTask');
     cy.visit('/airpax/tasks');
     cy.doNotAcceptPNRTerms();
     cy.wait('@airpaxTask').then(({ response }) => {
       expect(response.statusCode).to.be.equal(403);
     });
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText);
+    });
+    cy.get('a[href="#inProgress"]').click();
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText.replace(/new/g, 'in progress'));
+    });
+    cy.get('a[href="#issued"]').click();
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText.replace(/new/g, 'issued'));
+    });
+    cy.get('a[href="#complete"]').click();
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText.replace(/new/g, 'complete'));
+    });
   });
 
   it('Should check airPax task not visible if User not in the authorised location', () => {
+    const expectedText = 'You do not have access to view new PNR data. \n'
+        + '          To view new PNR data, \n'
+        + '          you will need to request access.';
+
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('airpaxTask');
     cy.visit('/airpax/tasks');
     cy.userNotInApprovedLocation();
     cy.wait('@airpaxTask').then(({ response }) => {
       expect(response.statusCode).to.be.equal(403);
+    });
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText);
+    });
+    cy.get('a[href="#inProgress"]').click();
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText.replace(/new/g, 'in progress'));
+    });
+    cy.get('a[href="#issued"]').click();
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText.replace(/new/g, 'issued'));
+    });
+    cy.get('a[href="#complete"]').click();
+    cy.get('.govuk-body-l').invoke('text').then((text) => {
+      expect(text.trim()).to.be.equal(expectedText.replace(/new/g, 'complete'));
     });
   });
 


### PR DESCRIPTION
## Description
Add tests to verify the PNS access control message

## To Test
npm run cypress:runner

run the following tests from spec `airpax-task-details.spec.js`
`Should check airPax task not visible if User not agreed for PNR terms`
`Should check airPax task not visible if User not in the authorised location`

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
