### PR TITLE
COP-11197: Add test for Update wording on assessment complete & dismiss task options.

### DIFF
--- a/cypress/integration/airpax/airpax-task-overview-page.spec.js
+++ b/cypress/integration/airpax/airpax-task-overview-page.spec.js
@@ -190,7 +190,7 @@ describe('AirPax Tasks overview Page - Should check All user journeys', () => {
 
   it('Should dismiss a task with a reason', () => {
     const reasons = [
-       'Arrived at port',
+      'Arrived at port',
       'False rule match',
       'Resource redirected',
       'Other',


### PR DESCRIPTION
## Description
Add test for Update wording on assessment complete & dismiss task options.
## To Test
npm run cypress:test:local -- --spec cypress/integration/cerberus/airpax-tasks-overview-page.spec.js

Should complete a task with a reason'

Should dismiss a task with a reason

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
