### PR TITLE
COP-11198 : Add test for Submit target information sheet

### DIFF
--- a/cypress/fixtures/airpax/issue-task-airpax.json
+++ b/cypress/fixtures/airpax/issue-task-airpax.json
@@ -22,16 +22,17 @@
         "trailer": null,
         "journey": {
             "id": "BA0103",
-            "direction": "INBOUND",
+            "direction": null,
+            "route": "CDG - YYZ - YYC - LHR",
             "arrival": {
-                "country": "GB",
-                "location": "LHR",
-                "time": "2019-07-21T18:35:00Z"
+                "country": null,
+                "location": "YYC",
+                "time": "2022-07-10T15:30:01Z"
             },
             "departure": {
-                "country": "CA",
-                "location": "YYC",
-                "time": "2019-07-21T16:40:00Z"
+                "country": null,
+                "location": "LHR",
+                "time": "2022-07-10T12:30:01Z"
             }
         },
         "flight": {
@@ -40,14 +41,14 @@
         "person": {
             "id": "dab092daf6d33e8fd2bfe5e2bcff8750",
             "name": {
-                "first": "ZUES CARLO",
-                "last": "BATZ STOUP",
-                "full": "ZUES CARLO BATZ STOUP"
+                "first": "Testing GivenName",
+                "last": "Testing FamilyName",
+                "full": "FamilyName GivenName"
             },
-            "dateOfBirth": "1976-12-10T00:00:00Z",
+            "dateOfBirth": "1976-12-30T00:00:00Z",
             "gender": {
-                "id": "M",
-                "name": "Male",
+                "id": "F",
+                "name": "Female",
                 "validfrom": "2019-01-01T00:01:00Z",
                 "validto": null,
                 "updatedby": null
@@ -66,27 +67,73 @@
                 "expiry": "2023-04-26T00:00:00Z"
             },
             "nationality": {
-                "id": 290,
-                "nationality": "British Citizen",
+                "id": 15,
+                "nationality": "Australia",
                 "description": null,
-                "iso31661alpha3": "GBR",
-                "iso31661alpha2": "GB",
+                "iso31661alpha3": "AUS",
+                "iso31661alpha2": "AU",
                 "visarequired": false,
                 "evwoptional": false,
                 "diplomaticexception": false,
                 "specialexception": false,
-                "countryid": 0,
-                "validfrom": "2022-01-25T00:00:01Z",
+                "countryid": 14,
+                "validfrom": "2019-01-01T00:01:00Z",
                 "validto": null,
-                "updatedby": "Ben Milnes"
+                "updatedby": null
             },
             "photograph": null
         },
-        "otherPersons": [],
+        "otherPersons": [
+            {
+                "id": "dab092daf6d33e8fd2bfe5e2bcff8750",
+                "name": {
+                    "first": "ZUES CARLO",
+                    "last": "BATZ STOUP",
+                    "full": "ZUES CARLO BATZ STOUP"
+                },
+                "dateOfBirth": "1976-12-10T00:00:00Z",
+                "gender": {
+                    "id": "M",
+                    "name": "Male",
+                    "validfrom": "2019-01-01T00:01:00Z",
+                    "validto": null,
+                    "updatedby": null
+                },
+                "document": {
+                    "type": {
+                        "id": 7,
+                        "code": "P ",
+                        "shortdescription": "Passport and Emergency Travel Document",
+                        "longdescription": "Passport and Emergency Travel Document (ETD)",
+                        "validfrom": "2019-01-01T00:01:00Z",
+                        "validto": null,
+                        "updatedby": null
+                    },
+                    "number": "119039375",
+                    "expiry": "2023-04-26T00:00:00Z"
+                },
+                "nationality": {
+                    "id": 290,
+                    "nationality": "British Citizen",
+                    "description": null,
+                    "iso31661alpha3": "GBR",
+                    "iso31661alpha2": "GB",
+                    "visarequired": false,
+                    "evwoptional": false,
+                    "diplomaticexception": false,
+                    "specialexception": false,
+                    "countryid": 0,
+                    "validfrom": "2022-01-25T00:00:01Z",
+                    "validto": null,
+                    "updatedby": "Ben Milnes"
+                },
+                "photograph": null
+            }
+        ],
         "baggage": {
-            "numberOfCheckedBags": null,
-            "weight": null,
-            "tags": ""
+            "numberOfCheckedBags": 1,
+            "weight": "23kg",
+            "tags": "739238"
         },
         "goods": null,
         "account": null,
@@ -97,12 +144,14 @@
     "risks": {
         "targetingIndicators": [],
         "selector": {
-            "category": "C",
-            "groupReference": null,
+            "category": "A",
+            "groupReference": "SR-216",
             "warning": {
                 "status": "NO",
-                "types": [],
-                "detail": null
+                "types": [
+                    "SELF_HARM"
+                ],
+                "detail": "Warning details would be shown here"
             }
         }
     },
@@ -145,32 +194,33 @@
         "telephone": "01589 654785 Example"
     },
     "eventPort": {
-        "id": 113461,
-        "name": "2 Marsham Street"
+        "id": 8217,
+        "name": "135 Dunganno Road"
     },
     "teamToReceiveTheTarget": {
-        "id": "2c646f45-0bb8-4f8a-b3d7-a46b36dec3e2",
-        "name": "GP6R02K8",
-        "code": "GP6R02K8",
+        "id": "c08c7de3-7238-4b3c-823d-eedcae8d1f80",
+        "name": "AP1T01P1",
+        "code": "AP1T01P1",
         "keycloakid": null,
-        "keycloakgrouppath": "/GP6R02K8",
-        "displayname": "Dover Frontline",
-        "grouptypeid": 5,
+        "keycloakgrouppath": "/AP1T01P1",
+        "displayname": "Aberdeen Airport Frontline",
+        "grouptypeid": 6,
         "teamid": null,
-        "branchid": 18,
-        "locationid": 28,
+        "branchid": 22,
+        "locationid": 0,
         "selfmanaged": true,
-        "validfrom": "2021-11-20T00:00:01Z",
+        "validfrom": "2022-05-27T00:00:01Z",
         "validto": null,
-        "updatedby": "Someswar Duddi"
+        "updatedby": "Cerberus Team"
     },
     "informFreightAndTourist": false,
