### PR TITLE
Cop 10921: Add test to Forward RORO movement records from cop targeting api to cerberus workflow service

### DIFF
--- a/cypress/fixtures/RoRo-tourist-v2.json
+++ b/cypress/fixtures/RoRo-tourist-v2.json
@@ -1,0 +1,706 @@
+{
+    "data": {
+        "movementId": "ROROXML:CMID=7c9977b1e44a4b7defa066754a5add1a/60e14ec3f5f109464c3f20457662b971/b09aba9186ad63e598755d0fc9eab2e4",
+        "riskSubmissionId": 53582,
+        "riskCreatedDate": "2021-12-30T11:14:03.647585Z",
+        "riskType": "Pre-Arrival",
+        "matchedRules": [
+            {
+                "ruleId": 208,
+                "ruleName": "PF - Cash Paid",
+                "ruleType": "Pre-arrival",
+                "ruleVersion": 2,
+                "ruleDescription": "Booking has been paid by Cash",
+                "securityLabels": [
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null"
+                ],
+                "ruleMatchedOnDate": "2021-12-30T11:14:03Z",
+                "rulePriority": "Tier 4",
+                "indicatorMatches": [
+                    {
+                        "entity": "Message",
+                        "descriptor": "cashPaid",
+                        "operator": "equals",
+                        "value": "true"
+                    },
+                    {
+                        "entity": "Message",
+                        "descriptor": "mode",
+                        "operator": "in",
+                        "value": "[RORO Tourist]"
+                    }
+                ],
+                "abuseTypes": [
+                    "Class A Drugs"
+                ]
+            }
+        ],
+        "matchedSelectors": [],
+        "movement": {
+            "cerberusMovementId": "ROROXML:CMID=7c9977b1e44a4b7defa066754a5add1a/60e14ec3f5f109464c3f20457662b971/b09aba9186ad63e598755d0fc9eab2e4",
+            "firstCerberusTimestamp": 1640862721569,
+            "cerberusTimestamp": 1640862813565,
+            "latestMessageType": "EVENT_SNAPSHOT",
+            "cerberusInternalLabels": [
+                "incomplete_travel-history-enrichment",
+                "incomplete_wash",
+                "needs_travel-history"
+            ],
+            "messageAnalysis": {
+                "messageMatches": [
+                    {
+                        "sourceMessageVersion": 1,
+                        "expectedMatches": 3,
+                        "countOfMatches": 3,
+                        "sourceMsgEnriches": 0
+                    }
+                ],
+                "countOfSourceMessages": 1,
+                "countOfSnapshots": 4,
+                "countOfNoStateChanges": 1,
+                "countOfWashes": 2,
+                "countOfEnrichments": 0,
+                "firstRunlogTimestamp": 1640862721925,
+                "lastRunlogTimestamp": 1640862721925,
+                "firstSnapshotTimestamp": 1640862721684,
+                "lastSnapshotTimestamp": 1640862813565,
+                "firstNSCTimestamp": 1640862721964,
+                "lastNSCTimestamp": 1640862721964,
+                "firstWashTimestamp": 1640862723611,
+                "lastWashTimestamp": 1640862723660,
+                "firstEnrichTimestamp": 0,
+                "lastEnrichTimestamp": 0,
+                "matchesComplete": true,
+                "latestVersion": "1.3"
+            },
+            "serviceMovement": {
+                "metadata": {
+                    "identityRecord": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:S=ff504aab4a3f10af49f367020f50d61f"
+                            },
+                            "v1": {
+                                "id": 103004818437996
+                            }
+                        },
+                        "type": "S"
+                    },
+                    "sourceRecord": {
+                        "name": "ROROXML",
+                        "shortName": "ROX",
+                        "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63942614/ETBKDBEL20211030.XML.364_20211230_111110790",
+                        "id": "ff504aab4a3f10af49f367020f50d61f",
+                        "audit": {
+                            "createdBy": "O3/qwRP5p7UagpXRdFZHiA==",
+                            "createdTimestamp": 1640862721258,
+                            "updatedBy": null,
+                            "updatedTimestamp": null,
+                            "deletedBy": null,
+                            "deletedTimestamp": null
+                        }
+                    },
+                    "complianceRecord": {
+                        "visibility": "UNKNOWN",
+                        "gscMarker": null,
+                        "retentionMarkerDays": -1
+                    },
+                    "mappingRecord": {
+                        "name": "RR-XML-Service-Movement",
+                        "version": "1"
+                    }
+                },
+                "type": "MOVEMENT",
+                "effectiveFromTimestamp": 1640860200000,
+                "effectiveToTimestamp": 1640889000000,
+                "dueTimestamp": null,
+                "status": null,
+                "movement": {
+                    "type": "Pre-Arrival",
+                    "businessIdentifier": "87982044",
+                    "mode": "RORO Tourist",
+                    "source": "Stena Line",
+                    "actualDepartureTimestamp": 1640860200000
+                },
+                "attributes": {
+                    "attrs": {
+                        "reference": "87982044",
+                        "oapCount": "0",
+                        "adultCount": "1",
+                        "bookingDateTime": "2021-12-30T10:15:59.547",
+                        "bookingCountry": "GB",
+                        "paymentMethod": "Cash",
+                        "childCount": "0",
+                        "ticketType": "Single",
+                        "driverCount": "0",
+                        "infantCount": "0"
+                    }
+                },
+                "features": {
+                    "feats": {
+                        "TOURIST-LATE-BOOKING-0_1_HR": {
+                            "id": null,
+                            "type": "TXE",
+                            "valueType": "BOOL",
+                            "value": true,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:bookingDateTime": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "STRING",
+                            "value": "2021-12-30T10:15:59.547Z",
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "RORO-BOOKING-MOVEMENT-CO-TRAVELLERS": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "STRING",
+                            "value": null,
+                            "valueList": {
+                                "val": []
+                            },
+                            "startTimestamp": null,
+                            "endTimestamp": 1640862723346
+                        },
+                        "STANDARDISED:cashPaid-PROXY": {
+                            "id": null,
+                            "type": "SCORED_INDICATOR",
+                            "valueType": "INT",
+                            "value": 30,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:cashPaid": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "BOOL",
+                            "value": true,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "TOURIST-LATE-BOOKING-0_1_HR-PROXY": {
+                            "id": null,
+                            "type": "SCORED_INDICATOR",
+                            "valueType": "INT",
+                            "value": 30,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:bookingIntentHours": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "LONG",
+                            "value": 0,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        }
+                    }
+                },
+                "changeHistory": null
+            },
+            "persons": [
+                {
+                    "metadata": {
+                        "identityRecord": {
+                            "poleId": {
+                                "v2": {
+                                    "id": "ROROXML:P=908350b6c424420bada6fb655122a149"
+                                },
+                                "v1": {
+                                    "id": 101004818438003
+                                }
+                            },
+                            "type": "P"
+                        },
+                        "sourceRecord": {
+                            "name": "ROROXML",
+                            "shortName": "ROX",
+                            "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63942614/ETBKDBEL20211030.XML.364_20211230_111110790",
+                            "id": "908350b6c424420bada6fb655122a149",
+                            "audit": {
+                                "createdBy": "O3/qwRP5p7UagpXRdFZHiA==",
+                                "createdTimestamp": 1640862721258,
+                                "updatedBy": null,
+                                "updatedTimestamp": null,
+                                "deletedBy": null,
+                                "deletedTimestamp": null
+                            }
+                        },
+                        "complianceRecord": {
+                            "visibility": "UNKNOWN",
+                            "gscMarker": null,
+                            "retentionMarkerDays": -1
+                        },
+                        "mappingRecord": {
+                            "name": "RR-XML-Party",
+                            "version": "1"
+                        }
+                    },
+                    "type": "PERSON",
+                    "person": {
+                        "type": "PERPAS",
+                        "title": null,
+                        "familyName": "geanina mihaela",
+                        "givenName": "calauz",
+                        "fullName": "calauz geanina mihaela",
+                        "dateOfBirth": null,
+                        "dateOfDeath": null,
+                        "gender": "M",
+                        "nationality": "GB",
+                        "yearOfBirth": null,
+                        "monthOfBirth": null,
+                        "dayOfBirth": null,
+                        "countryOfBirth": null,
+                        "placeOfBirth": null,
+                        "ethnicity": null,
+                        "maritalStatus": null,
+                        "religion": null,
+                        "passportNumber": null
+                    },
+                    "attributes": {
+                        "attrs": {
+                            "classification": "Adult",
+                            "role": "FOOTPASSENGER"
+                        }
+                    },
+                    "matching": {
+                        "svxId": 1476511514751606793,
+                        "selfScore": 82,
+                        "matchScore": null,
+                        "version": 0,
+                        "timestamp": 1640862752129
+                    },
+                    "features": {
+                        "feats": {
+                            "STANDARDISED:nationality": {
+                                "id": null,
+                                "type": null,
+                                "valueType": "STRING",
+                                "value": "GBR",
+                                "valueList": null,
+                                "startTimestamp": null,
+                                "endTimestamp": null
+                            }
+                        }
+                    },
+                    "washResponses": null,
+                    "matchMerge": {
+                        "matching": {
+                            "svxId": 1476511514751606793,
+                            "selfScore": 82,
+                            "matchScore": null,
+                            "version": 0,
+                            "timestamp": 1640862752129
+                        }
+                    },
+                    "changeHistory": {
+                        "changes": [
+                            {
+                                "sourceVersion": 1,
+                                "cerberusTimestamp": 1640862801100,
+                                "state": {
+                                    "creationTimestamp": 1640862721408,
+                                    "updateTimestamp": 1640862800940,
+                                    "version": 1
+                                },
+                                "change": {
+                                    "type": "STATE_CHANGE_SERVICE",
+                                    "changes": [
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "svxId",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "1476511514751606793"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "selfScore",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "82"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "version",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "0"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "timestamp",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "2021-12-30T11:12:32.129Z"
+                                            },
+                                            "entryChange": null
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "organisations": [
+                {
+                    "metadata": {
+                        "identityRecord": {
+                            "poleId": {
+                                "v2": {
+                                    "id": "ROROXML:P=17b408032d7e493c4cb7c0c37be278e6"
+                                },
+                                "v1": {
+                                    "id": 101004818437993
+                                }
+                            },
+                            "type": "P"
+                        },
+                        "sourceRecord": {
+                            "name": "ROROXML",
+                            "shortName": "ROX",
+                            "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63942614/ETBKDBEL20211030.XML.364_20211230_111110790",
+                            "id": "17b408032d7e493c4cb7c0c37be278e6",
+                            "audit": {
+                                "createdBy": "O3/qwRP5p7UagpXRdFZHiA==",
+                                "createdTimestamp": 1640862721258,
+                                "updatedBy": null,
+                                "updatedTimestamp": null,
+                                "deletedBy": null,
+                                "deletedTimestamp": null
+                            }
+                        },
+                        "complianceRecord": {
+                            "visibility": "UNKNOWN",
+                            "gscMarker": null,
+                            "retentionMarkerDays": -1
+                        },
+                        "mappingRecord": {
+                            "name": "RR-XML-Party",
+                            "version": "1"
+                        }
+                    },
+                    "type": "ORGANISATION",
+                    "organisation": {
+                        "type": "ORGBOOKER",
+                        "name": "calauz geanina mihaela",
+                        "registrationNumber": null,
+                        "vatNumber": null,
+                        "industrySector": null,
+                        "numberOfEmployees": null
+                    },
+                    "attributes": {
+                        "attrs": {
+                            "reference": "87982044",
+                            "countryOfBooking": "GB",
+                            "paymentMethod": "Cash",
+                            "ticketType": "Single",
+                            "bookingDateTime": "2021-12-30T10:15:59.547"
+                        }
+                    },
+                    "matching": {
+                        "svxId": 1476511515838025756,
+                        "selfScore": 18,
+                        "matchScore": null,
+                        "version": 0,
+                        "timestamp": 1640862752395
+                    },
+                    "features": null,
+                    "washResponses": null,
+                    "matchMerge": {
+                        "matching": {
+                            "svxId": 1476511515838025756,
+                            "selfScore": 18,
+                            "matchScore": null,
+                            "version": 0,
+                            "timestamp": 1640862752395
+                        }
+                    },
+                    "changeHistory": {
+                        "changes": [
+                            {
+                                "sourceVersion": 1,
+                                "cerberusTimestamp": 1640862813565,
+                                "state": {
+                                    "creationTimestamp": 1640862721402,
+                                    "updateTimestamp": 1640862813434,
+                                    "version": 1
+                                },
+                                "change": {
+                                    "type": "STATE_CHANGE_SERVICE",
+                                    "changes": [
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "svxId",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "1476511515838025756"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "selfScore",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "18"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "version",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "0"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "timestamp",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "2021-12-30T11:12:32.395Z"
+                                            },
+                                            "entryChange": null
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "documents": null,
+            "vehicles": null,
+            "vessel": {
+                "metadata": {
+                    "identityRecord": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:P=null[5cc3ff2fd2152d3bccd472fe33fb54cf],O=5cc3ff2fd2152d3bccd472fe33fb54cf"
+                            },
+                            "v1": {
+                                "id": 102004658430548
+                            }
+                        },
+                        "type": "O"
+                    },
+                    "sourceRecord": {
+                        "name": "ROROXML",
+                        "shortName": "ROX",
+                        "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63942614/ETBKDBEL20211030.XML.364_20211230_111110790",
+                        "id": "5cc3ff2fd2152d3bccd472fe33fb54cf",
+                        "audit": {
+                            "createdBy": "O3/qwRP5p7UagpXRdFZHiA==",
+                            "createdTimestamp": 1640862721258,
+                            "updatedBy": null,
+                            "updatedTimestamp": null,
+                            "deletedBy": null,
+                            "deletedTimestamp": null
+                        }
+                    },
+                    "complianceRecord": {
+                        "visibility": "UNKNOWN",
+                        "gscMarker": null,
+                        "retentionMarkerDays": -1
+                    },
+                    "mappingRecord": {
+                        "name": "RR-XML-Object-Vessel",
+                        "version": "1"
+                    }
+                },
+                "type": "VESSEL",
+                "party": {
+                    "poleId": {
+                        "v2": {
+                            "id": "ROROXML:P=null[5cc3ff2fd2152d3bccd472fe33fb54cf]"
+                        },
+                        "v1": null
+                    },
+                    "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vessel": {
+                    "type": "OBJVESWTR",
+                    "name": "Stena Edda",
+                    "operator": "Stena Line",
+                    "registrationNumber": null,
+                    "registrationCountry": null,
+                    "registrationPort": null,
+                    "mmsi": null,
+                    "imo": null,
+                    "callSign": null
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+            },
+            "addresses": null,
+            "contacts": null,
+            "voyage": {
+                "metadata": {
+                    "identityRecord": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:S=b33a44cece16cda881345b9374f18995"
+                            },
+                            "v1": {
+                                "id": 103004818437173
+                            }
+                        },
+                        "type": "S"
+                    },
+                    "sourceRecord": {
+                        "name": "ROROXML",
+                        "shortName": "ROX",
+                        "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63942614/ETBKDBEL20211030.XML.364_20211230_111110790",
+                        "id": "b33a44cece16cda881345b9374f18995",
+                        "audit": {
+                            "createdBy": "O3/qwRP5p7UagpXRdFZHiA==",
+                            "createdTimestamp": 1640862721258,
+                            "updatedBy": null,
+                            "updatedTimestamp": null,
+                            "deletedBy": null,
+                            "deletedTimestamp": null
+                        }
+                    },
+                    "complianceRecord": {
+                        "visibility": "UNKNOWN",
+                        "gscMarker": null,
+                        "retentionMarkerDays": -1
+                    },
+                    "mappingRecord": {
+                        "name": "RR-XML-Service-Voyage",
+                        "version": "1"
+                    }
+                },
+                "type": "VOYAGE",
+                "effectiveFromTimestamp": 1640860200000,
+                "effectiveToTimestamp": 1640889000000,
+                "dueTimestamp": null,
+                "status": null,
+                "voyage": {
+                    "type": "COMMERCIAL",
+                    "voyageType": "SEA",
+                    "departureLocation": "BKD",
+                    "departureCountry": null,
+                    "scheduledDepartureTimestamp": 1640860200000,
+                    "actualDepartureTimestamp": 1640860200000,
+                    "arrivalLocation": "BEL",
+                    "arrivalCountry": null,
+                    "scheduledArrivalTimestamp": 1640889000000,
+                    "actualArrivalTimestamp": 1640889000000,
+                    "intermediateLocations": null,
+                    "passengerCount": null,
+                    "crewCount": null,
+                    "durationMinutes": null,
+                    "routeId": null,
+                    "carrier": "Stena Line",
+                    "craftId": "Stena Edda"
+                },
+                "attributes": {
+                    "attrs": {
+                        "freightMovementCount": "157",
+                        "touristMovementCount": "125"
+                    }
+                },
+                "features": {
+                    "feats": {
+                        "STANDARDISED:arrivalPort": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "MAP",
+                            "value": null,
+                            "valueList": {
+                                "val": [
+                                    {
+                                        "UNLO5": "GBBEL"
+                                    }
+                                ]
+                            },
+                            "startTimestamp": null,
+                            "endTimestamp": 1640862721935
+                        },
+                        "STANDARDISED:estimatedArrivalTimestamp": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "LONG",
+                            "value": 1640889000000,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:departurePort": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "MAP",
+                            "value": null,
+                            "valueList": {
+                                "val": [
+                                    {
+                                        "UNLO5": "GBBRK"
+                                    }
+                                ]
+                            },
+                            "startTimestamp": null,
+                            "endTimestamp": 1640862721935
+                        }
+                    }
+                },
+                "changeHistory": null
+            },
+            "consolidation": null,
+            "consignments": null,
+            "booking": null,
+            "seizure": null,
+            "detainment": null
+        }
+    }
+}

--- a/cypress/fixtures/RoRo-unaccompanied-v2.json
+++ b/cypress/fixtures/RoRo-unaccompanied-v2.json
@@ -1,0 +1,1404 @@
+{
+    "data": {
+        "movementId": "ROROXML:CMID=407a807484b28b145ae7523a3ac75331/b8023f94b83f92a1310a664aeab2caf1/",
+        "riskSubmissionId": 53566,
+        "riskCreatedDate": "2021-12-30T08:51:40.02339Z",
+        "riskType": "Pre-Arrival",
+        "matchedRules": [
+            {
+                "ruleId": 206,
+                "ruleName": "goods description",
+                "ruleType": "Pre-arrival",
+                "ruleVersion": 1,
+                "ruleDescription": "test",
+                "securityLabels": [
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null",
+                    "null"
+                ],
+                "ruleMatchedOnDate": "2021-12-30T08:51:40Z",
+                "rulePriority": "Tier 1",
+                "indicatorMatches": [
+                    {
+                        "entity": "Message",
+                        "descriptor": "mode",
+                        "operator": "in",
+                        "value": "[RORO Unaccompanied Freight]"
+                    },
+                    {
+                        "entity": "Movement",
+                        "descriptor": "goodsDescriptionString",
+                        "operator": "in",
+                        "value": "[Metal]"
+                    }
+                ],
+                "abuseTypes": [
+                    "Class A Drugs"
+                ]
+            }
+        ],
+        "matchedSelectors": [],
+        "movement": {
+            "cerberusMovementId": "ROROXML:CMID=407a807484b28b145ae7523a3ac75331/b8023f94b83f92a1310a664aeab2caf1/",
+            "firstCerberusTimestamp": 1640854176969,
+            "cerberusTimestamp": 1640854259675,
+            "latestMessageType": "EVENT_SNAPSHOT",
+            "cerberusInternalLabels": [
+                "incomplete_travel-history-enrichment",
+                "incomplete_wash",
+                "needs_travel-history"
+            ],
+            "messageAnalysis": {
+                "messageMatches": [
+                    {
+                        "sourceMessageVersion": 1,
+                        "expectedMatches": 6,
+                        "countOfMatches": 6,
+                        "sourceMsgEnriches": 0
+                    }
+                ],
+                "countOfSourceMessages": 1,
+                "countOfSnapshots": 10,
+                "countOfNoStateChanges": 1,
+                "countOfWashes": 5,
+                "countOfEnrichments": 0,
+                "firstRunlogTimestamp": 1640854176969,
+                "lastRunlogTimestamp": 1640854176969,
+                "firstSnapshotTimestamp": 1640854177020,
+                "lastSnapshotTimestamp": 1640854259675,
+                "firstNSCTimestamp": 1640854177371,
+                "lastNSCTimestamp": 1640854177371,
+                "firstWashTimestamp": 1640854179365,
+                "lastWashTimestamp": 1640854184408,
+                "firstEnrichTimestamp": 0,
+                "lastEnrichTimestamp": 0,
+                "matchesComplete": true,
+                "latestVersion": "1.6"
+            },
+            "serviceMovement": {
+                "metadata": {
+                    "identityRecord": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:S=1424763a4b2c4225e8e67b84c3097c4c"
+                            },
+                            "v1": {
+                                "id": 103004818032066
+                            }
+                        },
+                        "type": "S"
+                    },
+                    "sourceRecord": {
+                        "name": "ROROXML",
+                        "shortName": "ROX",
+                        "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                        "id": "1424763a4b2c4225e8e67b84c3097c4c",
+                        "audit": {
+                            "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                            "createdTimestamp": 1640854176773,
+                            "updatedBy": null,
+                            "updatedTimestamp": null,
+                            "deletedBy": null,
+                            "deletedTimestamp": null
+                        }
+                    },
+                    "complianceRecord": {
+                        "visibility": "UNKNOWN",
+                        "gscMarker": null,
+                        "retentionMarkerDays": -1
+                    },
+                    "mappingRecord": {
+                        "name": "RR-XML-Service-Movement",
+                        "version": "1"
+                    }
+                },
+                "type": "MOVEMENT",
+                "effectiveFromTimestamp": 1640853900000,
+                "effectiveToTimestamp": 1640884500000,
+                "dueTimestamp": null,
+                "status": null,
+                "movement": {
+                    "type": "Pre-Arrival",
+                    "businessIdentifier": "72486800",
+                    "mode": "RORO Unaccompanied Freight",
+                    "source": "Stena Line",
+                    "actualDepartureTimestamp": 1640853900000
+                },
+                "attributes": {
+                    "attrs": {
+                        "reference": "72486800",
+                        "waybillNumber": "72486800",
+                        "checkInDateTime": "2021-12-30T07:19:39",
+                        "bookingDateTime": "2021-05-03T09:38:10",
+                        "hazardousCargo": "false",
+                        "bookingCountry": "GB",
+                        "paymentMethod": "Account",
+                        "ticketType": "Single",
+                        "goodsDescription": "Metal"
+                    }
+                },
+                "features": {
+                    "feats": {
+                        "STANDARDISED:checkInDateTime": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "STRING",
+                            "value": "2021-12-30T07:19:39Z",
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:bookingDateTime": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "STRING",
+                            "value": "2021-05-03T09:38:10Z",
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:checkInLeadTimeMilliseconds": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "LONG",
+                            "value": 5121000,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:isHazardousGoods": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "BOOL",
+                            "value": false,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:bookingIntentHours": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "LONG",
+                            "value": 5783,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        }
+                    }
+                },
+                "changeHistory": null
+            },
+            "persons": null,
+            "organisations": [
+                {
+                    "metadata": {
+                        "identityRecord": {
+                            "poleId": {
+                                "v2": {
+                                    "id": "ROROXML:P=5032d6cfb43f0d7c39c4bfd56595b306"
+                                },
+                                "v1": {
+                                    "id": 101004818032083
+                                }
+                            },
+                            "type": "P"
+                        },
+                        "sourceRecord": {
+                            "name": "ROROXML",
+                            "shortName": "ROX",
+                            "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                            "id": "5032d6cfb43f0d7c39c4bfd56595b306",
+                            "audit": {
+                                "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                                "createdTimestamp": 1640854176773,
+                                "updatedBy": null,
+                                "updatedTimestamp": null,
+                                "deletedBy": null,
+                                "deletedTimestamp": null
+                            }
+                        },
+                        "complianceRecord": {
+                            "visibility": "UNKNOWN",
+                            "gscMarker": null,
+                            "retentionMarkerDays": -1
+                        },
+                        "mappingRecord": {
+                            "name": "RR-XML-Party",
+                            "version": "1"
+                        }
+                    },
+                    "type": "ORGANISATION",
+                    "organisation": {
+                        "type": "ORGBOOKER",
+                        "name": "Stena Staff",
+                        "registrationNumber": null,
+                        "vatNumber": null,
+                        "industrySector": null,
+                        "numberOfEmployees": null
+                    },
+                    "attributes": {
+                        "attrs": {
+                            "reference": "72486800",
+                            "countryOfBooking": "GB",
+                            "paymentMethod": "Account",
+                            "ticketType": "Single",
+                            "checkInDateTime": "2021-12-30T07:19:39",
+                            "bookingDateTime": "2021-05-03T09:38:10"
+                        }
+                    },
+                    "matching": {
+                        "svxId": 1476475647030943745,
+                        "selfScore": 74,
+                        "matchScore": null,
+                        "version": 0,
+                        "timestamp": 1640854200505
+                    },
+                    "features": null,
+                    "washResponses": null,
+                    "matchMerge": {
+                        "matching": {
+                            "svxId": 1476475647030943745,
+                            "selfScore": 74,
+                            "matchScore": null,
+                            "version": 0,
+                            "timestamp": 1640854200505
+                        }
+                    },
+                    "changeHistory": {
+                        "changes": [
+                            {
+                                "sourceVersion": 1,
+                                "cerberusTimestamp": 1640854259675,
+                                "state": {
+                                    "creationTimestamp": 1640854176898,
+                                    "updateTimestamp": 1640854259547,
+                                    "version": 1
+                                },
+                                "change": {
+                                    "type": "STATE_CHANGE_SERVICE",
+                                    "changes": [
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "svxId",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "1476475647030943745"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "selfScore",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "74"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "version",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "0"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "timestamp",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "2021-12-30T08:50:00.505Z"
+                                            },
+                                            "entryChange": null
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "metadata": {
+                        "identityRecord": {
+                            "poleId": {
+                                "v2": {
+                                    "id": "ROROXML:P=87e53ca584b1e071f41edd1764434420"
+                                },
+                                "v1": {
+                                    "id": 101004818032100
+                                }
+                            },
+                            "type": "P"
+                        },
+                        "sourceRecord": {
+                            "name": "ROROXML",
+                            "shortName": "ROX",
+                            "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                            "id": "87e53ca584b1e071f41edd1764434420",
+                            "audit": {
+                                "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                                "createdTimestamp": 1640854176773,
+                                "updatedBy": null,
+                                "updatedTimestamp": null,
+                                "deletedBy": null,
+                                "deletedTimestamp": null
+                            }
+                        },
+                        "complianceRecord": {
+                            "visibility": "UNKNOWN",
+                            "gscMarker": null,
+                            "retentionMarkerDays": -1
+                        },
+                        "mappingRecord": {
+                            "name": "RR-XML-Party",
+                            "version": "1"
+                        }
+                    },
+                    "type": "ORGANISATION",
+                    "organisation": {
+                        "type": "ORGACCOUNT",
+                        "name": "MAMMOET FERRY TRANSPORT (UK) BV",
+                        "registrationNumber": null,
+                        "vatNumber": null,
+                        "industrySector": null,
+                        "numberOfEmployees": null
+                    },
+                    "attributes": {
+                        "attrs": {
+                            "referenceNumber": "MAMMUKBV",
+                            "holderName": "42117770"
+                        }
+                    },
+                    "matching": {
+                        "svxId": 1476475644606611456,
+                        "selfScore": 74,
+                        "matchScore": null,
+                        "version": 0,
+                        "timestamp": 1640854200092
+                    },
+                    "features": null,
+                    "washResponses": null,
+                    "matchMerge": {
+                        "matching": {
+                            "svxId": 1476475644606611456,
+                            "selfScore": 74,
+                            "matchScore": null,
+                            "version": 0,
+                            "timestamp": 1640854200092
+                        }
+                    },
+                    "changeHistory": {
+                        "changes": [
+                            {
+                                "sourceVersion": 1,
+                                "cerberusTimestamp": 1640854259493,
+                                "state": {
+                                    "creationTimestamp": 1640854176899,
+                                    "updateTimestamp": 1640854259380,
+                                    "version": 1
+                                },
+                                "change": {
+                                    "type": "STATE_CHANGE_SERVICE",
+                                    "changes": [
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "svxId",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "1476475644606611456"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "selfScore",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "74"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "version",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "0"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.party.PartyRecord/#matching",
+                                            "property": "timestamp",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "2021-12-30T08:50:00.092Z"
+                                            },
+                                            "entryChange": null
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "documents": null,
+            "vehicles": [
+                {
+                    "metadata": {
+                        "identityRecord": {
+                            "poleId": {
+                                "v2": {
+                                    "id": "ROROXML:P=null[3d05ca067c0d4772f587c01c26a843b1],O=3d05ca067c0d4772f587c01c26a843b1"
+                                },
+                                "v1": {
+                                    "id": 102004818032117
+                                }
+                            },
+                            "type": "O"
+                        },
+                        "sourceRecord": {
+                            "name": "ROROXML",
+                            "shortName": "ROX",
+                            "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                            "id": "3d05ca067c0d4772f587c01c26a843b1",
+                            "audit": {
+                                "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                                "createdTimestamp": 1640854176773,
+                                "updatedBy": null,
+                                "updatedTimestamp": null,
+                                "deletedBy": null,
+                                "deletedTimestamp": null
+                            }
+                        },
+                        "complianceRecord": {
+                            "visibility": "UNKNOWN",
+                            "gscMarker": null,
+                            "retentionMarkerDays": -1
+                        },
+                        "mappingRecord": {
+                            "name": "RR-XML-Object-Vehicle",
+                            "version": "1"
+                        }
+                    },
+                    "type": "VEHICLE",
+                    "party": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:P=null[3d05ca067c0d4772f587c01c26a843b1]"
+                            },
+                            "v1": {
+                                "id": 101004818032123
+                            }
+                        },
+                        "type": "P"
+                    },
+                    "role": "UNKNOWN",
+                    "startTimestamp": null,
+                    "endTimestamp": null,
+                    "name": null,
+                    "description": null,
+                    "additionalInformation": null,
+                    "url": null,
+                    "vehicle": {
+                        "type": "OBJVEHCTRL",
+                        "make": null,
+                        "model": null,
+                        "vin": null,
+                        "registrationNumber": "MTB3759",
+                        "registrationCountry": null,
+                        "year": null,
+                        "colour": null,
+                        "markings": null
+                    },
+                    "attributes": {
+                        "attrs": {
+                            "netWeight": "6500",
+                            "grossWeight": "16500",
+                            "role": "FREIGHT",
+                            "statusOfLoading": "Loaded",
+                            "type": "TR"
+                        }
+                    },
+                    "matching": {
+                        "svxId": 1476475640638787585,
+                        "selfScore": 40,
+                        "matchScore": null,
+                        "version": 0,
+                        "timestamp": 1640854198976
+                    },
+                    "features": null,
+                    "washResponses": [
+                        {
+                            "matched": {
+                                "poleId": 102001019806669,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001022418168,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001022973673,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001027327663,
+                                "sourceSystem": "RHTO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001031032193,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001033917809,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001032298905,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001039100083,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001029341204,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102001032838871,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004623678888,
+                                "sourceSystem": "ROTO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004637735434,
+                                "sourceSystem": "ROTO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004659396226,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004660086247,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004660407687,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004660489833,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004666303323,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004668753829,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004671373444,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        },
+                        {
+                            "matched": {
+                                "poleId": 102004673177684,
+                                "sourceSystem": "RHXO04006",
+                                "entityType": "SVO_OBJ",
+                                "entityId": 1425170416442183681,
+                                "selfScore": 0,
+                                "matchScore": 40,
+                                "comparisonDetail": null,
+                                "version": 1,
+                                "lastChangedTimestamp": 1640854179424
+                            },
+                            "objectRecord": null
+                        }
+                    ],
+                    "matchMerge": {
+                        "matching": {
+                            "svxId": 1476475640638787585,
+                            "selfScore": 40,
+                            "matchScore": null,
+                            "version": 0,
+                            "timestamp": 1640854198976
+                        }
+                    },
+                    "changeHistory": {
+                        "changes": [
+                            {
+                                "sourceVersion": 1,
+                                "cerberusTimestamp": 1640854242968,
+                                "state": {
+                                    "creationTimestamp": 1640854176904,
+                                    "updateTimestamp": 1640854242774,
+                                    "version": 1
+                                },
+                                "change": {
+                                    "type": "STATE_CHANGE_SERVICE",
+                                    "changes": [
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.object.ObjectRecord/#matching",
+                                            "property": "svxId",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "1476475640638787585"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.object.ObjectRecord/#matching",
+                                            "property": "selfScore",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "40"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.object.ObjectRecord/#matching",
+                                            "property": "version",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "0"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.object.ObjectRecord/#matching",
+                                            "property": "timestamp",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "2021-12-30T08:49:58.976Z"
+                                            },
+                                            "entryChange": null
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "vessel": {
+                "metadata": {
+                    "identityRecord": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:P=null[aa6013475ee95f8d8b89ee1911c1cc5d],O=aa6013475ee95f8d8b89ee1911c1cc5d"
+                            },
+                            "v1": {
+                                "id": 102004658443382
+                            }
+                        },
+                        "type": "O"
+                    },
+                    "sourceRecord": {
+                        "name": "ROROXML",
+                        "shortName": "ROX",
+                        "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                        "id": "aa6013475ee95f8d8b89ee1911c1cc5d",
+                        "audit": {
+                            "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                            "createdTimestamp": 1640854176773,
+                            "updatedBy": null,
+                            "updatedTimestamp": null,
+                            "deletedBy": null,
+                            "deletedTimestamp": null
+                        }
+                    },
+                    "complianceRecord": {
+                        "visibility": "UNKNOWN",
+                        "gscMarker": null,
+                        "retentionMarkerDays": -1
+                    },
+                    "mappingRecord": {
+                        "name": "RR-XML-Object-Vessel",
+                        "version": "1"
+                    }
+                },
+                "type": "VESSEL",
+                "party": {
+                    "poleId": {
+                        "v2": {
+                            "id": "ROROXML:P=null[aa6013475ee95f8d8b89ee1911c1cc5d]"
+                        },
+                        "v1": null
+                    },
+                    "type": "P"
+                },
+                "role": "UNKNOWN",
+                "startTimestamp": null,
+                "endTimestamp": null,
+                "name": null,
+                "description": null,
+                "additionalInformation": null,
+                "url": null,
+                "vessel": {
+                    "type": "OBJVESWTR",
+                    "name": "STENA HOLLANDICA",
+                    "operator": "Stena Line",
+                    "registrationNumber": null,
+                    "registrationCountry": null,
+                    "registrationPort": null,
+                    "mmsi": null,
+                    "imo": null,
+                    "callSign": null
+                },
+                "attributes": null,
+                "matching": null,
+                "features": null,
+                "washResponses": null,
+                "matchMerge": null,
+                "changeHistory": null
+            },
+            "addresses": [
+                {
+                    "metadata": {
+                        "identityRecord": {
+                            "poleId": {
+                                "v2": {
+                                    "id": "ROROXML:P=87e53ca584b1e071f41edd1764434420,L=0fed64033bc1e55e776a183c0df277eb"
+                                },
+                                "v1": {
+                                    "id": 103004818032096
+                                }
+                            },
+                            "type": "L"
+                        },
+                        "sourceRecord": {
+                            "name": "ROROXML",
+                            "shortName": "ROX",
+                            "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                            "id": "0fed64033bc1e55e776a183c0df277eb",
+                            "audit": {
+                                "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                                "createdTimestamp": 1640854176773,
+                                "updatedBy": null,
+                                "updatedTimestamp": null,
+                                "deletedBy": null,
+                                "deletedTimestamp": null
+                            }
+                        },
+                        "complianceRecord": {
+                            "visibility": "UNKNOWN",
+                            "gscMarker": null,
+                            "retentionMarkerDays": -1
+                        },
+                        "mappingRecord": {
+                            "name": "RR-XML-Location-Address",
+                            "version": "1"
+                        }
+                    },
+                    "type": "ADDRESS",
+                    "party": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:P=87e53ca584b1e071f41edd1764434420"
+                            },
+                            "v1": {
+                                "id": 101004818032099
+                            }
+                        },
+                        "type": "P"
+                    },
+                    "role": "PTOLASSO",
+                    "startTimestamp": null,
+                    "endTimestamp": null,
+                    "address": {
+                        "type": "LOCADDR",
+                        "postCode": "WA7 3GE",
+                        "poBox": null,
+                        "fullAddress": "Aston Lane North Preston Brook Runcorn WA7 3GE GB",
+                        "name": "MAMMOET FERRY TRANSPORT (UK) BV",
+                        "siteLocation": null,
+                        "number": null,
+                        "street": null,
+                        "town": "Runcorn",
+                        "area": null,
+                        "district": null,
+                        "county": null,
+                        "country": "GB",
+                        "uniquePropertyReferenceNumber": null,
+                        "latitude": null,
+                        "longitude": null
+                    },
+                    "attributes": {
+                        "attrs": {
+                            "addressLine1": "Aston Lane North",
+                            "addressLine2": "Preston Brook"
+                        }
+                    },
+                    "matching": {
+                        "svxId": 1476475646120804353,
+                        "selfScore": 52,
+                        "matchScore": null,
+                        "version": 0,
+                        "timestamp": 1640854200283
+                    },
+                    "features": null,
+                    "washResponses": null,
+                    "matchMerge": {
+                        "matching": {
+                            "svxId": 1476475646120804353,
+                            "selfScore": 52,
+                            "matchScore": null,
+                            "version": 0,
+                            "timestamp": 1640854200283
+                        }
+                    },
+                    "changeHistory": {
+                        "changes": [
+                            {
+                                "sourceVersion": 1,
+                                "cerberusTimestamp": 1640854232362,
+                                "state": {
+                                    "creationTimestamp": 1640854176899,
+                                    "updateTimestamp": 1640854232256,
+                                    "version": 1
+                                },
+                                "change": {
+                                    "type": "STATE_CHANGE_SERVICE",
+                                    "changes": [
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "svxId",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "1476475646120804353"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "selfScore",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "52"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "version",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "0"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "timestamp",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "2021-12-30T08:50:00.283Z"
+                                            },
+                                            "entryChange": null
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "metadata": {
+                        "identityRecord": {
+                            "poleId": {
+                                "v2": {
+                                    "id": "ROROXML:P=5032d6cfb43f0d7c39c4bfd56595b306,L=e18b2228c4943619ccdfad074c8efee3"
+                                },
+                                "v1": {
+                                    "id": 103004818032067
+                                }
+                            },
+                            "type": "L"
+                        },
+                        "sourceRecord": {
+                            "name": "ROROXML",
+                            "shortName": "ROX",
+                            "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                            "id": "e18b2228c4943619ccdfad074c8efee3",
+                            "audit": {
+                                "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                                "createdTimestamp": 1640854176773,
+                                "updatedBy": null,
+                                "updatedTimestamp": null,
+                                "deletedBy": null,
+                                "deletedTimestamp": null
+                            }
+                        },
+                        "complianceRecord": {
+                            "visibility": "UNKNOWN",
+                            "gscMarker": null,
+                            "retentionMarkerDays": -1
+                        },
+                        "mappingRecord": {
+                            "name": "RR-XML-Location-Address",
+                            "version": "1"
+                        }
+                    },
+                    "type": "ADDRESS",
+                    "party": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:P=5032d6cfb43f0d7c39c4bfd56595b306"
+                            },
+                            "v1": {
+                                "id": 101004818032083
+                            }
+                        },
+                        "type": "P"
+                    },
+                    "role": "PTOLASSO",
+                    "startTimestamp": null,
+                    "endTimestamp": null,
+                    "address": {
+                        "type": "LOCADDR",
+                        "postCode": "WA7 3GE",
+                        "poBox": null,
+                        "fullAddress": "Aston Lane North Preston Brook Runcorn WA7 3GE GB",
+                        "name": "Stena Staff",
+                        "siteLocation": null,
+                        "number": null,
+                        "street": null,
+                        "town": "Runcorn",
+                        "area": null,
+                        "district": null,
+                        "county": null,
+                        "country": "GB",
+                        "uniquePropertyReferenceNumber": null,
+                        "latitude": null,
+                        "longitude": null
+                    },
+                    "attributes": {
+                        "attrs": {
+                            "addressLine1": "Aston Lane North",
+                            "addressLine2": "Preston Brook"
+                        }
+                    },
+                    "matching": {
+                        "svxId": 1476475647689519104,
+                        "selfScore": 52,
+                        "matchScore": null,
+                        "version": 0,
+                        "timestamp": 1640854200657
+                    },
+                    "features": null,
+                    "washResponses": null,
+                    "matchMerge": {
+                        "matching": {
+                            "svxId": 1476475647689519104,
+                            "selfScore": 52,
+                            "matchScore": null,
+                            "version": 0,
+                            "timestamp": 1640854200657
+                        }
+                    },
+                    "changeHistory": {
+                        "changes": [
+                            {
+                                "sourceVersion": 1,
+                                "cerberusTimestamp": 1640854232402,
+                                "state": {
+                                    "creationTimestamp": 1640854176895,
+                                    "updateTimestamp": 1640854232237,
+                                    "version": 1
+                                },
+                                "change": {
+                                    "type": "STATE_CHANGE_SERVICE",
+                                    "changes": [
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "svxId",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "1476475647689519104"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "selfScore",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "52"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "version",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "0"
+                                            },
+                                            "entryChange": null
+                                        },
+                                        {
+                                            "type": "VALUE_CHANGED",
+                                            "object": "uk.gov.ho.dacc.pole.location.LocationRecord/#matching",
+                                            "property": "timestamp",
+                                            "propertyChange": {
+                                                "oldValue": null,
+                                                "newValue": "2021-12-30T08:50:00.657Z"
+                                            },
+                                            "entryChange": null
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "contacts": null,
+            "voyage": {
+                "metadata": {
+                    "identityRecord": {
+                        "poleId": {
+                            "v2": {
+                                "id": "ROROXML:S=19aafdcd743bd63ca19bfe917f75a2db"
+                            },
+                            "v1": {
+                                "id": 103004818031888
+                            }
+                        },
+                        "type": "S"
+                    },
+                    "sourceRecord": {
+                        "name": "ROROXML",
+                        "shortName": "ROX",
+                        "location": "archive/GroupId=none/CollectionDate=2021-12-30/DataFeedId=417/DataFeedTaskId=63922762/EFHARHOO20210845.XML.364_20211230_084819141",
+                        "id": "fc618f59f5bec619fee6b65fa1dec108",
+                        "audit": {
+                            "createdBy": "2olC2sR6xmdqeyxucH4xxg==",
+                            "createdTimestamp": 1640854176773,
+                            "updatedBy": null,
+                            "updatedTimestamp": null,
+                            "deletedBy": null,
+                            "deletedTimestamp": null
+                        }
+                    },
+                    "complianceRecord": {
+                        "visibility": "UNKNOWN",
+                        "gscMarker": null,
+                        "retentionMarkerDays": -1
+                    },
+                    "mappingRecord": {
+                        "name": "RR-XML-Service-Voyage",
+                        "version": "1"
+                    }
+                },
+                "type": "VOYAGE",
+                "effectiveFromTimestamp": 1640853900000,
+                "effectiveToTimestamp": 1640884500000,
+                "dueTimestamp": null,
+                "status": null,
+                "voyage": {
+                    "type": "COMMERCIAL",
+                    "voyageType": "SEA",
+                    "departureLocation": "HAR",
+                    "departureCountry": null,
+                    "scheduledDepartureTimestamp": 1640853900000,
+                    "actualDepartureTimestamp": 1640853900000,
+                    "arrivalLocation": "HOO",
+                    "arrivalCountry": null,
+                    "scheduledArrivalTimestamp": null,
+                    "actualArrivalTimestamp": null,
+                    "intermediateLocations": null,
+                    "passengerCount": null,
+                    "crewCount": null,
+                    "durationMinutes": null,
+                    "routeId": null,
+                    "carrier": "Stena Line",
+                    "craftId": "STENA HOLLANDICA"
+                },
+                "attributes": {
+                    "attrs": {
+                        "freightMovementCount": "88"
+                    }
+                },
+                "features": {
+                    "feats": {
+                        "STANDARDISED:arrivalPort": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "MAP",
+                            "value": null,
+                            "valueList": {
+                                "val": [
+                                    {
+                                        "UNLO5": "NLHVH"
+                                    }
+                                ]
+                            },
+                            "startTimestamp": null,
+                            "endTimestamp": 1640854176985
+                        },
+                        "STANDARDISED:estimatedArrivalTimestamp": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "LONG",
+                            "value": null,
+                            "valueList": null,
+                            "startTimestamp": null,
+                            "endTimestamp": null
+                        },
+                        "STANDARDISED:departurePort": {
+                            "id": null,
+                            "type": null,
+                            "valueType": "MAP",
+                            "value": null,
+                            "valueList": {
+                                "val": [
+                                    {
+                                        "UNLO5": "GBHRW"
+                                    }
+                                ]
+                            },
+                            "startTimestamp": null,
+                            "endTimestamp": 1640854176985
+                        }
+                    }
+                },
+                "changeHistory": null
+            },
+            "consolidation": null,
+            "consignments": null,
+            "booking": null,
+            "seizure": null,
+            "detainment": null
+        }
+    }
+}

--- a/cypress/fixtures/airpax/airpax-expected-response.json
+++ b/cypress/fixtures/airpax/airpax-expected-response.json
@@ -12,9 +12,9 @@
       "bookedAt": null,
       "checkInAt": "2019-07-20T16:43:35Z",
       "ticket": {
-        "number": "AL12345",
-        "type": null,
-        "price": null
+        "number": "1234",
+        "type": "Return",
+        "price": "£25.00"
       },
       "country": null,
       "payments": [
@@ -43,12 +43,12 @@
       "arrival": {
         "country": null,
         "location": "YYC",
-        "time": "2019-07-21T18:35:00Z"
+        "time": "2022-07-10T15:30:01Z"
       },
       "departure": {
         "country": null,
         "location": "LHR",
-        "time": "2019-07-21T16:40:00Z"
+        "time": "2022-07-10T12:30:01Z"
       },
       "route": [
         "CDG",
@@ -106,14 +106,14 @@
     "person": {
       "entitySearchUrl": null,
       "name": {
-        "first": "ZUES CARLO",
-        "last": "BATZ STOUP",
-        "full": "ZUES CARLO BATZ STOUP"
+        "first": "Testing GivenName",
+        "last": "Testing FamilyName",
+        "full": "FamilyName GivenName"
       },
       "role": "PASSENGER",
-      "dateOfBirth": "1976-12-10T00:00:00Z",
-      "gender": "M",
-      "nationality": "GB",
+      "dateOfBirth": "1976-12-30T00:00:00Z",
+      "gender": "F",
+      "nationality": "AU",
       "document": {
         "entitySearchUrl": null,
         "type": "PASSPORT",
@@ -137,9 +137,9 @@
       "seatNumber": "34A"
     },
     "baggage": {
-      "numberOfCheckedBags": null,
-      "weight": null,
-      "tags": []
+      "numberOfCheckedBags": 1,
+      "weight": "23kg",
+      "tags": ["739238"]
     },
     "vehicle": null,
     "trailer": null,

--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -8,7 +8,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
@@ -84,7 +84,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
@@ -122,7 +122,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
@@ -140,7 +140,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         cy.claimAirPaxTaskWithUserId(response.id);
@@ -156,7 +156,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.fixture('airpax/airpax-task-expected-details.json').then((expectedResponse) => {
@@ -175,7 +175,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax-multiple-passengers.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.fixture('airpax/airpax-task-baggage-expected-multiple-passengers.json').then((expectedResponse) => {
@@ -195,7 +195,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.fixture('airpax/airpax-task-expected-details.json').then((expectedDetails) => {
@@ -219,7 +219,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax-no-rules-selectors.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.get('.task-versions .task-versions--right').should('contain.text', 'No rule matches');
@@ -233,7 +233,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax-selectors-selector-matched-rule.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.get('.task-versions .task-versions--right').should('contain.text', 'No rule matches');
@@ -247,14 +247,14 @@ describe('Verify AirPax task details of different sections', () => {
     const movementID = `APIPNR:CMID=15148b83b4fbba770dad11348d1c9b13_${Math.floor((Math.random() * 1000000) + 1)}`;
     cy.fixture('airpax/task-airpax-same-group-reference-selectors.json').then((task) => {
       task.data.movementId = movementID;
-      cy.createAirPaxTask(task).then(() => {
+      cy.createTargetingApiTask(task).then(() => {
         cy.wait(4000);
       });
     });
 
     cy.fixture('airpax/task-airpax-different-group-reference-selectors.json').then((task) => {
       task.data.movementId = movementID;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
       });
@@ -328,7 +328,7 @@ describe('Verify AirPax task details of different sections', () => {
       task.data.matchedRules[0].rulePriority = 'Tier 2';
       task.data.matchedRules[1].rulePriority = 'Tier 3';
       task.data.matchedRules[2].rulePriority = 'Tier 2';
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain(taskName);
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -392,14 +392,14 @@ describe('Verify AirPax task details of different sections', () => {
 
     cy.fixture('airpax/task-airpax-rules-with-diff-threat.json').then((task) => {
       task.data.movementId = movementID;
-      cy.createAirPaxTask(task).then(() => {
+      cy.createTargetingApiTask(task).then(() => {
         cy.wait(4000);
       });
     });
 
     cy.fixture('airpax/task-airpax-rules-v2.json').then((task) => {
       task.data.movementId = movementID;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         businessKey = response.id;
         cy.visit('/airpax/tasks');
@@ -446,7 +446,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.fixture('airpax/airpax-task-expected-details.json').then((expectedDetails) => {
@@ -465,7 +465,7 @@ describe('Verify AirPax task details of different sections', () => {
     const movementID = `APIPNR:CMID=15148b83b4fbba770dad11348d1c9b13_${Math.floor((Math.random() * 1000000) + 1)}`;
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = movementID;
-      cy.createAirPaxTask(task).then(() => {
+      cy.createTargetingApiTask(task).then(() => {
         cy.wait(4000);
       });
     });
@@ -473,7 +473,7 @@ describe('Verify AirPax task details of different sections', () => {
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = movementID;
       task.data.movement.persons[0].person.nationality = 'AUS';
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
       });
@@ -482,7 +482,7 @@ describe('Verify AirPax task details of different sections', () => {
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = movementID;
       task.data.movement.persons[0].person.nationality = 'THA';
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
       });
@@ -496,7 +496,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AUTOTEST';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.fixture('airpax/airpax-task-expected-details.json').then((expectedDetails) => {
@@ -515,7 +515,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AUTOTEST';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.fixture('airpax/airpax-task-expected-details.json').then((expectedDetails) => {
@@ -534,7 +534,7 @@ describe('Verify AirPax task details of different sections', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
         cy.fixture('airpax/airpax-task-expected-details.json').then((expectedDetails) => {
@@ -559,7 +559,7 @@ describe('Verify AirPax task details of different sections', () => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
       task.data.movement.voyage.voyage.scheduledDepartureTimestamp = departureTime;
       task.data.movement.voyage.voyage.scheduledArrivalTimestamp = arrivalTimeInFeature;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${taskResponse.id}`);
         cy.wait('@task').then(({ response }) => {
@@ -587,7 +587,7 @@ describe('Verify AirPax task details of different sections', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('airpaxTask');
     cy.fixture('airpax/task-airpax-rules-selectros-with-diff-threat-category.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain(taskName);
         cy.wait(4000);
         businessKey = response.id;

--- a/cypress/integration/airpax/airpax-task-overview-page.spec.js
+++ b/cypress/integration/airpax/airpax-task-overview-page.spec.js
@@ -15,7 +15,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -91,7 +91,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -141,7 +141,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -206,7 +206,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -287,7 +287,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -343,7 +343,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     cy.fixture('airpax/taskSummaryExpected-Crew.json').as('expectedData');
     cy.fixture('airpax/task-airpax-Crew.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -371,7 +371,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -421,7 +421,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const nextPage = 'a[data-test="next"]';
     cy.fixture('airpax/task-airpax-rules-with-diff-threat.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain(taskName);
         cy.wait(4000);
         let businessKey = taskResponse.id;
@@ -480,7 +480,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         let businessKey = taskResponse.id;
         let movementId = taskResponse.movement.id;
@@ -581,7 +581,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
       task.data.movement.voyage.voyage.scheduledDepartureTimestamp = departureTime;
       task.data.movement.voyage.voyage.scheduledArrivalTimestamp = arrivalTimeInFeature;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain(taskName);
         cy.wait(5000);
         let businessKey = taskResponse.id;
@@ -612,7 +612,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
       task.data.movement.voyage.voyage.scheduledDepartureTimestamp = departureTime;
       task.data.movement.voyage.voyage.scheduledArrivalTimestamp = arrivalTimeInPast;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain(taskName);
         cy.wait(5000);
         let businessKey = taskResponse.id;

--- a/cypress/integration/airpax/create-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/create-aipax-tasks.spec.js
@@ -110,6 +110,7 @@ describe('Create AirPax task and verify it on UI', () => {
     });
   });
 
+
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));

--- a/cypress/integration/airpax/create-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/create-aipax-tasks.spec.js
@@ -8,7 +8,7 @@ describe('Create AirPax task and verify it on UI', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         console.log(response);
         cy.fixture('airpax/airpax-expected-response.json').then((expectedResponse) => {
@@ -32,7 +32,7 @@ describe('Create AirPax task and verify it on UI', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
@@ -54,7 +54,7 @@ describe('Create AirPax task and verify it on UI', () => {
       task.data.movement.voyage.features.feats['STANDARDISED:departurePort'].valueList.val[0].CountryCode = departure[1];
       task.data.movement.voyage.features.feats['STANDARDISED:arrivalPort'].valueList.val[0].UNLO3 = arrival[0];
       task.data.movement.voyage.features.feats['STANDARDISED:arrivalPort'].valueList.val[0].CountryCode = arrival[1];
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         expect(taskResponse.movement.journey.departure.country).to.eq(departure[1]);
         expect(taskResponse.movement.journey.departure.location).to.eq(departure[0]);
@@ -76,7 +76,7 @@ describe('Create AirPax task and verify it on UI', () => {
       task.data.movement.voyage.voyage.arrivalCountry = arrival[1];
       delete task.data.movement.voyage.features.feats['STANDARDISED:departurePort'];
       delete task.data.movement.voyage.features.feats['STANDARDISED:arrivalPort'];
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         expect(taskResponse.movement.journey.departure.country).to.eq(departure[1]);
         expect(taskResponse.movement.journey.departure.location).to.eq(departure[0]);
@@ -90,7 +90,7 @@ describe('Create AirPax task and verify it on UI', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax-rules-with-diff-threat.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
@@ -102,7 +102,7 @@ describe('Create AirPax task and verify it on UI', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax-rules-selectros-with-diff-threat-category.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('AIRPAX');
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);

--- a/cypress/integration/airpax/create-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/create-aipax-tasks.spec.js
@@ -110,7 +110,6 @@ describe('Create AirPax task and verify it on UI', () => {
     });
   });
 
-
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));

--- a/cypress/integration/airpax/filter-airpax-tasks-by-ruleID.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-ruleID.spec.js
@@ -18,7 +18,7 @@ describe('Filter airpax tasks by Selectors on task management Page', () => {
         rule.ruleName = `${rule.ruleName}_${randomNumber}`;
         ruleNames.push(rule.ruleName);
       });
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain(taskName);
         cy.wait(4000);
         cy.checkAirPaxTaskDisplayed(`${response.id}`);
@@ -63,7 +63,7 @@ describe('Filter airpax tasks by Selectors on task management Page', () => {
         rule.ruleName = `Auto-test_${randomNumber}`;
         task1RuleNames.push(rule.ruleName);
       });
-      cy.createAirPaxTask(task).then((task1Response) => {
+      cy.createTargetingApiTask(task).then((task1Response) => {
         expect(task1Response.movement.id).to.contain(taskName);
         cy.wait(4000);
       });
@@ -76,7 +76,7 @@ describe('Filter airpax tasks by Selectors on task management Page', () => {
         rule.ruleName = `Auto-test_${randomNumber}`;
         task2RuleNames.push(rule.ruleName);
       });
-      cy.createAirPaxTask(task).then((task2Response) => {
+      cy.createTargetingApiTask(task).then((task2Response) => {
         expect(task2Response.movement.id).to.contain(taskName);
         cy.wait(4000);
 

--- a/cypress/integration/airpax/task-list-page.spec.js
+++ b/cypress/integration/airpax/task-list-page.spec.js
@@ -65,7 +65,7 @@ describe('Airpax task list page', () => {
         task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
         task.data.movement.serviceMovement.features.feats['STANDARDISED:lastReportedStatus'].value = statusInitial;
         console.log(task);
-        cy.createAirPaxTask(task).then((taskResponse) => {
+        cy.createTargetingApiTask(task).then((taskResponse) => {
           expect(taskResponse.movement.id).to.contain('AIRPAX');
           expect(taskResponse.movement.flight.departureStatus).to.contain(status[i]);
           console.log(taskResponse);
@@ -97,7 +97,7 @@ describe('Airpax task list page', () => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
       task.data.movement.serviceMovement.features.feats['STANDARDISED:lastReportedStatus'].value = null;
       console.log(task);
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         expect(taskResponse.movement.flight.departureStatus).to.eql(null);
         console.log(taskResponse);
@@ -124,7 +124,7 @@ describe('Airpax task list page', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         let businessKey = taskResponse.id;
         cy.wait(3000);
@@ -147,7 +147,7 @@ describe('Airpax task list page', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax-no-selectors.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         console.log(taskResponse);
         let businessKey = taskResponse.id;
@@ -166,7 +166,7 @@ describe('Airpax task list page', () => {
         });
         cy.fixture('airpax/task-airpax.json').then((updateTask) => {
           updateTask.data.movementId = movementId;
-          cy.createAirPaxTask(updateTask).then((updateResponse) => {
+          cy.createTargetingApiTask(updateTask).then((updateResponse) => {
             expect(updateResponse.movement.id).to.contain(movementId);
             expect(updateResponse.id).to.equal(businessKey);
             cy.reload();
@@ -193,7 +193,7 @@ describe('Airpax task list page', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((taskResponse) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         expect(taskResponse.movement.id).to.contain('AIRPAX');
         let businessKey = taskResponse.id;
         let movementId = taskResponse.movement.id;
@@ -220,13 +220,13 @@ describe('Airpax task list page', () => {
         cy.contains('Finish').click();
         cy.fixture('airpax/task-airpax-same-group-reference-selectors.json').then((updateTask) => {
           updateTask.data.movementId = movementId;
-          cy.createAirPaxTask(updateTask).then((updateResponse) => {
+          cy.createTargetingApiTask(updateTask).then((updateResponse) => {
             expect(updateResponse.movement.id).to.contain(movementId);
             expect(updateResponse.id).to.equal(businessKey);
             cy.wait(2000);
             cy.fixture('airpax/task-airpax-latest.json').then((relistedTask) => {
               relistedTask.data.movementId = movementId;
-              cy.createAirPaxTask(relistedTask).then((relistedResponse) => {
+              cy.createTargetingApiTask(relistedTask).then((relistedResponse) => {
                 expect(relistedResponse.movement.id).to.contain(movementId);
                 expect(relistedResponse.id).to.equal(businessKey);
                 cy.visit('/airpax/tasks');

--- a/cypress/integration/cerberus/archive-RoRo-tasks.spec.js
+++ b/cypress/integration/cerberus/archive-RoRo-tasks.spec.js
@@ -15,7 +15,7 @@ describe('Airpax tasks archive functionality', () => {
 
     cy.fixture('RoRo-accompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain(taskName);
         cy.wait(4000);
         const taskID = response.id;
@@ -57,7 +57,7 @@ describe('Airpax tasks archive functionality', () => {
     cy.setTimeOffset(diff);
     cy.fixture('RoRo-accompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain(taskName);
         cy.wait(4000);
         const taskID = response.id;
@@ -110,7 +110,7 @@ describe('Airpax tasks archive functionality', () => {
 
     cy.fixture('RoRo-accompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain(taskName);
         cy.wait(4000);
         const taskID = response.id;

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -336,7 +336,7 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it.only('Should create a Roro-Accompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
+  it('Should create a Roro-Accompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
     const taskName = 'RORO-Accompanied';
     cy.fixture('RoRo-accompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
@@ -347,13 +347,13 @@ describe('Create task with different payload from Cerberus', () => {
         cy.getProcessInstanceId(`${response.id}`).then((processInstanceId) => {
           cy.getBusinessKeyByProcessInstanceId(processInstanceId).then((businessKey) => {
             expect(businessKey).to.equal(response.id);
-          })
+          });
         });
       });
     });
    });
   
-  it.only('Should create a Roro-Unaccompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
+  it('Should create a Roro-Unaccompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
     const taskName = 'RORO-Unaccompanied';
     cy.fixture('RoRo-unaccompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
@@ -370,7 +370,7 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
   
-  it.only('Should create a Roro-tourist task from Cop-targetting API and forward to Ceberus workflow service', () => {
+  it('Should create a Roro-tourist task from Cop-targetting API and forward to Ceberus workflow service', () => {
     const taskName = 'RORO-tourist';
     cy.fixture('RoRo-tourist-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -348,6 +348,9 @@ describe('Create task with different payload from Cerberus', () => {
           cy.getBusinessKeyByProcessInstanceId(processInstanceId).then((businessKey) => {
             expect(businessKey).to.equal(response.id);
           });
+          cy.getMovementRecordByProcessInstanceId(processInstanceId).then((responseBody) => {
+            expect(responseBody[0].value).to.deep.include(task.data.movementId);
+          });
         });
       });
     });
@@ -364,7 +367,10 @@ describe('Create task with different payload from Cerberus', () => {
         cy.getProcessInstanceId(`${response.id}`).then((processInstanceId) => {
           cy.getBusinessKeyByProcessInstanceId(processInstanceId).then((businessKey) => {
             expect(businessKey).to.equal(response.id);
-          })
+          });
+          cy.getMovementRecordByProcessInstanceId(processInstanceId).then((responseBody) => {
+            expect(responseBody[0].value).to.deep.include(task.data.movementId);
+          });
         });
       });
     });
@@ -381,7 +387,10 @@ describe('Create task with different payload from Cerberus', () => {
         cy.getProcessInstanceId(`${response.id}`).then((processInstanceId) => {
           cy.getBusinessKeyByProcessInstanceId(processInstanceId).then((businessKey) => {
             expect(businessKey).to.equal(response.id);
-          })
+          });
+          cy.getMovementRecordByProcessInstanceId(processInstanceId).then((responseBody) => {
+            expect(responseBody[0].value).to.deep.include(task.data.movementId);
+          });
         });
       });
     });

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -336,6 +336,57 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
+  it.only('Should create a Roro-Accompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
+    const taskName = 'RORO-Accompanied';
+    cy.fixture('RoRo-accompanied-v2.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((response) => {
+        expect(response.movement.id).to.contain('RORO-Accompanied');
+        cy.wait(4000);
+        cy.checkTaskDisplayed(`${response.id}`);
+        cy.getProcessInstanceId(`${response.id}`).then((processInstanceId) => {
+          cy.getBusinessKeyByProcessInstanceId(processInstanceId).then((businessKey) => {
+            expect(businessKey).to.equal(response.id);
+          })
+        });
+      });
+    });
+   });
+  
+  it.only('Should create a Roro-Unaccompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
+    const taskName = 'RORO-Unaccompanied';
+    cy.fixture('RoRo-unaccompanied-v2.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((response) => {
+        expect(response.movement.id).to.contain('RORO-Unaccompanied');
+        cy.wait(4000);
+        cy.checkTaskDisplayed(`${response.id}`);
+        cy.getProcessInstanceId(`${response.id}`).then((processInstanceId) => {
+          cy.getBusinessKeyByProcessInstanceId(processInstanceId).then((businessKey) => {
+            expect(businessKey).to.equal(response.id);
+          })
+        });
+      });
+    });
+  });
+  
+  it.only('Should create a Roro-tourist task from Cop-targetting API and forward to Ceberus workflow service', () => {
+    const taskName = 'RORO-tourist';
+    cy.fixture('RoRo-tourist-v2.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createAirPaxTask(task).then((response) => {
+        expect(response.movement.id).to.contain('RORO-tourist');
+        cy.wait(4000);
+        cy.checkTaskDisplayed(`${response.id}`);
+        cy.getProcessInstanceId(`${response.id}`).then((processInstanceId) => {
+          cy.getBusinessKeyByProcessInstanceId(processInstanceId).then((businessKey) => {
+            expect(businessKey).to.equal(response.id);
+          })
+        });
+      });
+    });
+  });
+
   after(() => {
     cy.deleteAutomationTestData();
     cy.contains('Sign out').click();

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -336,11 +336,11 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it('Should create a Roro-Accompanied task from Cop-targetting API and forward to Cerberus workflow service', () => {
+  it('Should create a Roro-Accompanied task from Cop-targeting API and forward to Cerberus workflow service', () => {
     const taskName = 'RORO-Accompanied';
     cy.fixture('RoRo-accompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createTargettingApiTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('RORO-Accompanied');
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.id}`);
@@ -356,11 +356,11 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it('Should create a Roro-Unaccompanied task from Cop-targetting API and forward to Cerberus workflow service', () => {
+  it('Should create a Roro-Unaccompanied task from Cop-targeting API and forward to Cerberus workflow service', () => {
     const taskName = 'RORO-Unaccompanied';
     cy.fixture('RoRo-unaccompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createTargettingApiTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('RORO-Unaccompanied');
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.id}`);
@@ -376,11 +376,11 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it('Should create a Roro-Tourist task from Cop-targetting API and forward to Cerberus workflow service', () => {
+  it('Should create a Roro-Tourist task from Cop-targeting API and forward to Cerberus workflow service', () => {
     const taskName = 'RORO-Tourist';
     cy.fixture('RoRo-tourist-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createTargettingApiTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('RORO-Tourist');
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.id}`);

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -336,7 +336,7 @@ describe('Create task with different payload from Cerberus', () => {
     });
   });
 
-  it('Should create a Roro-Accompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
+  it('Should create a Roro-Accompanied task from Cop-targetting API and forward to Cerberus workflow service', () => {
     const taskName = 'RORO-Accompanied';
     cy.fixture('RoRo-accompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
@@ -354,9 +354,9 @@ describe('Create task with different payload from Cerberus', () => {
         });
       });
     });
-   });
-  
-  it('Should create a Roro-Unaccompanied task from Cop-targetting API and forward to Ceberus workflow service', () => {
+  });
+
+  it('Should create a Roro-Unaccompanied task from Cop-targetting API and forward to Cerberus workflow service', () => {
     const taskName = 'RORO-Unaccompanied';
     cy.fixture('RoRo-unaccompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
@@ -375,13 +375,13 @@ describe('Create task with different payload from Cerberus', () => {
       });
     });
   });
-  
-  it('Should create a Roro-tourist task from Cop-targetting API and forward to Ceberus workflow service', () => {
-    const taskName = 'RORO-tourist';
+
+  it('Should create a Roro-Tourist task from Cop-targetting API and forward to Cerberus workflow service', () => {
+    const taskName = 'RORO-Tourist';
     cy.fixture('RoRo-tourist-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
       cy.createAirPaxTask(task).then((response) => {
-        expect(response.movement.id).to.contain('RORO-tourist');
+        expect(response.movement.id).to.contain('RORO-Tourist');
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.id}`);
         cy.getProcessInstanceId(`${response.id}`).then((processInstanceId) => {

--- a/cypress/integration/cerberus/create-tasks.spec.js
+++ b/cypress/integration/cerberus/create-tasks.spec.js
@@ -340,7 +340,7 @@ describe('Create task with different payload from Cerberus', () => {
     const taskName = 'RORO-Accompanied';
     cy.fixture('RoRo-accompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargettingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('RORO-Accompanied');
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.id}`);
@@ -360,7 +360,7 @@ describe('Create task with different payload from Cerberus', () => {
     const taskName = 'RORO-Unaccompanied';
     cy.fixture('RoRo-unaccompanied-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargettingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('RORO-Unaccompanied');
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.id}`);
@@ -380,7 +380,7 @@ describe('Create task with different payload from Cerberus', () => {
     const taskName = 'RORO-Tourist';
     cy.fixture('RoRo-tourist-v2.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createAirPaxTask(task).then((response) => {
+      cy.createTargettingApiTask(task).then((response) => {
         expect(response.movement.id).to.contain('RORO-Tourist');
         cy.wait(4000);
         cy.checkTaskDisplayed(`${response.id}`);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -479,6 +479,17 @@ Cypress.Commands.add('getBusinessKey', (partOfTheBusinessKey) => {
   });
 });
 
+Cypress.Commands.add('getMovementRecordByProcessInstanceId', (processInstanceId) => {
+  cy.request({
+    method: 'GET',
+    url: `https://${cerberusServiceUrl}/camunda/engine-rest/history/variable-instance?processInstanceIdln=${processInstanceId}&deserializeValues=false`,
+    headers: { Authorization: `Bearer ${token}` },
+  }).then((response) => {
+    expect(response.status).to.eq(200);
+    return response.body;
+  });
+});
+
 Cypress.Commands.add('getTaskDetails', () => {
   const obj = {};
   cy.get('.govuk-task-details-grid-item').each((item) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1906,7 +1906,7 @@ Cypress.Commands.add('verifyDateTime', (elementName, dateTimeFormatted) => {
   );
 });
 
-Cypress.Commands.add('createTargettingApiTask', (task) => {
+Cypress.Commands.add('createTargetingApiTask', (task) => {
   cy.request({
     method: 'POST',
     url: `https://${targetingApiUrl}/v2/movement-records`,

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -482,7 +482,7 @@ Cypress.Commands.add('getBusinessKey', (partOfTheBusinessKey) => {
 Cypress.Commands.add('getMovementRecordByProcessInstanceId', (processInstanceId) => {
   cy.request({
     method: 'GET',
-    url: `https://${cerberusServiceUrl}/camunda/engine-rest/history/variable-instance?processInstanceIdln=${processInstanceId}&deserializeValues=false`,
+    url: `https://${cerberusServiceUrl}/camunda/engine-rest/history/variable-instance?processInstanceIdIn=${processInstanceId}&deserializeValues=false`,
     headers: { Authorization: `Bearer ${token}` },
   }).then((response) => {
     expect(response.status).to.eq(200);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1918,18 +1918,6 @@ Cypress.Commands.add('createTargetingApiTask', (task) => {
   });
 });
 
-Cypress.Commands.add('createAirPaxTask', (task) => {
-  cy.request({
-    method: 'POST',
-    url: `https://${targetingApiUrl}/v2/movement-records`,
-    headers: { Authorization: `Bearer ${token}` },
-    body: task,
-  }).then((response) => {
-    expect(response.status).to.eq(201);
-    return response.body;
-  });
-});
-
 Cypress.Commands.add('issueAirPaxTask', (task) => {
   cy.request({
     method: 'POST',

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1906,6 +1906,18 @@ Cypress.Commands.add('verifyDateTime', (elementName, dateTimeFormatted) => {
   );
 });
 
+Cypress.Commands.add('createTargettingApiTask', (task) => {
+  cy.request({
+    method: 'POST',
+    url: `https://${targetingApiUrl}/v2/movement-records`,
+    headers: { Authorization: `Bearer ${token}` },
+    body: task,
+  }).then((response) => {
+    expect(response.status).to.eq(201);
+    return response.body;
+  });
+});
+
 Cypress.Commands.add('createAirPaxTask', (task) => {
   cy.request({
     method: 'POST',


### PR DESCRIPTION
## Description
Add test to Forward RORO movement records from cop targeting api to cerberus workflow service
## To Test
npm run cypress:test -- --spec cypress/integration/cerberus/create-tasks.spec.js

Should create a Roro-Accompanied task from Cop-targetting API and forward to Cerberus workflow service
Should create a Roro-Unaccompanied task from Cop-targetting API and forward to Cerberus workflow service
Should create a Roro-Tourist task from Cop-targetting API and forward to Cerberus workflow service
## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
