### PR TITLE
COP-10787 - Hide notes form

### DIFF
--- a/src/cop-forms/completeTaskCerberus.js
+++ b/src/cop-forms/completeTaskCerberus.js
@@ -75,7 +75,7 @@ export default {
     {
       id: 'add-a-note',
       name: 'add-a-note',
-      title: 'Add a note?',
+      title: 'Add a note',
       hint: 'Add any additional information related to your request',
       components: [
         {

--- a/src/cop-forms/dismissTaskCerberus.js
+++ b/src/cop-forms/dismissTaskCerberus.js
@@ -78,7 +78,7 @@ export default {
         {
           id: 'addANote',
           fieldId: 'addANote',
-          label: 'Add a note?',
+          label: 'Add a note',
           hint: 'Add any additional information related to your request',
           type: 'textarea',
         },

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -258,7 +258,7 @@ const TaskDetailsPage = () => {
             && (
             <TaskNotes
               noteVariant={MOVEMENT_VARIANT.AIRPAX}
-              displayForm={assignee === currentUser}
+              displayForm={assignee === currentUser && !isCompleteFormOpen && !isDismissTaskFormOpen}
               businessKey={businessKey}
               setRefreshNotesForm={() => setRefreshNotesForm(!refreshNotesForm)}
             />

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -258,7 +258,8 @@ const TaskDetailsPage = () => {
             && (
             <TaskNotes
               noteVariant={MOVEMENT_VARIANT.AIRPAX}
-              displayForm={assignee === currentUser && !isCompleteFormOpen && !isDismissTaskFormOpen}
+              displayForm={assignee === currentUser
+                && !isIssueTargetFormOpen && !isCompleteFormOpen && !isDismissTaskFormOpen}
               businessKey={businessKey}
               setRefreshNotesForm={() => setRefreshNotesForm(!refreshNotesForm)}
             />

--- a/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
@@ -25,6 +25,11 @@ extendedRouterMock.useParams = jest.fn().mockReturnValue({ businessKey: 'BK-123'
 describe('Task details page', () => {
   const mockAxios = new MockAdapter(axios);
 
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => { });
+    mockAxios.reset();
+  });
+
   const mockAxiosCalls = (mockTaskPayload, mockIsPayload) => {
     mockAxios
       .onGet('/targeting-tasks/BK-123')
@@ -39,19 +44,16 @@ describe('Task details page', () => {
     </ApplicationContext.Provider>
   );
 
-  beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => { });
-    mockAxios.reset();
-  });
+  const renderPage = async () => render(
+    <MockApplicationContext>
+      <TaskDetailsPage />
+    </MockApplicationContext>,
+  );
 
   it('should render TaskDetailsPage component with a loading state', () => {
     mockAxiosCalls([], {});
 
-    render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    );
+    renderPage();
 
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });
@@ -59,11 +61,7 @@ describe('Task details page', () => {
   it('should display the business key', async () => {
     mockAxiosCalls(dataNoAssignee, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.getByText('BK-123')).toBeInTheDocument();
@@ -72,11 +70,7 @@ describe('Task details page', () => {
   it('should display the activity log', async () => {
     mockAxiosCalls(dataNoAssignee, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.getByText('Task activity')).toBeInTheDocument();
@@ -85,11 +79,7 @@ describe('Task details page', () => {
   it('should not render notes form when task not assigned', async () => {
     mockAxiosCalls(dataNoAssignee, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
@@ -98,11 +88,7 @@ describe('Task details page', () => {
   it('should not render notes form when task is assigned to someone other than the current user', async () => {
     mockAxiosCalls(dataOtherUser, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
@@ -111,11 +97,7 @@ describe('Task details page', () => {
   it('should render notes form when task is assigned to a current user', async () => {
     mockAxiosCalls(dataCurrentUser, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
@@ -124,11 +106,7 @@ describe('Task details page', () => {
   it('should render "Claim" button when the task assignee is null and the target has not been completed or issued', async () => {
     mockAxiosCalls(dataNoAssignee, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getByText('Task not assigned')).toBeInTheDocument();
     expect(screen.getByText('Claim')).toBeInTheDocument();
@@ -137,11 +115,7 @@ describe('Task details page', () => {
   it('should render "Unclaim" button when current user is assigned to the task and the target has not been completed or issued', async () => {
     mockAxiosCalls(dataCurrentUser, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getByText('Assigned to you')).toBeInTheDocument();
     expect(screen.getByText('Unclaim task')).toBeInTheDocument();
@@ -150,11 +124,7 @@ describe('Task details page', () => {
   it('should render "Assigned to ANOTHER_USER" & "unclaim" when task is assigned to another user and the process has not been completed or issued', async () => {
     mockAxiosCalls(dataOtherUser, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.getByText('Assigned to notcurrentuser')).toBeInTheDocument();
     expect(screen.getByText('Unclaim task')).toBeInTheDocument();
@@ -163,11 +133,7 @@ describe('Task details page', () => {
   it('should not render user or claim/unclaim buttons when a target is complete', async () => {
     mockAxiosCalls(dataTaskComplete, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.queryByText('Task not assigned')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to you')).not.toBeInTheDocument();
@@ -179,11 +145,7 @@ describe('Task details page', () => {
   it('should not render user or claim/unclaim buttons when a target is issued', async () => {
     mockAxiosCalls(dataTargetIssued, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.queryByText('Task not assigned')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to you')).not.toBeInTheDocument();
@@ -195,11 +157,7 @@ describe('Task details page', () => {
   it('should not show action buttons for unclaimed tasks', async () => {
     mockAxiosCalls(dataTargetIssued, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.queryByText('Issue target')).not.toBeInTheDocument();
     expect(screen.queryByText('Assessment complete')).not.toBeInTheDocument();
@@ -209,11 +167,7 @@ describe('Task details page', () => {
   it('should show action buttons for claimed tasks', async () => {
     mockAxiosCalls(dataClaimedTask, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.queryByText('Unclaim task')).toBeInTheDocument();
     expect(screen.queryByText('Dismiss')).toBeInTheDocument();
@@ -224,11 +178,7 @@ describe('Task details page', () => {
   it('should render a new label on a new and unclamied task', async () => {
     mockAxiosCalls(dataNoAssignee, {});
 
-    const { container } = await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    const { container } = await waitFor(() => renderPage());
 
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(1);
   });
@@ -236,11 +186,7 @@ describe('Task details page', () => {
   it('should not render a new label on a claimed task', async () => {
     mockAxiosCalls(dataClaimedTask, {});
 
-    const { container } = await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    const { container } = await waitFor(() => renderPage());
 
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(0);
   });
@@ -248,11 +194,7 @@ describe('Task details page', () => {
   it('should not render a new label on an issued task', async () => {
     mockAxiosCalls(dataTargetIssued, {});
 
-    const { container } = await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    const { container } = await waitFor(() => renderPage());
 
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(0);
   });
@@ -260,11 +202,7 @@ describe('Task details page', () => {
   it('should not render a new label on a complete task', async () => {
     mockAxiosCalls(dataTaskComplete, {});
 
-    const { container } = await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    const { container } = await waitFor(() => renderPage());
 
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(0);
   });
@@ -272,11 +210,7 @@ describe('Task details page', () => {
   it('should not show action buttons for task that has been dismissed', async () => {
     mockAxiosCalls(dataDismissedTask, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
     expect(screen.queryByText('Issue target')).not.toBeInTheDocument();
@@ -286,11 +220,7 @@ describe('Task details page', () => {
   it('should hide the notes form on clicking the assessment complete button', async () => {
     mockAxiosCalls(dataClaimedTask, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
 
@@ -303,16 +233,25 @@ describe('Task details page', () => {
   it('should hide the notes form on clicking the dismiss button', async () => {
     mockAxiosCalls(dataClaimedTask, {});
 
-    await waitFor(() => render(
-      <MockApplicationContext>
-        <TaskDetailsPage />
-      </MockApplicationContext>,
-    ));
+    await waitFor(() => renderPage());
 
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
 
     const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
     fireEvent.click(dismissButton);
+
+    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+  });
+
+  it('should hide the notes form on clicking the issue target button', async () => {
+    mockAxiosCalls(dataClaimedTask, {});
+
+    await waitFor(() => renderPage());
+
+    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+
+    const issueTargetButton = screen.getByRole('button', { name: 'Issue target' });
+    fireEvent.click(issueTargetButton);
 
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
   });

--- a/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
@@ -25,6 +25,14 @@ extendedRouterMock.useParams = jest.fn().mockReturnValue({ businessKey: 'BK-123'
 describe('Task details page', () => {
   const mockAxios = new MockAdapter(axios);
 
+  const mockAxiosCalls = (mockTaskPayload, mockIsPayload) => {
+    mockAxios
+      .onGet('/targeting-tasks/BK-123')
+      .reply(200, mockTaskPayload)
+      .onGet('/targeting-tasks/BK-123/information-sheets')
+      .reply(200, mockIsPayload);
+  };
+
   const MockApplicationContext = ({ children }) => (
     <ApplicationContext.Provider value={{ refDataAirlineCodes }}>
       {children}
@@ -37,160 +45,130 @@ describe('Task details page', () => {
   });
 
   it('should render TaskDetailsPage component with a loading state', () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, [])
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls([], {});
 
     render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     );
+
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });
 
   it('should display the business key', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataNoAssignee)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataNoAssignee, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.getByText('BK-123')).toBeInTheDocument();
   });
 
   it('should display the activity log', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataNoAssignee)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataNoAssignee, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.getByText('Task activity')).toBeInTheDocument();
   });
 
   it('should not render notes form when task not assigned', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataNoAssignee)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataNoAssignee, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
   });
 
   it('should not render notes form when task is assigned to someone other than the current user', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataOtherUser)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataOtherUser, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
   });
 
   it('should render notes form when task is assigned to a current user', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataCurrentUser)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataCurrentUser, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getAllByText('Overview')).toHaveLength(4);
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
   });
 
   it('should render "Claim" button when the task assignee is null and the target has not been completed or issued', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataNoAssignee)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataNoAssignee, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getByText('Task not assigned')).toBeInTheDocument();
     expect(screen.getByText('Claim')).toBeInTheDocument();
   });
 
   it('should render "Unclaim" button when current user is assigned to the task and the target has not been completed or issued', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataCurrentUser)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataCurrentUser, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getByText('Assigned to you')).toBeInTheDocument();
     expect(screen.getByText('Unclaim task')).toBeInTheDocument();
   });
 
   it('should render "Assigned to ANOTHER_USER" & "unclaim" when task is assigned to another user and the process has not been completed or issued', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataOtherUser)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataOtherUser, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.getByText('Assigned to notcurrentuser')).toBeInTheDocument();
     expect(screen.getByText('Unclaim task')).toBeInTheDocument();
   });
 
   it('should not render user or claim/unclaim buttons when a target is complete', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataTaskComplete)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataTaskComplete, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.queryByText('Task not assigned')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to you')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to notcurrentuser')).not.toBeInTheDocument();
@@ -199,17 +177,14 @@ describe('Task details page', () => {
   });
 
   it('should not render user or claim/unclaim buttons when a target is issued', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataTargetIssued)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataTargetIssued, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.queryByText('Task not assigned')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to you')).not.toBeInTheDocument();
     expect(screen.queryByText('Assigned to notcurrentuser')).not.toBeInTheDocument();
@@ -218,34 +193,28 @@ describe('Task details page', () => {
   });
 
   it('should not show action buttons for unclaimed tasks', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataTargetIssued)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataTargetIssued, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.queryByText('Issue target')).not.toBeInTheDocument();
     expect(screen.queryByText('Assessment complete')).not.toBeInTheDocument();
     expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
   });
 
   it('should show action buttons for claimed tasks', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataClaimedTask)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataClaimedTask, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.queryByText('Unclaim task')).toBeInTheDocument();
     expect(screen.queryByText('Dismiss')).toBeInTheDocument();
     expect(screen.queryByText('Issue target')).toBeInTheDocument();
@@ -253,79 +222,98 @@ describe('Task details page', () => {
   });
 
   it('should render a new label on a new and unclamied task', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataNoAssignee)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataNoAssignee, {});
 
     const { container } = await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(1);
   });
 
   it('should not render a new label on a claimed task', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataClaimedTask)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataClaimedTask, {});
 
     const { container } = await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(0);
   });
 
   it('should not render a new label on an issued task', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataTargetIssued)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataTargetIssued, {});
 
     const { container } = await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(0);
   });
 
   it('should not render a new label on a complete task', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataTaskComplete)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataTaskComplete, {});
 
     const { container } = await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(container.getElementsByClassName('govuk-tag--newTarget')).toHaveLength(0);
   });
 
   it('should not show action buttons for task that has been dismissed', async () => {
-    mockAxios
-      .onGet('/targeting-tasks/BK-123')
-      .reply(200, dataDismissedTask)
-      .onGet('/targeting-tasks/BK-123/information-sheets')
-      .reply(200, {});
+    mockAxiosCalls(dataDismissedTask, {});
 
     await waitFor(() => render(
       <MockApplicationContext>
         <TaskDetailsPage />
       </MockApplicationContext>,
     ));
+
     expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
     expect(screen.queryByText('Issue target')).not.toBeInTheDocument();
     expect(screen.queryByText('Assessment complete')).not.toBeInTheDocument();
+  });
+
+  it('should hide the notes form on clicking the assessment complete button', async () => {
+    mockAxiosCalls(dataClaimedTask, {});
+
+    await waitFor(() => render(
+      <MockApplicationContext>
+        <TaskDetailsPage />
+      </MockApplicationContext>,
+    ));
+
+    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+
+    const assessmentCompleteButton = screen.getByRole('button', { name: 'Assessment complete' });
+    fireEvent.click(assessmentCompleteButton);
+
+    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+  });
+
+  it('should hide the notes form on clicking the dismiss button', async () => {
+    mockAxiosCalls(dataClaimedTask, {});
+
+    await waitFor(() => render(
+      <MockApplicationContext>
+        <TaskDetailsPage />
+      </MockApplicationContext>,
+    ));
+
+    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    fireEvent.click(dismissButton);
+
+    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
   });
 });

--- a/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
@@ -420,7 +420,8 @@ const TaskDetailsPage = () => {
             <div className="govuk-grid-column-one-third">
               <TaskNotes
                 noteVariant={MOVEMENT_VARIANT.RORO}
-                displayForm={assignee === currentUser && !isCompleteFormOpen && !isDismissFormOpen}
+                displayForm={assignee === currentUser
+                  && !isIssueTargetFormOpen && !isCompleteFormOpen && !isDismissFormOpen}
                 businessKey={targetData.taskSummaryBasedOnTIS?.parentBusinessKey?.businessKey}
                 processInstanceId={processInstanceId}
                 refreshNotes={refreshNotesForm}

--- a/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
@@ -420,7 +420,7 @@ const TaskDetailsPage = () => {
             <div className="govuk-grid-column-one-third">
               <TaskNotes
                 noteVariant={MOVEMENT_VARIANT.RORO}
-                displayForm={assignee === currentUser}
+                displayForm={assignee === currentUser && !isCompleteFormOpen && !isDismissFormOpen}
                 businessKey={targetData.taskSummaryBasedOnTIS?.parentBusinessKey?.businessKey}
                 processInstanceId={processInstanceId}
                 refreshNotes={refreshNotesForm}

--- a/src/routes/roro/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/roro/__tests__/TaskDetailsPage.test.jsx
@@ -569,4 +569,31 @@ describe('TaskDetailsPage', () => {
 
     expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
   });
+
+  it('should hide the notes form on clicking the issue target button', async () => {
+    mockTaskDetailsAxiosCalls({
+      processInstanceResponse: [{ id: '123' }],
+      taskResponse: [{
+        processInstanceId: '123',
+        assignee: 'test',
+        id: 'task123',
+        taskDefinitionKey: 'developTarget',
+      }],
+      variableInstanceResponse: variableInstanceStatusNew,
+      operationsHistoryResponse: operationsHistoryFixture,
+      taskHistoryResponse: taskHistoryFixture,
+      noteFormResponse: noteFormFixure,
+      modecode: 'rorotour',
+      targetModeResponse: targetModeTourist,
+    });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+
+    const issueTargetButton = screen.getByRole('button', { name: 'Issue target' });
+    fireEvent.click(issueTargetButton);
+
+    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+  });
 });

--- a/src/routes/roro/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/roro/__tests__/TaskDetailsPage.test.jsx
@@ -515,4 +515,58 @@ describe('TaskDetailsPage', () => {
     expect(screen.queryByText('Add a new note')).toBeInTheDocument();
     expect(screen.queryByText('Assigned to you')).toBeInTheDocument();
   });
+
+  it('should hide the notes form on clicking the assessment complete button', async () => {
+    mockTaskDetailsAxiosCalls({
+      processInstanceResponse: [{ id: '123' }],
+      taskResponse: [{
+        processInstanceId: '123',
+        assignee: 'test',
+        id: 'task123',
+        taskDefinitionKey: 'developTarget',
+      }],
+      variableInstanceResponse: variableInstanceStatusNew,
+      operationsHistoryResponse: operationsHistoryFixture,
+      taskHistoryResponse: taskHistoryFixture,
+      noteFormResponse: noteFormFixure,
+      modecode: 'rorotour',
+      targetModeResponse: targetModeTourist,
+    });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+
+    const assessmentCompleteButton = screen.getByRole('button', { name: 'Assessment complete' });
+    fireEvent.click(assessmentCompleteButton);
+
+    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+  });
+
+  it('should hide the notes form on clicking the dismiss button', async () => {
+    mockTaskDetailsAxiosCalls({
+      processInstanceResponse: [{ id: '123' }],
+      taskResponse: [{
+        processInstanceId: '123',
+        assignee: 'test',
+        id: 'task123',
+        taskDefinitionKey: 'developTarget',
+      }],
+      variableInstanceResponse: variableInstanceStatusNew,
+      operationsHistoryResponse: operationsHistoryFixture,
+      taskHistoryResponse: taskHistoryFixture,
+      noteFormResponse: noteFormFixure,
+      modecode: 'rorotour',
+      targetModeResponse: targetModeTourist,
+    });
+
+    await waitFor(() => render(<TaskDetailsPage />));
+
+    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    fireEvent.click(dismissButton);
+
+    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Description
This PR hides the `Notes` form when the user clicks the `Issue target`, `Assessment complete` & `Dismiss` buttons (RoRo & AirPax).

### Supplemental
- Within the optional notes form which allows the user to enter additional notes, the `?` that was initially on the `Add a note?` label has been removed.


## To Test
- Pull & run against dev
- Click either `Issue target`, `Assessment complete` or `Dismiss task` button
- The notes form will be hidden.