+    "publicInterestImmunity": false,
     "form": {
-        "formVersionId": "6124a7b4-d527-41ac-b7b1-f0c14beed458",
-        "formId": "59ae1bdd-f2a5-475a-ad5f-4b5cd4cd0a95",
-        "title": "Target Information Sheet",
-        "name": "targetInformationSheet",
-        "submissionDate": "2022-03-01T13:01:56.010Z",
-        "submittedBy": "joe.bloggs@homeoffice.gov.uk"
+        "formVersionId": "1.1.1",
+        "formId": "cerberus-airpax-target-information-sheet",
+        "title": "Target Information Sheet (AirPax)",
+        "name": "cerberus-airpax-target-information-sheet",
+        "submissionDate": "2022-07-14T12:48:10.799Z",
+        "submittedBy": "acceptance-cerberus-user@system.local"
     }
 }

--- a/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
@@ -64,6 +64,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
       let passengerName = task.data.movement.persons[1].person.familyName;
+      const passengerRegex = new RegExp(passengerName, 'i');
       cy.createTargetingApiTask(task).then((taskResponse) => {
         cy.wait(3000);
         console.log(taskResponse);
@@ -74,7 +75,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
         cy.wait('@pages').then(({ response }) => {
           expect(response.statusCode).to.equal(200);
         });
-        cy.get('.govuk-task-list-card').contains(passengerName.toUpperCase());
+        cy.get('.govuk-task-list-card').contains(passengerRegex);
       });
     });
   });
@@ -86,6 +87,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
       let passengerName = task.data.movement.persons[1].person.familyName;
       const partialPassengerName = passengerName.split(' ');
+      const passengerRegex = new RegExp(partialPassengerName[0], 'i');
       cy.createTargetingApiTask(task).then((taskResponse) => {
         cy.wait(3000);
         console.log(taskResponse);
@@ -96,7 +98,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
         cy.wait('@pages').then(({ response }) => {
           expect(response.statusCode).to.equal(200);
         });
-        cy.get('.govuk-task-list-card').contains(partialPassengerName[0].toUpperCase());
+        cy.get('.govuk-task-list-card').contains(passengerRegex);
       });
     });
   });

--- a/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
@@ -1,5 +1,4 @@
 describe('Filter airpax tasks by TaskId or Passenger name', () => {
-
   beforeEach(() => {
     cy.login(Cypress.env('userName'));
     cy.acceptPNRTerms();
@@ -10,9 +9,9 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
       task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createTargetingApiTask(task).then((response) => {
+      cy.createTargetingApiTask(task).then((taskResponse) => {
         cy.wait(3000);
-        let businessKey = response.id;
+        let businessKey = taskResponse.id;
         cy.visit('/airpax/tasks');
         cy.get('.govuk-input').should('be.visible').type(businessKey);
         cy.contains('Apply').click();
@@ -23,7 +22,6 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
       });
     });
   });
-
 
   after(() => {
     cy.contains('Sign out').click();

--- a/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
@@ -13,6 +13,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
         cy.wait(3000);
         let businessKey = taskResponse.id;
         cy.visit('/airpax/tasks');
+        cy.wait(2000);
         cy.get('.govuk-input').should('be.visible').type(businessKey);
         cy.contains('Apply').click();
         cy.wait('@pages').then(({ response }) => {
@@ -22,6 +23,96 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
       });
     });
   });
