### PR TITLE
COP-11199 Add test for Remove main traveller row from co-travellers table

### DIFF
--- a/cypress/fixtures/airpax/airpax-task-expected-details.json
+++ b/cypress/fixtures/airpax/airpax-task-expected-details.json
@@ -123,22 +123,9 @@
   ],
   "Co-travellers": [
       {
-        "Traveller": "TravellerTESTING FAMILYNAME, Testing GivenName DCFemale, 30 Dec 1976, Australia (AU)",
-        "Age": "Age45",
-        "Check-in": "Check-in12 Jun 2022 at 13:00a month before departure",
-        "Seat": "Seat34A",
-        "Document": "DocumentPASSPORTIssued by GB",
-        "Checked baggage": "Checked baggage23kg",
-        "": "This movement"
-      },
-      {
         "Traveller": "TravellerBATZ STOUP, ZUES CARLO DCMale, 10 Dec 1976, United Kingdom (GB)",
         "Age": "Age45",
-        "Check-in": "Check-in12 Jun 2022 at 13:00a month before departure",
-        "Seat": "Seat34A",
-        "Document": "DocumentPASSPORTIssued by GB",
-        "Checked baggage": "Checked baggage23kg",
-        "": "Movement detail"
+        "Document": "DocumentPASSPORTIssued by GB"
       }
     ],
     "Voyage": [

--- a/cypress/fixtures/airpax/task-airpax-singlePassenger.json
+++ b/cypress/fixtures/airpax/task-airpax-singlePassenger.json
@@ -1,0 +1,2124 @@
+{
+  "data": {
+    "movementId": "APIPNR:S=c85b5c5426a6696b24ac6ca7851f0977",
+    "riskSubmissionId": 213295,
+    "riskCreatedDate": "2022-05-26T11:00:31.779414Z",
+    "riskType": "Pre-Arrival",
+    "matchedRules": [
+      {
+        "ruleId": 8867,
+        "ruleName": "Duration of Stay -days",
+        "ruleType": "Both",
+        "ruleVersion": 1,
+        "ruleDescription": "Test",
+        "securityLabels": [
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-03-28T10:42:15Z",
+        "rulePriority": "Tier 1",
+        "indicatorMatches": [
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Freight, Air Passenger, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+          },
+          {
+            "entity": "Booking",
+            "descriptor": "durationOfStay",
+            "operator": "between",
+            "value": "[1, 70]"
+          }
+        ],
+        "abuseTypes": [
+          "Alcohol"
+        ]
+      },
+      {
+        "ruleId": 8865,
+        "ruleName": "Duration of Whole trip",
+        "ruleType": "Both",
+        "ruleVersion": 1,
+        "ruleDescription": "Duration of Whole trip",
+        "securityLabels": [
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-03-28T10:42:15Z",
+        "rulePriority": "Tier 1",
+        "indicatorMatches": [
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Freight, Air Passenger, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+          },
+          {
+            "entity": "Booking",
+            "descriptor": "durationOfWholeTrip",
+            "operator": "between",
+            "value": "[1, 70]"
+          }
+        ],
+        "abuseTypes": [
+          "Alcohol"
+        ]
+      },
+      {
+        "ruleId": 7808,
+        "ruleName": "PNR-Arrival Airport",
+        "ruleType": "Both",
+        "ruleVersion": 1,
+        "ruleDescription": "Test",
+        "securityLabels": [
+          "null",
+          "null",
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-03-28T10:42:15Z",
+        "rulePriority": "Tier 1",
+        "indicatorMatches": [
+          {
+            "entity": "Booking",
+            "descriptor": "arrivalLocations",
+            "operator": "contains_any_of",
+            "value": "[lhr, man]"
+          },
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Passenger]"
+          }
+        ],
+        "abuseTypes": [
+          "Alcohol"
+        ]
+      },
+      {
+        "ruleId": 7849,
+        "ruleName": "PNR-Risk-Rule",
+        "ruleType": "Both",
+        "ruleVersion": 1,
+        "ruleDescription": "test pne",
+        "securityLabels": [
+          "null",
+          "null",
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-03-28T10:42:15Z",
+        "rulePriority": "Tier 1",
+        "indicatorMatches": [
+          {
+            "entity": "Voyage",
+            "descriptor": "arrivalLocation",
+            "operator": "contains",
+            "value": "LHR"
+          },
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Passenger]"
+          }
+        ],
+        "abuseTypes": [
+          "Class B&C Drugs inc. Cannabis"
+        ]
+      },
+      {
+        "ruleId": 7963,
+        "ruleName": "Predict_Movement_Name_qwerty",
+        "ruleType": "Both",
+        "ruleVersion": 1,
+        "ruleDescription": "Test",
+        "securityLabels": [
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-03-28T10:42:15Z",
+        "rulePriority": "Tier 1",
+        "indicatorMatches": [
+          {
+            "entity": "Movement",
+            "descriptor": "name",
+            "operator": "not_equal",
+            "value": "qwerty"
+          },
+          {
+            "entity": "Movement",
+            "descriptor": "name",
+            "operator": "not_equal",
+            "value": "qwerty"
+          },
+          {
+            "entity": "Movement",
+            "descriptor": "name",
+            "operator": "not_equal",
+            "value": "qwerty"
+          },
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Freight, Air Passenger, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+          }
+        ],
+        "abuseTypes": [
+          "Alcohol"
+        ]
+      },
+      {
+        "ruleId": 7844,
+        "ruleName": "Return Leg- Return",
+        "ruleType": "Both",
+        "ruleVersion": 1,
+        "ruleDescription": "Test",
+        "securityLabels": [
+          "null",
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-03-28T10:42:15Z",
+        "rulePriority": "Tier 1",
+        "indicatorMatches": [
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Passenger]"
+          },
+          {
+            "entity": "Booking",
+            "descriptor": "bookingType",
+            "operator": "equal",
+            "value": "RETURN"
+          }
+        ],
+        "abuseTypes": [
+          "Alcohol"
+        ]
+      },
+      {
+        "ruleId": 7919,
+        "ruleName": "Generic rule - For trailer",
+        "ruleType": "Pre-load",
+        "ruleVersion": 1,
+        "ruleDescription": "Eu velit commodo ill",
+        "securityLabels": [
+          "null",
+          "null",
+          "null"
+        ],
+        "ruleMatchedOnDate": "2022-03-28T10:42:15Z",
+        "rulePriority": "Tier 3",
+        "indicatorMatches": [
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "[Air Freight, Air Passenger, Fast Parcels, RORO Accompanied Freight, RORO Tourist, RORO Unaccompanied Freight]"
+          },
+          {
+            "entity": "Trailer",
+            "descriptor": "registrationNumber",
+            "operator": "not_equal",
+            "value": "AA005022"
+          }
+        ],
+        "abuseTypes": [
+          "International Trade inc. Missing Trader Intra-Community Fraud (MTIC)"
+        ]
+      }
+    ],
+    "matchedSelectors": [
+      {
+        "selectorId": 279,
+        "selectorReference": "2021-279",
+        "groupReference":"SR-215",
+        "groupVersionNumber":1,
+        "startDate": "2021-12-08T08:23:40.257Z",
+        "endDate": "2022-01-19T23:59:59Z",
+        "category": "A",
+        "agencyCode": "Counter Terrorism Police (CTP)",
+        "intelligenceSource": "intel source",
+        "pointOfContact": "Point Of Contact Testing",
+        "pocMessage": "selector for auto testing",
+        "priority": "Selector",
+        "inboundActionCode": "action required",
+        "outboundActionCode": "No action required",
+        "threatType": "National Security at the Border",
+        "notes": "notes testing",
+        "creator": "test user",
+        "approver": "bfbfdbf",
+        "securityLabels": [
+          "DATA_RISK_PREARRIVAL"
+        ],
+        "localReference": "SR-220",
+        "warnings": "bdfbdfbf",
+        "selectorWarnings":"CTGN,SEH",
+        "warningStatus": "Yes",
+        "warningDetails": "Warning details would be shown here",
+        "requestingOfficer": "Tester",
+        "requestingTeam": "MAH gateway",
+        "indicatorMatches": [
+          {
+            "entity": "Trailer",
+            "descriptor": "registrationNumber",
+            "operator": "equal",
+            "value": "qwerty"
+          },
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "RORO Unaccompanied Freight"
+          }
+        ],
+        "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+      },
+      {
+        "selectorId": 278,
+        "selectorReference": "2021-278",
+        "groupReference":"SR-216",
+        "groupVersionNumber":1,
+        "startDate": "2021-12-02T16:48:51.203Z",
+        "endDate": "2022-01-13T23:59:59Z",
+        "category": "A",
+        "agencyCode": "Food Standards Agency (FSA)",
+        "intelligenceSource": "intel source",
+        "pointOfContact": "Point Of Contact Testing",
+        "pocMessage": "selector for auto testing",
+        "priority": "Selector",
+        "inboundActionCode": "No action required",
+        "outboundActionCode": "No action required",
+        "threatType": "National Security at the Border",
+        "notes": "notes testing",
+        "creator": "test user",
+        "approver": "jyjyt",
+        "securityLabels": [
+          "DATA_RISK_PREARRIVAL"
+        ],
+        "localReference": "SR-219",
+        "warnings": "Warnings from testing",
+        "selectorWarnings":"SEH",
+        "warningStatus": "Yes",
+        "warningDetails": "Warning details would be shown here",
+        "requestingOfficer": "Tester",
+        "requestingTeam": "MAH gateway",
+        "indicatorMatches": [
+          {
+            "entity": "Vehicle",
+            "descriptor": "registrationNumber",
+            "operator": "equal",
+            "value": "ABC123"
+          },
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          }
+        ],
+        "selectorMatchedOnDate": "2021-12-08T09:19:33.097Z"
+      },
+      {
+        "selectorId":225,
+        "selectorReference":"2022-100",
+        "groupReference":"SR-217",
+        "groupVersionNumber":1,
+        "startDate":"2022-01-27T10:23:12.732Z",
+        "endDate":"2022-07-27T10:23:12.732Z",
+        "category":"A",
+        "agencyCode":"BF",
+        "intelligenceSource":"intel source",
+        "pointOfContact":"Point Of Contact Testing",
+        "pocMessage":"selector for auto testing",
+        "priority":"Selector",
+        "inboundActionCode":"No action required",
+        "outboundActionCode":"No action required",
+        "threatType":"National Security at the Border",
+        "notes": "notes testing",
+        "creator": "test user",
+        "approver":"null",
+        "securityLabels":[
+          "DATA_RISK_PREARRIVAL"
+        ],
+        "localReference":"null",
+        "warnings":"Warnings from testing for group reference",
+        "selectorWarnings":"O",
+        "warningStatus": "Yes",
+        "warningDetails": "Warning details would be shown here",
+        "requestingOfficer":"Tester",
+        "requestingTeam":"null",
+        "indicatorMatches":[
+          {
+            "entity":"vehicle",
+            "descriptor":"registrationNumber",
+            "operator":"equal",
+            "value":"DK-45678"
+          }
+        ],
+        "selectorMatchedOnDate":"2022-02-08T16:18:43.998Z"
+      },
+      {
+        "selectorId": 51,
+        "selectorReference": "2021-10",
+        "groupReference":"SR-218",
+        "groupVersionNumber":1,
+        "startDate": "2021-07-09T13:42:48.381Z",
+        "endDate": "2021-08-20T22:59:59Z",
+        "category": "A",
+        "agencyCode": "Counter Terrorism Police (CTP)",
+        "intelligenceSource": "intel source",
+        "pointOfContact": "Point Of Contact Testing",
+        "pocMessage": "selector for auto testing",
+        "priority": "Tier 2",
+        "inboundActionCode": "No action required",
+        "outboundActionCode": "No action required",
+        "threatType": "National Security at the Border",
+        "notes": "notes testing",
+        "creator": "test user",
+        "approver": "Henry Hamlet",
+        "securityLabels": [
+          "DATA_RISK_PREARRIVAL"
+        ],
+        "localReference": "Local Reference",
+        "warnings": "Supplemental warnings",
+        "selectorWarnings":"CTGN",
+        "warningStatus": "Yes",
+        "warningDetails": "Warning details would be shown here",
+        "requestingOfficer": "Tester",
+        "requestingTeam": "RoRo accompanied",
+        "indicatorMatches": [
+          {
+            "entity": "Organisation",
+            "descriptor": "telephone",
+            "operator": "equal",
+            "value": "01234 56723737"
+          },
+          {
+            "entity": "Message",
+            "descriptor": "mode",
+            "operator": "in",
+            "value": "RORO Accompanied Freight,RORO Tourist,RORO Unaccompanied Freight"
+          }
+        ],
+        "selectorMatchedOnDate": "2021-09-05T09:30:02.896Z"
+      },
+      {
+        "selectorId":245,
+        "selectorReference":"2022-245",
+        "groupReference":"SR-227",
+        "groupVersionNumber":1,
+        "startDate":"2022-02-01T09:40:27.767Z",
+        "endDate":"2023-02-01T23:59:59Z",
+        "category":"C",
+        "agencyCode":"Borders and Aviation Security Unit Homeland Security Group (HSG)",
+        "intelligenceSource":"Qui adipisci consectetur ullam consequatur a aspernatur in",
+        "pointOfContact":"Dolores est qui laboriosam velit tenetur aut sit laborum Temporibus distinctio Aut hic non autem",
+        "pocMessage":"Blanditiis consectetur impedit omnis veniam veniam quibusdam ad eiusmod et consequatur fuga Fugiat nesciunt tenetur expedita aliquam",
+        "priority":"Selector",
+        "inboundActionCode":"Worthy of attention",
+        "outboundActionCode":"Monitor only",
+        "threatType":"Alcohol",
+        "notes":"notes",
+        "creator":"user",
+        "approver":"Ut adipisci culpa reiciendis dicta ullam vel duis laboriosam eiusmod",
+        "securityLabels":[
+          "DATA_RISK_PREARRIVAL"
+        ],
+        "localReference":"Quos ex reprehenderit dolor dolor at quia placeat fugiat qui voluptas non reiciendis voluptatum molestiae",
+        "warnings":"This is a different group reference",
+        "selectorWarnings":"No Warnings",
+        "warningStatus": "No",
+        "warningDetails": "Warning details would be shown here",
+        "requestingOfficer":"Velit in sunt aliquip voluptate tempore consectetur",
+        "requestingTeam":"RoRo tourist",
+        "indicatorMatches":[
+          {
+            "entity":"Person",
+            "descriptor":"familyName",
+            "operator":"equal",
+            "value":"TURNER"
+          }
+        ],
+        "selectorMatchedOnDate":"2022-02-08T16:18:43.998Z"
+      }
+    ],
+    "movement": {
+      "cerberusMovementId": "APIPNR:S=c85b5c5426a6696b24ac6ca7851f0977",
+      "firstCerberusTimestamp": 1653562817371,
+      "cerberusTimestamp": 1653562817371,
+      "latestMessageType": "RUN_LOG",
+      "cerberusInternalLabels": [
+        "incomplete_wash",
+        "incomplete_travel-history-enrichment",
+        "needs_travel-history"
+      ],
+      "messageAnalysis": {
+        "messageMatches": [
+          {
+            "sourceMessageVersion": 1,
+            "expectedMatches": 4,
+            "countOfMatches": 0,
+            "sourceMsgEnriches": 0
+          }
+        ],
+        "countOfSourceMessages": 1,
+        "countOfSnapshots": 0,
+        "countOfNoStateChanges": 0,
+        "countOfWashes": 0,
+        "countOfEnrichments": 0,
+        "firstRunlogTimestamp": 1653562817371,
+        "lastRunlogTimestamp": 1653562817371,
+        "firstSnapshotTimestamp": 0,
+        "lastSnapshotTimestamp": 0,
+        "firstNSCTimestamp": 0,
+        "lastNSCTimestamp": 0,
+        "firstWashTimestamp": 0,
+        "lastWashTimestamp": 0,
+        "firstEnrichTimestamp": 0,
+        "lastEnrichTimestamp": 0,
+        "matchesComplete": false,
+        "latestVersion": "1.0"
+      },
+      "serviceMovement": {
+        "metadata": {
+          "identityRecord": {
+            "poleId": {
+              "v2": {
+                "id": "APIPNR:S=c85b5c5426a6696b24ac6ca7851f0977"
+              },
+              "v1": null
+            },
+            "type": "S"
+          },
+          "sourceRecord": {
+            "name": "APIPNR",
+            "shortName": null,
+            "location": null,
+            "id": null,
+            "audit": {
+              "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+              "createdTimestamp": 1563637415000,
+              "updatedBy": null,
+              "updatedTimestamp": null,
+              "deletedBy": null,
+              "deletedTimestamp": null
+            }
+          },
+          "complianceRecord": {
+            "visibility": "UNKNOWN",
+            "gscMarker": null,
+            "retentionMarkerDays": -1
+          },
+          "mappingRecord": {
+            "name": "APIPNR-Service-Movement",
+            "version": "1"
+          }
+        },
+        "type": "MOVEMENT",
+        "effectiveFromTimestamp": 1563727200000,
+        "effectiveToTimestamp": 1563734100000,
+        "dueTimestamp": null,
+        "status": null,
+        "movement": {
+          "type": "Pre-Arrival",
+          "businessIdentifier": null,
+          "mode": "Air Passenger",
+          "source": "BA",
+          "actualDepartureTimestamp": null
+        },
+        "attributes": {
+          "attrs": {
+            "commonAPIPlus.SourceData.0.subject": "BA103;LHR;2019-07-21;PONQVFT",
+            "commonAPIPlus.SourceData.0.source": "PNRGOV",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.1.pnrPassengerRef": "3",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.checkinDateTime": "2019-07-20 16:43:35",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.1.membershipLevel": "BRNZ",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.seatNumber": "34A",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.0.pnrPassengerRef": "2",
+            "commonAPIPlus.manifestDetails.datetimeReceived": "2019-07-20T15:43:35Z",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.0.uniquePassengerId": "20058AB300012AD5",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.0.membershipLevel": "GOLD",
+            "commonAPIPlus.SourceData.0.component": "PNRGovMessageHandler",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.pnrLocator": "PONQVFT",
+            "commonAPIPlus.manifestDetails.paxCount": "178",
+            "commonAPIPlus.manifestDetails.manifestGUID": "502992e4-f319-4422-ac26-09dbdcda5f58",
+            "commonAPIPlus.SourceData.0.type": "PNR",
+            "commonAPIPlus.manifestDetails.protocol": "MQ",
+            "commonAPIPlus.manifestDetails.dataType": "PNR",
+            "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.1.uniquePassengerId": "20058AB300012AD6",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.ticketNumber": "AL12345",
+            "bookingType": "Online",
+            "paymentMethod": "CC",
+            "bookingCountry": "GB",
+            "ticketNumber": "1234",
+            "ticketType": "Return",
+            "ticketPrice": "£25.00",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.baggageDetails.0.tagNumber": "739238",
+            "commonAPIPlus.dcsDetails.dcsData.dcsRecord.baggageDetails.1.tagNumber": "739239",
+            "checkedInCount": "1",
+            "checkedInWeight": "23kg"
+          }
+        },
+        "features": {
+          "feats": {
+            "EU-HOSTED-DATA": {
+              "id": null,
+              "type": null,
+              "valueType": "BOOL",
+              "value": false,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:movementId": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "voyage,pnrLocator,passportNumber,familyName,givenName (1st 3 chars),dateOfBirth",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:checkInLeadTimeMilliseconds": {
+              "id": null,
+              "type": null,
+              "valueType": "LONG",
+              "value": 86185000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:bookingIntentHours": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 1,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:lastReportedStatus": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "DC",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:bookingDateTime": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "2022-06-09T10:00:00Z",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:checkinDateTime": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "2022-06-12T13:00:00Z",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            }
+          }
+        },
+        "changeHistory": null
+      },
+      "persons": [
+        {
+          "metadata": {
+            "identityRecord": {
+              "poleId": {
+                "v2": {
+                  "id": "PNR:P=dab092daf6d33e8fd2bfe5e2bcff8750"
+                },
+                "v1": null
+              },
+              "type": "P"
+            },
+            "sourceRecord": {
+              "name": "PNR",
+              "shortName": "PNR",
+              "location": "MT2-PNR1.xml",
+              "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+              "audit": {
+                "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+                "createdTimestamp": 1563637415000,
+                "updatedBy": null,
+                "updatedTimestamp": null,
+                "deletedBy": null,
+                "deletedTimestamp": null
+              }
+            },
+            "complianceRecord": null,
+            "mappingRecord": {
+              "name": "Passenger (dcs)",
+              "version": "1.0"
+            }
+          },
+          "type": "PERSON",
+          "person": {
+            "type": "PERPAS",
+            "title": null,
+            "familyName": "Testing FamilyName",
+            "givenName": "Testing GivenName",
+            "fullName": "FamilyName GivenName",
+            "dateOfBirth": 2555,
+            "dateOfDeath": null,
+            "gender": "F",
+            "nationality": "AUS",
+            "yearOfBirth": 1982,
+            "monthOfBirth": 11,
+            "dayOfBirth": 9,
+            "countryOfBirth": null,
+            "placeOfBirth": null,
+            "ethnicity": null,
+            "maritalStatus": null,
+            "religion": null,
+            "passportNumber": "119039399"
+          },
+          "attributes": {
+            "attrs": {
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.freqFlyerNumber": "680419104BA"
+            }
+          },
+          "matching": null,
+          "features": null,
+          "washResponses": null,
+          "matchMerge": null,
+          "changeHistory": null
+        }
+      ],
+      "organisations": [
+        {
+          "metadata": {
+            "identityRecord": {
+              "poleId": {
+                "v2": {
+                  "id": "PNR:P=5051a10ebfaabae6df5655be104b24ec"
+                },
+                "v1": null
+              },
+              "type": "P"
+            },
+            "sourceRecord": {
+              "name": "PNR",
+              "shortName": "PNR",
+              "location": "MT2-PNR1.xml",
+              "id": "890534932",
+              "audit": {
+                "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+                "createdTimestamp": 1563637415000,
+                "updatedBy": null,
+                "updatedTimestamp": null,
+                "deletedBy": null,
+                "deletedTimestamp": null
+              }
+            },
+            "complianceRecord": null,
+            "mappingRecord": {
+              "name": "Travel Agent",
+              "version": "1.0"
+            }
+          },
+          "type": "ORGANISATION",
+          "organisation": {
+            "type": "ORGTRVL",
+            "name": "890534932",
+            "registrationNumber": null,
+            "vatNumber": null,
+            "industrySector": null,
+            "numberOfEmployees": null
+          },
+          "attributes": {
+            "attrs": {
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentCountryCode": "GB",
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.passengerDetails.passenger.freqFlyerNumber": "8767844",
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentCityCode": "LHR",
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.travelAgentType": "A"
+            }
+          },
+          "matching": null,
+          "features": null,
+          "washResponses": null,
+          "matchMerge": null,
+          "changeHistory": null
+        }
+      ],
+      "documents": [
+        {
+          "metadata": {
+            "identityRecord": {
+              "poleId": {
+                "v2": {
+                  "id": "PNR:P=dab092daf6d33e8fd2bfe5e2bcff8750,O=bec77b0b7613e0d05ff1a7421f6abcf4"
+                },
+                "v1": null
+              },
+              "type": "O"
+            },
+            "sourceRecord": {
+              "name": "PNR",
+              "shortName": "PNR",
+              "location": "MT2-PNR1.xml",
+              "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+              "audit": {
+                "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+                "createdTimestamp": 1563637415000,
+                "updatedBy": null,
+                "updatedTimestamp": null,
+                "deletedBy": null,
+                "deletedTimestamp": null
+              }
+            },
+            "complianceRecord": null,
+            "mappingRecord": {
+              "name": "TDI (dcs)",
+              "version": "1.0"
+            }
+          },
+          "type": "DOCUMENT",
+          "party": {
+            "poleId": {
+              "v2": {
+                "id": "PNR:P=dab092daf6d33e8fd2bfe5e2bcff8750"
+              },
+              "v1": null
+            },
+            "type": "P"
+          },
+          "role": "PTOOUSES",
+          "startTimestamp": null,
+          "endTimestamp": null,
+          "name": null,
+          "description": null,
+          "additionalInformation": null,
+          "url": null,
+          "document": {
+            "type": "OBJDOCPAS",
+            "value": "119039375",
+            "subject": null,
+            "category": null,
+            "status": null,
+            "placeOfIssue": "GBR",
+            "countryOfIssue": null,
+            "dateOfIssue": null,
+            "validFromDate": 17648,
+            "expiryDate": 19473
+          },
+          "attributes": {
+            "attrs": {
+              "commonAPIPlus.pnrDetails.pnrData.pnrDetail.itinerary.travelSegment.dcsDetails.dcsData.dcsRecord.1.travelDocument.0.travelDocType": "P"
+            }
+          },
+          "matching": null,
+          "features": null,
+          "washResponses": null,
+          "matchMerge": null,
+          "changeHistory": null
+        }
+      ],
+      "vehicles": null,
+      "vessel": null,
+      "addresses": null,
+      "contacts": null,
+      "voyage": {
+        "metadata": {
+          "identityRecord": {
+            "poleId": {
+              "v2": {
+                "id": "PNR:S=7b6ca8653ee18febc78bdb22aa572889"
+              },
+              "v1": null
+            },
+            "type": "S"
+          },
+          "sourceRecord": {
+            "name": "PNR",
+            "shortName": "PNR",
+            "location": "MT2-PNR1.xml",
+            "id": "502992e4-f319-4422-ac26-09dbdcda5f58",
+            "audit": {
+              "createdBy": "w5Z2Vjtkw5PCv8Ohc0PCk8KjwpzCv1jDrQ==",
+              "createdTimestamp": 1563637415000,
+              "updatedBy": null,
+              "updatedTimestamp": null,
+              "deletedBy": null,
+              "deletedTimestamp": null
+            }
+          },
+          "complianceRecord": null,
+          "mappingRecord": {
+            "name": "Voyage",
+            "version": "1.0"
+          }
+        },
+        "type": "VOYAGE",
+        "effectiveFromTimestamp": 1563727200000,
+        "effectiveToTimestamp": 1563734100000,
+        "dueTimestamp": null,
+        "status": null,
+        "voyage": {
+          "type": "FLIGHT",
+          "voyageType": null,
+          "departureLocation": "LHR",
+          "departureCountry": null,
+          "scheduledDepartureTimestamp": 1657456201000,
+          "actualDepartureTimestamp": null,
+          "arrivalLocation": "YYC",
+          "arrivalCountry": null,
+          "scheduledArrivalTimestamp": 1657467001000,
+          "actualArrivalTimestamp": null,
+          "intermediateLocations": null,
+          "passengerCount": 178,
+          "crewCount": null,
+          "durationMinutes": null,
+          "routeId": "BA0103",
+          "carrier": "BA",
+          "craftId": null
+        },
+        "attributes": {
+          "attrs": {
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureAirport": "LHR",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureDate": "2019-07-21",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalTime": "1835",
+            "commonAPIPlus.pnrDetails.flightSummary.airlineCode": "BA",
+            "journeyHash": "7b6ca8653ee18febc78bdb22aa572889",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureTime": "1640",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalDate": "2019-07-21",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalAirport": "YYC",
+            "commonAPIPlus.pnrDetails.flightSummary.flightCode": "BA103"
+          }
+        },
+        "features": {
+          "feats": {
+            "PNR-EU-MOVEMENT": {
+              "id": null,
+              "type": null,
+              "valueType": "BOOL",
+              "value": false,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            }
+          }
+        },
+        "changeHistory": null
+      },
+      "consolidation": null,
+      "consignments": null,
+      "booking": {
+        "metadata": {
+          "identityRecord": {
+            "poleId": {
+              "v2": {
+                "id": "PNR:S=LSV4UV29eb441dfde1318b19a55a3617932ae5"
+              },
+              "v1": {
+                "id": 105000070371824
+              }
+            },
+            "type": "S"
+          },
+          "sourceRecord": {
+            "name": "PNR",
+            "shortName": "PNR",
+            "location": "pnr/whole_flight_AC0850_zatb",
+            "id": "d06ff6ef-736d-47f6-a4a8-af22b2d2cc21",
+            "audit": {
+              "createdBy": "T11SwrIdw7xLBMKyecKOw61rOzZ2",
+              "createdTimestamp": 1537317004000,
+              "updatedBy": "UsOiwqHDo8KlTkPClGNZw7VXwrB4QcOZ",
+              "updatedTimestamp": 1537401580000,
+              "deletedBy": null,
+              "deletedTimestamp": null
+            }
+          },
+          "complianceRecord": null,
+          "mappingRecord": {
+            "name": "Booking",
+            "version": "1.0"
+          }
+        },
+        "type": "BOOKING",
+        "effectiveFromTimestamp": 1531958400000,
+        "effectiveToTimestamp": null,
+        "dueTimestamp": null,
+        "status": null,
+        "booking": {
+          "type": "PNR",
+          "pnrData": {
+            "locator": "LSV4UV",
+            "masterLocator": null,
+            "split": null,
+            "raw": "7S:0A/HN+00I.+1/'+D00SCDYT8+U4:+UK7+K9DUOPAOL:D1U4:+I.KUR+R/*'.:D90:0UAL1DO::0LR3'D?/?KIES2YP+++YO?.I1YDAC:LR1.B'S+AA+UA+EC*2A:+0:A:LI005G+C++10++?50TD+D+S0XIA*:H:UY:5Y:O0SC+:NOT+XTBY:::TTD+AC:0IMLGW:IA'0GI+''AS41+4T+RS:+9AN.7G::++NN/XSHT0L0000'ACC:4+KP:+:G6A4+-*03DV0+P'+.VS0AS:9A:VC:E19O:89'2:+5:X038:2ARQOGA:C4S91/:8?LO+CCE*+C:+C1FLI6FAGAKHA8:0SI1NID/C+YY1+E1ZVMA7ICLW+A2?/:1D:TLXS:0:1'Y10:'O0RA+:EH0:I+1R4L0AB/F09/AV09T+VFE:E1A/::+?NTT'TJFLCWD2F0C:CMWXPA:E:1:E3+CA+I9DY6S:4Y.E.:S:Y'/U+94JB:2'ET9C+:1P-:RY19:8S:1NCH3'I+:T8:2VREUL9D0+4:G'AD100+/:T4AMS/A8A+180810?X3+A:+1/'AR'A115IB9WKAT871C+Y/5A:CL9C0++03:TN4XI/1S0::9IYLE'DRXI8TAC+8MPL8I:XIC+AWXT808AJXAR:DO'17GXS1+FH:T1'II90//:++VC80RLN.3I+3891*DQ/G0{05L'/C1TT8:R4/107811O8SA:DE::0'3:6:A'UT80UX'H10E+TD+1H+,'H+Y8YU+1AD01+:VCK*AA+191O308::'M9*9S9C+:01AY?:E91RW1R0A4YA:T1CU:5/A:+2G23B+:61EV1E'?NE+NB:LOA90::C0'I+C051I++T*:DRC2CC4I7:CDG8A?TN1VNFI'+'Y:1PIA'N:E0A709T0FSXHS80FCZ+160'+:IR1X9+TA+/+T'OE2/J61+S7'.+SE+8+'I77:T3DAR3C5:YC'VI0?E050SI9IYT1.C1C+O+KACLC++::48YTP0H0:ABA7++L1O07EN0::FRI:94EMRN7NS:8:F*M:5WRI:91DBM84:9QL'XI6A:R+G4/83+SAHO:8:X9/HO'930B1+AWL8CT59::,:+9P.+7BOST/SGYVRUO.*:*LITN7C+8'0M8TX.:IKADV1FADM73I:J71/UE20:0SY0:'I:8ETWICF/X'+TDPOLLHO'D?:O9A:0:NX3+VY+7AH:+?XRLX7::1'S+:+D4#A+:'1F4:1+CCYS:+ST9CR050D/H:VCRC:01+D++.HC0:2AXPT4'?0+Y+BICDLIDFA+LR/TMD'II:+C7C0Y8+MRCTS33CA:N:0:*5Y'ISDDA'Q:VA:}::'748A1:AS0'+.+6::65'0S:+1LAO'O+:0TUE:ULRL:'L5S*7LHH::/X913I+0:'WAOU:3GT9SSO31+2O'GA1N:4AR0AL+::7AN+TA'D0+/:+*17C1KA0RA'A::D+:81+?4ZH0::F4AH1E2':'3OX+7S:7::W+T+:1+A1:900DC'R6L6T'P1KCC8':+C8:+AZ0A:S:RT+R2AT++S0:UAH+1:BA0Y1BT+Q:'/0P3L+S+1/W/I0+C+Y+CLY0C:+98KCRT1AFS+F+943MUA.T3DDT'K'L'T4SNVC03S+:?.K?OT.+I'+TA1AA1?NW+X8AHS7UD495A0HT:1LSV/:A+':Y+N50D:J8TDA::T+P4'8R:C+KV0TA3A':411A5S+T:+I+:H83V0I1+RC8D:2A:+-D1ACS:'?ICAFD.10EL08?4DF6D'X2:+IP8++H:V::+:A.RM:DAE91YAF+D1C1AAR.A1A4W:+J'0X4'DACT120TI'XHLT0I0A0FSU0CBM+A2AY8EB#XA3:ACH8-AFVARTCC9WT'T+:3'U010I5DA4OR++'CAO1:++C+S6.RA?51*+::LA+91XASG:1M27LB43:UL5LF7H4#IF++:RIVCEGT+AEFID9V++VIOTF5001D?:VH0EI7TA0L+4R+M08N1Y+A1:+.TSTT1NC8:+L4A:SRTC3DCA4:IA:20'X.1'58++.3I7::CTKSMO+'2CQ,XA+C4TA3DA:+NARK+DIRX8FC:C'1:XE1':ACHD.CTVH8X+01YT14Y0581::T4AT:0'D3LR0L?29'/A1''I++RLETADSD::EA1:SQB9AN1:::ZV:R:09D+:+:S7+S0A4+I011SL+AYC0+/++1D+:63J8DLH:#MATOT8YALU40D1JD'F1D:A?1++ATO*CX1+:NS+T7.RI91DUIB:4BTIXFU81UXYD_C'A64E2QT::DM24YR4C'ASX9CAMVETX.-C0'::1GGSAVSO4RRCT91S+22LR34::0?R/:V9V9511:DY++N0G5AF:8F9GT1+1.8:S+C'CR?0CZ:+I0NT3AIAX:A++CEDLPI:C4YA4WN90M5FDC+''Y:H80:401EL'D+92OC:5:4'1I44RCA1CI1LM+9-.4+A'ACTRS72O/YAE++/:S:+AYTLRD7+DTT5S1:Y+DL0I:0IKCI3:3DYNM:HSESC4TAA+2U9S8C+V0I:9A'::9+1*9R8'C:RCS3V.1Y1:79:2:VV+0+R+:9F+9R6:7:?VTDC++:CBFDOT:RW.1C+AR:A+SGL+'1LT3AXZ:H1:1YZ9+2+1:SIH:8GA01:E/4H0EL5'1E5+U0CA19+NW.YKNXD:+U2W:::GT5O0:+1+KGT.2+0C:BLATOI0T2:TCC4N'LI+3SBICSB41HT6'/0:VC9+3++4A0OLR93X815L'Y:7'?4'17,7D:7T2S+:A:''VT:EC84P+9L342VVU0R:A3H:7",
+            "history": null
+          },
+          "accompaniedByInfant": false,
+          "unaccompaniedMinor": null,
+          "contacts": [
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "7",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": null,
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": null,
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": "CA"
+            },
+            {
+              "type": null,
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": "CTCE",
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": null,
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": null,
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            },
+            {
+              "type": null,
+              "text": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER",
+              "countryCode": null
+            }
+          ],
+          "itineraryTravel": [
+            {
+              "type": "FLIGHT",
+              "voyageType": null,
+              "departureLocation": "CDG",
+              "departureCountry": "FR",
+              "scheduledDepartureTimestamp": 1538564400000,
+              "actualDepartureTimestamp": null,
+              "arrivalLocation": "YYZ",
+              "arrivalCountry": "CA",
+              "scheduledArrivalTimestamp": 1538571900000,
+              "actualArrivalTimestamp": null,
+              "intermediateLocations": null,
+              "passengerCount": null,
+              "crewCount": null,
+              "durationMinutes": null,
+              "routeId": "AC0850",
+              "carrier": null,
+              "craftId": null
+            },
+            {
+              "type": "FLIGHT",
+              "voyageType": null,
+              "departureLocation": "YYZ",
+              "departureCountry": "CA",
+              "scheduledDepartureTimestamp": 1538582700000,
+              "actualDepartureTimestamp": null,
+              "arrivalLocation": "YYC",
+              "arrivalCountry": "CA",
+              "scheduledArrivalTimestamp": 1538590560000,
+              "actualArrivalTimestamp": null,
+              "intermediateLocations": null,
+              "passengerCount": null,
+              "crewCount": null,
+              "durationMinutes": null,
+              "routeId": "BD0998",
+              "carrier": null,
+              "craftId": null
+            },
+            {
+              "type": "FLIGHT",
+              "voyageType": null,
+              "departureLocation": "YYC",
+              "departureCountry": "CA",
+              "scheduledDepartureTimestamp": 1538591560000,
+              "actualDepartureTimestamp": null,
+              "arrivalLocation": "LHR",
+              "arrivalCountry": "GB",
+              "scheduledArrivalTimestamp": 1538601560000,
+              "actualArrivalTimestamp": null,
+              "intermediateLocations": null,
+              "passengerCount": null,
+              "crewCount": null,
+              "durationMinutes": null,
+              "routeId": "XZ0123",
+              "carrier": null,
+              "craftId": null
+            }
+          ],
+          "payments": [
+            {
+              "type": "MS",
+              "amount": null,
+              "cardNumber": null,
+              "cardExpiryDate": null,
+              "data": "L-/0005109#04",
+              "vendorCode": null
+            },
+            {
+              "type": "CC",
+              "amount": 2190.48,
+              "cardNumber": "30XXXXXXXXXXX63X",
+              "cardExpiryDate": 18536,
+              "data": null,
+              "vendorCode": "VI"
+            },
+            {
+              "type": "MS",
+              "amount": null,
+              "cardNumber": null,
+              "cardExpiryDate": null,
+              "data": "AGT0005109#04                   APC: 02339I",
+              "vendorCode": null
+            },
+            {
+              "type": "MS",
+              "amount": null,
+              "cardNumber": null,
+              "cardExpiryDate": null,
+              "data": "L-/0005109#04",
+              "vendorCode": null
+            },
+            {
+              "type": "CC",
+              "amount": 2190.48,
+              "cardNumber": "30XXXXXXXXXXX63X",
+              "cardExpiryDate": 18536,
+              "data": null,
+              "vendorCode": "VI"
+            },
+            {
+              "type": "MS",
+              "amount": null,
+              "cardNumber": null,
+              "cardExpiryDate": null,
+              "data": "AGT0005109#04                   APC: 02339I",
+              "vendorCode": null
+            }
+          ],
+          "tickets": [
+            {
+              "number": "1741815210698",
+              "issueDate": 17731,
+              "priceType": "B",
+              "currencyCode": "CAD",
+              "paymentAmount": "441.0"
+            },
+            {
+              "number": "1741815210698",
+              "issueDate": 17731,
+              "priceType": "T",
+              "currencyCode": "CAD",
+              "paymentAmount": "1095.24"
+            },
+            {
+              "number": "1718705911248",
+              "issueDate": 17731,
+              "priceType": "B",
+              "currencyCode": "CAD",
+              "paymentAmount": "441.0"
+            },
+            {
+              "number": "1718705911248",
+              "issueDate": 17731,
+              "priceType": "T",
+              "currencyCode": "CAD",
+              "paymentAmount": "1095.24"
+            }
+          ],
+          "requests": [
+            {
+              "type": "DOCS",
+              "data": "1'+:ORKSSS:DH:YCY"
+            },
+            {
+              "type": "DOCS",
+              "data": "1'+:ORKSSS:DH:YCY"
+            },
+            {
+              "type": "AUTH",
+              "data": "1WUT:O/C:CJWBHAA:'KEEOWAASC:HW+8UG:C:DS/RCDTAW::1CONELUSU9CA/DOS"
+            },
+            {
+              "type": "AUTH",
+              "data": "+WW1U/GU:IK004SU:LR:A:A:T:SP:1/HS8AGV0CSLWVH:C/J1S9'W"
+            },
+            {
+              "type": "AUTH",
+              "data": "A0HVCU::W1AHWSP:2L04/+9GR::::KSCTISSU1:8AJL0U/W'VW/SG"
+            }
+          ],
+          "excessBaggage": [],
+          "history": [
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYC",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "LHR",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": []
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "CDG",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "YYZ",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYZ",
+                  "departureCountry": "null",
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "YYC",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYC",
+                  "departureCountry": "CA",
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "LHR",
+                  "arrivalCountry": "GB",
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "EF0123",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "X",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYC",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "LHR",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYC",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "LHR",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": []
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "CDG",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "YYZ",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYZ",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "YYC",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "A",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYC",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "LHR",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            },
+            {
+              "status": "X",
+              "historyTimestamp": null,
+              "requests": [],
+              "contacts": [],
+              "itineraryTravel": [
+                {
+                  "type": "FLIGHT",
+                  "voyageType": null,
+                  "departureLocation": "YYC",
+                  "departureCountry": null,
+                  "scheduledDepartureTimestamp": null,
+                  "actualDepartureTimestamp": null,
+                  "arrivalLocation": "LHR",
+                  "arrivalCountry": null,
+                  "scheduledArrivalTimestamp": null,
+                  "actualArrivalTimestamp": null,
+                  "intermediateLocations": null,
+                  "passengerCount": null,
+                  "crewCount": null,
+                  "durationMinutes": null,
+                  "routeId": "AC0850",
+                  "carrier": null,
+                  "craftId": null
+                }
+              ]
+            }
+          ]
+        },
+        "attributes": {
+          "attrs": {
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureAirport": "YYC",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureDate": "2018-09-19",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalTime": "1000",
+            "commonAPIPlus.pnrDetails.flightSummary.airlineCode": "AC",
+            "journeyHash": "29eb441dfde1318b19a55a3617932ae5",
+            "commonAPIPlus.pnrDetails.flightSummary.flightDepartureTime": "1825",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalDate": "2018-09-20",
+            "commonAPIPlus.pnrDetails.flightSummary.flightArrivalAirport": "LHR",
+            "commonAPIPlus.pnrDetails.flightSummary.flightCode": "AC0850"
+          }
+        },
+        "features": {
+          "feats": {
+            "STANDARDISED:legTimestampDifferenceMilliseconds[1]": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 1213200000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:durationWholeTripMilliseconds": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 1209060000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:durationStayMilliseconds": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 1231500000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:ticketType": {
+              "id": null,
+              "type": null,
+              "valueType": "STRING",
+              "value": "RETURN",
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            },
+            "STANDARDISED:legTimestampDifferenceMilliseconds[2]": {
+              "id": null,
+              "type": null,
+              "valueType": "INT",
+              "value": 10800000,
+              "valueList": null,
+              "startTimestamp": null,
+              "endTimestamp": null
+            }
+          }
+        },
+        "changeHistory": {
+          "changes": [
+            {
+              "sourceVersion": 2,
+              "cerberusTimestamp": 1648463971376,
+              "state": {
+                "creationTimestamp": 1632402217763,
+                "updateTimestamp": 1632402224742,
+                "version": 1
+              },
+              "change": {
+                "type": "STATE_CHANGE_SERVICE",
+                "changes": [
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/contacts/17",
+                    "property": "text",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "REDACTED@EMAIL.COM, REDACTED ADDRESS, REDACTED PHONE NUMBER"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/5/itineraryTravel/0",
+                    "property": "type",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "FLIGHT"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/5/itineraryTravel/0",
+                    "property": "departureLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "YYC"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/5/itineraryTravel/0",
+                    "property": "arrivalLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "LHR"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/5/itineraryTravel/0",
+                    "property": "routeId",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "AC0850"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11",
+                    "property": "status",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "X"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11",
+                    "property": "itineraryTravel",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11/itineraryTravel/0"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10",
+                    "property": "status",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "A"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10",
+                    "property": "itineraryTravel",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10/itineraryTravel/0"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8/itineraryTravel/0",
+                    "property": "type",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "FLIGHT"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8/itineraryTravel/0",
+                    "property": "departureLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "CDG"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8/itineraryTravel/0",
+                    "property": "arrivalLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "YYZ"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8/itineraryTravel/0",
+                    "property": "routeId",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "AC0850"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9/itineraryTravel/0",
+                    "property": "type",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "FLIGHT"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9/itineraryTravel/0",
+                    "property": "departureLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "YYZ"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9/itineraryTravel/0",
+                    "property": "arrivalLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "YYC"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9/itineraryTravel/0",
+                    "property": "routeId",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "AC0850"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10/itineraryTravel/0",
+                    "property": "type",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "FLIGHT"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10/itineraryTravel/0",
+                    "property": "departureLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "YYC"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10/itineraryTravel/0",
+                    "property": "arrivalLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "LHR"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10/itineraryTravel/0",
+                    "property": "routeId",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "AC0850"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9",
+                    "property": "status",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "A"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9",
+                    "property": "itineraryTravel",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9/itineraryTravel/0"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8",
+                    "property": "status",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "A"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8",
+                    "property": "itineraryTravel",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8/itineraryTravel/0"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11/itineraryTravel/0",
+                    "property": "type",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "FLIGHT"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11/itineraryTravel/0",
+                    "property": "departureLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "YYC"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11/itineraryTravel/0",
+                    "property": "arrivalLocation",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "LHR"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11/itineraryTravel/0",
+                    "property": "routeId",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "AC0850"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/7/itineraryTravel/0",
+                    "property": "type",
+                    "propertyChange": {
+                      "oldValue": "FLIGHT",
+                      "newValue": null
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/7/itineraryTravel/0",
+                    "property": "departureLocation",
+                    "propertyChange": {
+                      "oldValue": "YYZ",
+                      "newValue": null
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/7/itineraryTravel/0",
+                    "property": "arrivalLocation",
+                    "propertyChange": {
+                      "oldValue": "YYC",
+                      "newValue": null
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/7/itineraryTravel/0",
+                    "property": "routeId",
+                    "propertyChange": {
+                      "oldValue": "AC0850",
+                      "newValue": null
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/pnrData",
+                    "property": "raw",
+                    "propertyChange": {
+                      "oldValue": "742TWA8/:E6L1+2DG1+L03*:9CDMFR+R10H'AQWG7STC:.LOQF00.L:+W:T4FC5L+044+VN7G++TZ+IR0PA5UAAQCLNN:4H.8LI2Y''++1SV89+:T0HY0DID+R'59:8S'+4+7XSOS'+CAO/+R/E9BODI:A5DVTAL0U+X0+0S?1:'AA,3VRC8TJA3G0:0ATF*1'IX.18IST+G+99UACQCO17I+:+D+Y+5NTTAW9C:'5S0Z06DIEX1*:D4O:1T0'++R39A1HEJT+H:A0DYTA8+::1BNVDS:76+10DD'RUGAILAC6:Y:SCA42BA:D6D?YV/70LDK17YR*0A7:I+0413345I2AT80D'':/DVT:1IT:'C+A:F6:+C':I:0F'A7RT'HK0'A2R'JT9AD'KLBC:'L+1/Y88D:+3UK,A.?+Y'+'ET:8A+CRNNCH*T/CCA+'V9O:S+DT84'4E3:Y0G3O/.IA/++:MKT+XYD:1T:MEFRC2GA:3+L3D10AF7+:YS:17'WS:96A88F+R:R/'A,0G0R+AO81+100+P8BOCI+00?+891+*SVJ':/4X*5NR++4L0:TY::/?+1+YV4IXKA:Y718L+C1EVH10THHC+QC+IEP1+0'8.A0'DL+TP'N4R:8+:A80DKTUV8:7E:I9DD+:F8D+++XCG5.:DM4319GAA/1:S2V2H0:287A'A:1:T:AXH07I:5+CDS8B31:AN+II2R2':1+U:SF7ME'+8+FA01?33XL.C:D3K/+0:+R+F0LD1FONM541E?1AO::V4S1CWUM.M3T+S501:DRGHTNCPOT+L+'F?ZACX+L1+:0DJ:W0:S1?4/7LL:+/:+A41U01AH3::I.F6+E::8HFFO9:1'Z/I00A:X.0YUL0+:YA788I:+0:K:D::AD0XAUDT:AO:LW':E:?1/NA'1X:::4XR/7'1T1R4SE++IC++R/R1MTUCY:+:ABYLD+DHA+D.TD0A:R.:S2/098VT.2OO9R''N:0T:A1:+VG+1F+::S0IR-FIT:'K'1+2SD:A8P0R3::RA::IC'CFTD4WE+R02:X++9SC:?4AO::T+CDI74STOF+NC:*+AHIX15Z0:2Y7S9'0R:C1WVI1T4CCC:A4+D1'WXA:Y4A'1'01D:XBAXUDS60E:C1K1XIARWH122LC3Y5+J+SISUA'T?0E:R+EDIOCU+WELS:A17C9G?7L1/F:P31CR1-C1T9T1:TC:0L+7R:C9:CH.+:I+7:+4D5TTX'LEAV+4'YIOL:C+/4:+*9018DRW22DPT3'38:TE70'5K:U0R0EXCXAH+98?V10YA:#I14IA:L:+':X+CC:+''0BCC+I:1:YSO::9:4:H+S0'C:+TE44ADO:AMV.AN':+?G:9:R1VLRIH1DILCG873XT0+1L5IIA898+SO1:A0+90+R:L+'/9/+++OCVDD0C+0UC70Z+A0CRL9:+7IAXO3+K0IP5:+9AT1A0ST+LSS6GIEA:A'Q+V+:1270DE3+GAS4W3TIL9M+RA+Z:AAD*1:VAC1U:::YF:12:V6D+6LA?.''NLR:H?''4:.A07TP4X3C2RA5CAC3ASLI/A/GF+L1::0:E1U.+:+:819}9O:E500+AD10:''0+OA-N:/SLCI+0K1VCT1'T.0R2/TUOTT:NTTK5IHY1DAC:'54:T1+RC:,'ETAYS:1:+J+R:/ASCSDDTRR7+SAAL0TMA.:ST4:CM:D10N45*8C:9:+E'R3S993C01V.+EG:CC?S:YI91?00A:?0SMR'IS18CMY:*CMSNA/I5LXD41J:'S6CSP09+0218:S4++:0+PSC+2A:51'SDX3.:2:4A3+0ECAEAGAK:RATHWLSM:R'TE:AA+F:C433.9:X3A10XI':A.BO89I0X9NBCI1:0DM++?#IT10T+:'E:+I:B93ACNDAHO.PYE3/NEH9:::Y1:2+I:+A6T+ALZ0L+/ATA'1+C235*:07B::+7:{'2C33'?/W+S046'ISWD0D4VM8D:9CCR04YU::+0SX'8:HA0RSX++1S:'::++SL1XXC:9A23TD39IL?710NUYD:IL1+TTAX0OP+00VOCA0'0:IYE:07IYR1+94YQ:11TTA:T4:C12DID:+2B4T*0CA4E:TST6O1::'ER+:Q_AV+AG'S+T87:51AAU5'XAH+O+A1+'NCOT900'+C#1GCA074N++0GFU/KR4S2*+:6:R?Y'::A1P:5C9+1:UIALY+U73.AADCOWHBSCVU::J+.PR3.:ISA:/LY6:PAG'LT372?01XTTT9TV4BA+?/TDAC5E1NBD:1EI0+E*I08CIV3:HABCBFD+I1A1IF+?:0E+8I:1W7F++4:0:+8M+8+S1C00:R8TV:8++D1::9:4T850+DCIU+A4?A+'/0VHD8'0F+RYECTOTKT1E.+F?::9M:K'1'AV01MC7N-:SA'C3/+CI-.0H:2+:N.UN:FN27M-XH1AO4X9N01T+A0YET:LKBR:N#DXSS:+USI:D'3LD*HAP9AIU0:C:28AFIV8DOC8'4:SS1A1CDXSF:0.T1.::++:/T4ORAI/N:LA1UNFG*Y04A",
+                      "newValue": "7S:0A/HN+00I.+1/'+D00SCDYT8+U4:+UK7+K9DUOPAOL:D1U4:+I.KUR+R/*'.:D90:0UAL1DO::0LR3'D?/?KIES2YP+++YO?.I1YDAC:LR1.B'S+AA+UA+EC*2A:+0:A:LI005G+C++10++?50TD+D+S0XIA*:H:UY:5Y:O0SC+:NOT+XTBY:::TTD+AC:0IMLGW:IA'0GI+''AS41+4T+RS:+9AN.7G::++NN/XSHT0L0000'ACC:4+KP:+:G6A4+-*03DV0+P'+.VS0AS:9A:VC:E19O:89'2:+5:X038:2ARQOGA:C4S91/:8?LO+CCE*+C:+C1FLI6FAGAKHA8:0SI1NID/C+YY1+E1ZVMA7ICLW+A2?/:1D:TLXS:0:1'Y10:'O0RA+:EH0:I+1R4L0AB/F09/AV09T+VFE:E1A/::+?NTT'TJFLCWD2F0C:CMWXPA:E:1:E3+CA+I9DY6S:4Y.E.:S:Y'/U+94JB:2'ET9C+:1P-:RY19:8S:1NCH3'I+:T8:2VREUL9D0+4:G'AD100+/:T4AMS/A8A+180810?X3+A:+1/'AR'A115IB9WKAT871C+Y/5A:CL9C0++03:TN4XI/1S0::9IYLE'DRXI8TAC+8MPL8I:XIC+AWXT808AJXAR:DO'17GXS1+FH:T1'II90//:++VC80RLN.3I+3891*DQ/G0{05L'/C1TT8:R4/107811O8SA:DE::0'3:6:A'UT80UX'H10E+TD+1H+,'H+Y8YU+1AD01+:VCK*AA+191O308::'M9*9S9C+:01AY?:E91RW1R0A4YA:T1CU:5/A:+2G23B+:61EV1E'?NE+NB:LOA90::C0'I+C051I++T*:DRC2CC4I7:CDG8A?TN1VNFI'+'Y:1PIA'N:E0A709T0FSXHS80FCZ+160'+:IR1X9+TA+/+T'OE2/J61+S7'.+SE+8+'I77:T3DAR3C5:YC'VI0?E050SI9IYT1.C1C+O+KACLC++::48YTP0H0:ABA7++L1O07EN0::FRI:94EMRN7NS:8:F*M:5WRI:91DBM84:9QL'XI6A:R+G4/83+SAHO:8:X9/HO'930B1+AWL8CT59::,:+9P.+7BOST/SGYVRUO.*:*LITN7C+8'0M8TX.:IKADV1FADM73I:J71/UE20:0SY0:'I:8ETWICF/X'+TDPOLLHO'D?:O9A:0:NX3+VY+7AH:+?XRLX7::1'S+:+D4#A+:'1F4:1+CCYS:+ST9CR050D/H:VCRC:01+D++.HC0:2AXPT4'?0+Y+BICDLIDFA+LR/TMD'II:+C7C0Y8+MRCTS33CA:N:0:*5Y'ISDDA'Q:VA:}::'748A1:AS0'+.+6::65'0S:+1LAO'O+:0TUE:ULRL:'L5S*7LHH::/X913I+0:'WAOU:3GT9SSO31+2O'GA1N:4AR0AL+::7AN+TA'D0+/:+*17C1KA0RA'A::D+:81+?4ZH0::F4AH1E2':'3OX+7S:7::W+T+:1+A1:900DC'R6L6T'P1KCC8':+C8:+AZ0A:S:RT+R2AT++S0:UAH+1:BA0Y1BT+Q:'/0P3L+S+1/W/I0+C+Y+CLY0C:+98KCRT1AFS+F+943MUA.T3DDT'K'L'T4SNVC03S+:?.K?OT.+I'+TA1AA1?NW+X8AHS7UD495A0HT:1LSV/:A+':Y+N50D:J8TDA::T+P4'8R:C+KV0TA3A':411A5S+T:+I+:H83V0I1+RC8D:2A:+-D1ACS:'?ICAFD.10EL08?4DF6D'X2:+IP8++H:V::+:A.RM:DAE91YAF+D1C1AAR.A1A4W:+J'0X4'DACT120TI'XHLT0I0A0FSU0CBM+A2AY8EB#XA3:ACH8-AFVARTCC9WT'T+:3'U010I5DA4OR++'CAO1:++C+S6.RA?51*+::LA+91XASG:1M27LB43:UL5LF7H4#IF++:RIVCEGT+AEFID9V++VIOTF5001D?:VH0EI7TA0L+4R+M08N1Y+A1:+.TSTT1NC8:+L4A:SRTC3DCA4:IA:20'X.1'58++.3I7::CTKSMO+'2CQ,XA+C4TA3DA:+NARK+DIRX8FC:C'1:XE1':ACHD.CTVH8X+01YT14Y0581::T4AT:0'D3LR0L?29'/A1''I++RLETADSD::EA1:SQB9AN1:::ZV:R:09D+:+:S7+S0A4+I011SL+AYC0+/++1D+:63J8DLH:#MATOT8YALU40D1JD'F1D:A?1++ATO*CX1+:NS+T7.RI91DUIB:4BTIXFU81UXYD_C'A64E2QT::DM24YR4C'ASX9CAMVETX.-C0'::1GGSAVSO4RRCT91S+22LR34::0?R/:V9V9511:DY++N0G5AF:8F9GT1+1.8:S+C'CR?0CZ:+I0NT3AIAX:A++CEDLPI:C4YA4WN90M5FDC+''Y:H80:401EL'D+92OC:5:4'1I44RCA1CI1LM+9-.4+A'ACTRS72O/YAE++/:S:+AYTLRD7+DTT5S1:Y+DL0I:0IKCI3:3DYNM:HSESC4TAA+2U9S8C+V0I:9A'::9+1*9R8'C:RCS3V.1Y1:79:2:VV+0+R+:9F+9R6:7:?VTDC++:CBFDOT:RW.1C+AR:A+SGL+'1LT3AXZ:H1:1YZ9+2+1:SIH:8GA01:E/4H0EL5'1E5+U0CA19+NW.YKNXD:+U2W:::GT5O0:+1+KGT.2+0C:BLATOI0T2:TCC4N'LI+3SBICSB41HT6'/0:VC9+3++4A0OLR93X815L'Y:7'?4'17,7D:7T2S+:A:''VT:EC84P+9L342VVU0R:A3H:7"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#metadata/sourceRecord/audit",
+                    "property": "updatedBy",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "UsOiwqHDo8KlTkPClGNZw7VXwrB4QcOZ"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#metadata/sourceRecord/audit",
+                    "property": "updatedTimestamp",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "2018-09-19T23:59:40Z"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/6/itineraryTravel/0",
+                    "property": "departureLocation",
+                    "propertyChange": {
+                      "oldValue": "CDG",
+                      "newValue": "YYC"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/6/itineraryTravel/0",
+                    "property": "arrivalLocation",
+                    "propertyChange": {
+                      "oldValue": "YYZ",
+                      "newValue": "LHR"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/7",
+                    "property": "itineraryTravel",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "REMOVED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/7/itineraryTravel/0",
+                          "newValue": null
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/contacts/14",
+                    "property": "type",
+                    "propertyChange": {
+                      "oldValue": null,
+                      "newValue": "CTCE"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#metadata/sourceRecord",
+                    "property": "location",
+                    "propertyChange": {
+                      "oldValue": "pnr/whole_flight_AC0850_xn",
+                      "newValue": "pnr/whole_flight_AC0850_zatb"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking",
+                    "property": "contacts",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/contacts/17"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking",
+                    "property": "history",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/8"
+                        }
+                      },
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/9"
+                        }
+                      },
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/10"
+                        }
+                      },
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/11"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "VALUE_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/5",
+                    "property": "status",
+                    "propertyChange": {
+                      "oldValue": "A",
+                      "newValue": "X"
+                    },
+                    "entryChange": null
+                  },
+                  {
+                    "type": "COLLECTION_CHANGED",
+                    "object": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/5",
+                    "property": "itineraryTravel",
+                    "propertyChange": null,
+                    "entryChange": [
+                      {
+                        "type": "ADDED",
+                        "key": null,
+                        "propertyChange": {
+                          "oldValue": null,
+                          "newValue": "uk.gov.ho.dacc.pole.service.ServiceRecord/#booking/history/5/itineraryTravel/0"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "seizure": null,
+      "detainment": null
+    }
+  }
+}

--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -510,7 +510,7 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
-  it('Should verify Co-traveller details of an AirPax task on task details page', () => {
+  it.only('Should verify Co-traveller details of an AirPax task on task details page', () => {
     cy.acceptPNRTerms();
     const taskName = 'AUTOTEST';
     cy.fixture('airpax/task-airpax.json').then((task) => {
@@ -525,6 +525,19 @@ describe('Verify AirPax task details of different sections', () => {
             });
           });
         });
+      });
+    });
+  });
+
+  it.only('Should verify Co-traveller details not available for an AirPax task with single passenger on task details page', () => {
+    cy.acceptPNRTerms();
+    const taskName = 'AUTOTEST';
+    cy.fixture('airpax/task-airpax-singlePassenger.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createTargetingApiTask(task).then((response) => {
+        cy.wait(4000);
+        cy.checkAirPaxTaskDisplayed(`${response.id}`);
+        cy.contains('h3', '1 Co-traveller').should('not.exist');
       });
     });
   });

--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -510,7 +510,7 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
-  it.only('Should verify Co-traveller details of an AirPax task on task details page', () => {
+  it('Should verify Co-traveller details of an AirPax task on task details page', () => {
     cy.acceptPNRTerms();
     const taskName = 'AUTOTEST';
     cy.fixture('airpax/task-airpax.json').then((task) => {
@@ -529,7 +529,7 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
-  it.only('Should verify Co-traveller details not available for an AirPax task with single passenger on task details page', () => {
+  it('Should verify Co-traveller details not available for an AirPax task with a single passenger on task details page', () => {
     cy.acceptPNRTerms();
     const taskName = 'AUTOTEST';
     cy.fixture('airpax/task-airpax-singlePassenger.json').then((task) => {


### PR DESCRIPTION
## Description
Add test for Remove main traveller row from co-travellers table
https://support.cop.homeoffice.gov.uk/browse/COP-11199

## To Test
npm run cypress:test:local -- --spec cypress/integration/airpax/airpax-tasks-details.spec.js

Should verify Co-traveller details not available for an AirPax task with a single passenger on task details page


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