+
+  it('Should be able to filter by partial taskID', () => {
+    cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createTargetingApiTask(task).then((taskResponse) => {
+        cy.wait(3000);
+        let businessKey = taskResponse.id;
+        const split = businessKey.split('-');
+        let partialBusinessKey = (split[0] + '-' + split[1]);
+        cy.visit('/airpax/tasks');
+        cy.wait(2000);
+        cy.get('.govuk-input').should('be.visible').type(partialBusinessKey);
+        cy.contains('Apply').click();
+        cy.wait('@pages').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+        cy.get('.govuk-task-list-card').contains(partialBusinessKey);
+      });
+    });
+   });
+  
+  it('Should not be able to filter by taskID that does not exist ', () => {
+    cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
+    cy.visit('/airpax/tasks');
+    cy.wait(2000);
+      cy.get('.govuk-input').should('be.visible').type('DEV-22000629-1273');
+      cy.contains('Apply').click();
+      cy.wait('@pages').then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
+    cy.get('.govuk-task-list-card').should('not.exist');
+   });
+  
+    it('Should be able to filter by valid passenger name ', () => {
+    cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      let passengerName = task.data.movement.persons[1].person.familyName;
+      cy.createTargetingApiTask(task).then((taskResponse) => {
+        cy.wait(3000);
+        console.log(taskResponse);
+        cy.visit('/airpax/tasks');
+        cy.wait(2000);
+        cy.get('.govuk-input').should('be.visible').type(passengerName);
+        cy.contains('Apply').click();
+        cy.wait('@pages').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+        cy.get('.govuk-task-list-card').contains(passengerName.toUpperCase());
+      });
+    });
+    });
+  
+   it('Should be able to filter by valid partial passenger name ', () => {
+    cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      let passengerName = task.data.movement.persons[1].person.familyName;
+      const partialPassengerName = passengerName.split(' ');
+      cy.createTargetingApiTask(task).then((taskResponse) => {
+        cy.wait(3000);
+        console.log(taskResponse);
+        cy.visit('/airpax/tasks');
+        cy.wait(2000);
+        cy.get('.govuk-input').should('be.visible').type(partialPassengerName[0]);
+        cy.contains('Apply').click();
+        cy.wait('@pages').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+        cy.get('.govuk-task-list-card').contains(partialPassengerName[0].toUpperCase());
+      });
+    });
+   });
+  
+  it('Should not be able to filter by passenger name that does not exist ', () => {
+    cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
+    cy.visit('/airpax/tasks');
+    cy.wait(2000);
+      cy.get('.govuk-input').should('be.visible').type('AutomationTester NotExist');
+      cy.contains('Apply').click();
+      cy.wait('@pages').then(({ response }) => {
+          xpect(response.statusCode).to.equal(200);
+      });
+    cy.get('.govuk-task-list-card').should('not.exist');
+   });
+
 
   after(() => {
     cy.contains('Sign out').click();

--- a/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
@@ -33,7 +33,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
         cy.wait(3000);
         let businessKey = taskResponse.id;
         const split = businessKey.split('-');
-        let partialBusinessKey = (split[0] + '-' + split[1]);
+        let partialBusinessKey = (split[1]);
         cy.visit('/airpax/tasks');
         cy.wait(2000);
         cy.get('.govuk-input').should('be.visible').type(partialBusinessKey);
@@ -41,24 +41,24 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
         cy.wait('@pages').then(({ response }) => {
           expect(response.statusCode).to.equal(200);
         });
-        cy.get('.govuk-task-list-card').contains(partialBusinessKey);
+        cy.get('.govuk-task-list-card').contains(businessKey);
       });
     });
-   });
+  });
   
-  it('Should not be able to filter by taskID that does not exist ', () => {
+  it('Should not be able to filter by taskID that does not exist', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     cy.visit('/airpax/tasks');
     cy.wait(2000);
-      cy.get('.govuk-input').should('be.visible').type('DEV-22000629-1273');
-      cy.contains('Apply').click();
-      cy.wait('@pages').then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
-      });
+    cy.get('.govuk-input').should('be.visible').type('DEV-22000629-1273');
+    cy.contains('Apply').click();
+    cy.wait('@pages').then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
     cy.get('.govuk-task-list-card').should('not.exist');
-   });
+  });
   
-    it('Should be able to filter by valid passenger name ', () => {
+  it('Should be able to filter by valid passenger name', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
@@ -77,9 +77,9 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
         cy.get('.govuk-task-list-card').contains(passengerName.toUpperCase());
       });
     });
-    });
+  });
   
-   it('Should be able to filter by valid partial passenger name ', () => {
+  it('Should be able to filter by valid partial passenger name', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
@@ -99,20 +99,19 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
         cy.get('.govuk-task-list-card').contains(partialPassengerName[0].toUpperCase());
       });
     });
-   });
+  });
   
-  it('Should not be able to filter by passenger name that does not exist ', () => {
+  it('Should not be able to filter by passenger name that does not exist', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     cy.visit('/airpax/tasks');
     cy.wait(2000);
-      cy.get('.govuk-input').should('be.visible').type('AutomationTester NotExist');
-      cy.contains('Apply').click();
-      cy.wait('@pages').then(({ response }) => {
-          xpect(response.statusCode).to.equal(200);
-      });
+    cy.get('.govuk-input').should('be.visible').type('AutomationTester NotExist');
+    cy.contains('Apply').click();
+    cy.wait('@pages').then(({ response }) => {
+      xpect(response.statusCode).to.equal(200);
+    });
     cy.get('.govuk-task-list-card').should('not.exist');
-   });
-
+  });
 
   after(() => {
     cy.contains('Sign out').click();

--- a/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
@@ -45,7 +45,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
       });
     });
   });
-  
+
   it('Should not be able to filter by taskID that does not exist', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     cy.visit('/airpax/tasks');
@@ -57,7 +57,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
     });
     cy.get('.govuk-task-list-card').should('not.exist');
   });
-  
+
   it('Should be able to filter by valid passenger name', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     const taskName = 'AIRPAX';
@@ -78,7 +78,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
       });
     });
   });
-  
+
   it('Should be able to filter by valid partial passenger name', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     const taskName = 'AIRPAX';
@@ -100,7 +100,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
       });
     });
   });
-  
+
   it('Should not be able to filter by passenger name that does not exist', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     cy.visit('/airpax/tasks');
@@ -108,7 +108,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
     cy.get('.govuk-input').should('be.visible').type('AutomationTester NotExist');
     cy.contains('Apply').click();
     cy.wait('@pages').then(({ response }) => {
-      xpect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(200);
     });
     cy.get('.govuk-task-list-card').should('not.exist');
   });

--- a/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
@@ -1,0 +1,32 @@
+describe('Filter airpax tasks by TaskId or Passenger name', () => {
+
+  beforeEach(() => {
+    cy.login(Cypress.env('userName'));
+    cy.acceptPNRTerms();
+  });
+
+  it('Should be able to filter by taskID', () => {
+    cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createTargetingApiTask(task).then((response) => {
+        cy.wait(3000);
+        let businessKey = response.id;
+        cy.visit('/airpax/tasks');
+        cy.get('.govuk-input').should('be.visible').type(businessKey);
+        cy.contains('Apply').click();
+        cy.wait('@pages').then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
+        cy.get('.govuk-task-list-card').should('have.length', '1').contains(businessKey);
+      });
+    });
+  });
+
+
+  after(() => {
+    cy.contains('Sign out').click();
+    cy.url().should('include', Cypress.env('auth_realm'));
+  });
+});

--- a/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-TaskId-or-Passenger.spec.js
@@ -50,7 +50,7 @@ describe('Filter airpax tasks by TaskId or Passenger name', () => {
     cy.intercept('POST', '/v2/targeting-tasks/pages').as('pages');
     cy.visit('/airpax/tasks');
     cy.wait(2000);
-    cy.get('.govuk-input').should('be.visible').type('DEV-22000629-1273');
+    cy.get('.govuk-input').should('be.visible').type('DEV-AIRPAX-30010629-1273');
     cy.contains('Apply').click();
     cy.wait('@pages').then(({ response }) => {
       expect(response.statusCode).to.equal(200);

--- a/cypress/integration/airpax/issue-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/issue-aipax-tasks.spec.js
@@ -142,7 +142,7 @@ describe('Create AirPax task and issue target', () => {
       'Nominal type is required',
       'System checks completed is required',
       'Select the team that should receive the target is required'];
-    
+
     let expectedErrorNames = [];
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {

--- a/cypress/integration/airpax/issue-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/issue-aipax-tasks.spec.js
@@ -90,11 +90,13 @@ describe('Create AirPax task and issue target', () => {
           cy.get('#eventPort').type(targetData.eventPort.name);
           cy.get('#eventPort__option--0').contains((targetData.eventPort.name)).click();
           cy.contains('Continue').click();
-          //Update Co-traveller details
-          cy.get('.govuk-summary-list__row').should('have.class', 'govuk-summary-list__title').next().contains('Given name').siblings('.govuk-summary-list__actions').within(() => {
-            cy.get('.govuk-link').contains('Change').click();
-            cy.wait(2000);
-          });
+          // Update Co-traveller details
+          cy.get('.govuk-summary-list__row').should('have.class', 'govuk-summary-list__title').next().contains('Given name')
+            .siblings('.govuk-summary-list__actions')
+            .within(() => {
+              cy.get('.govuk-link').contains('Change').click();
+              cy.wait(2000);
+            });
           cy.get('input[name="seatNumber"]').type('34B');
           cy.get('#bagCount').type('1');
           cy.get('#weight').type(targetData.movement.baggage.weight);
@@ -108,7 +110,7 @@ describe('Create AirPax task and issue target', () => {
           cy.get('#category').type(targetData.risks.selector.category);
           cy.contains('Continue').click();
 
-          //Add Nominal Details
+          // Add Nominal Details
           cy.clickChangeInTIS('Nominal type');
           cy.get('.hods-autocomplete__input').type(targetData.nominalChecks[0].type);
           cy.get('.hods-autocomplete__option').contains('Account').click();
@@ -116,14 +118,14 @@ describe('Create AirPax task and issue target', () => {
           cy.get('.hods-multi-select-autocomplete__menu').contains(targetData.nominalChecks[0].checks[0].name).click();
           cy.contains('Continue').click();
 
-          //Select team to receive target
+          // Select team to receive target
           cy.clickChangeInTIS('Select the team that should receive the target');
           cy.get('.hods-autocomplete__input').type(targetData.teamToReceiveTheTarget.displayname);
           cy.get('.hods-autocomplete__option').contains(targetData.teamToReceiveTheTarget.displayname).click();
           cy.contains('Continue').click();
           cy.contains('Accept and send').click();
           cy.contains('Finish').click();
-        })
+        });
       });
     });
   });

--- a/cypress/integration/airpax/issue-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/issue-aipax-tasks.spec.js
@@ -141,8 +141,8 @@ describe('Create AirPax task and issue target', () => {
       'Targeting indicators is required',
       'Nominal type is required',
       'System checks completed is required',
-      'Select the team that should receive the target is required'
-    ];
+      'Select the team that should receive the target is required'];
+    
     let expectedErrorNames = [];
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
@@ -163,7 +163,7 @@ describe('Create AirPax task and issue target', () => {
           }).then(() => {
             expect(expectedErrorNames).to.deep.equal(errorNames);
           });
-        })
+        });
       });
     });
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -407,6 +407,13 @@ Cypress.Commands.add('waitForNoErrors', () => {
   cy.get(formioErrorText).should('not.exist');
 });
 
+Cypress.Commands.add('clickChangeInTIS', (section) => {
+  cy.get('.govuk-summary-list__row').contains(section).siblings('.govuk-summary-list__actions').within(() => {
+          cy.get('.govuk-link').contains('Change').click({ force: true });
+  });
+  cy.wait(2000);
+});
+
 Cypress.Commands.add('typeValueInTextField', (elementName, value) => {
   cy.get(`${formioComponent}textfield${formioComponent}${elementName} input`)
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -409,7 +409,7 @@ Cypress.Commands.add('waitForNoErrors', () => {
 
 Cypress.Commands.add('clickChangeInTIS', (section) => {
   cy.get('.govuk-summary-list__row').contains(section).siblings('.govuk-summary-list__actions').within(() => {
-          cy.get('.govuk-link').contains('Change').click({ force: true });
+    cy.get('.govuk-link').contains('Change').click({ force: true });
   });
   cy.wait(2000);
 });


### PR DESCRIPTION
## Description
Add test for Submit target information sheet
https://support.cop.homeoffice.gov.uk/browse/COP-11198
## To Test
npm run cypress:test:local -- --spec cypress/integration/airpax/issue-airpax-tasks.spec.js

Should submit a target successfully from an AirPax task
## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
