### PR TITLE
COP-111346 - Document number (co-travellers table)

### DIFF
--- a/src/routes/airpax/TaskDetails/builder/CoTraveller.jsx
+++ b/src/routes/airpax/TaskDetails/builder/CoTraveller.jsx
@@ -32,6 +32,7 @@ const toDocumentColumnContent = (person) => {
   return (
     <>
       <div className="font__bold">{DocumentUtil.docType(document)}</div>
+      <div className="font__light">{DocumentUtil.docNumber(document)}</div>
       <div className="font__light">Issued by {DocumentUtil.docCountryCode(document)}</div>
     </>
   );

--- a/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
+++ b/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
@@ -1160,6 +1160,11 @@ exports[`TaskVersions should render task versions 1`] = `
                       <div
                         className="font__light"
                       >
+                        Unknown
+                      </div>
+                      <div
+                        className="font__light"
+                      >
                         Issued by 
                         Unknown
                       </div>
@@ -1231,6 +1236,11 @@ exports[`TaskVersions should render task versions 1`] = `
                       <div
                         className="font__light"
                       >
+                        Unknown
+                      </div>
+                      <div
+                        className="font__light"
+                      >
                         Issued by 
                         Unknown
                       </div>
@@ -1296,6 +1306,11 @@ exports[`TaskVersions should render task versions 1`] = `
                       </span>
                       <div
                         className="font__bold"
+                      >
+                        Unknown
+                      </div>
+                      <div
+                        className="font__light"
                       >
                         Unknown
                       </div>

--- a/src/routes/airpax/__tests__/builder/__snapshots__/CoTraveller.test.jsx.snap
+++ b/src/routes/airpax/__tests__/builder/__snapshots__/CoTraveller.test.jsx.snap
@@ -110,6 +110,11 @@ exports[`CoTraveller should render the co-traveller component 1`] = `
           <div
             className="font__light"
           >
+            Unknown
+          </div>
+          <div
+            className="font__light"
+          >
             Issued by 
             Unknown
           </div>
@@ -181,6 +186,11 @@ exports[`CoTraveller should render the co-traveller component 1`] = `
           <div
             className="font__light"
           >
+            Unknown
+          </div>
+          <div
+            className="font__light"
+          >
             Issued by 
             Unknown
           </div>
@@ -246,6 +256,11 @@ exports[`CoTraveller should render the co-traveller component 1`] = `
           </span>
           <div
             className="font__bold"
+          >
+            Unknown
+          </div>
+          <div
+            className="font__light"
           >
             Unknown
           </div>


### PR DESCRIPTION
## Description
This PR adds the document number within the co-travellers table.

## To Test
- Pull & run against dev
- Load any airpax task with co-travellers.
- Within the co-travellers table, if a co-traveller has a document number, it is now displayed (see screenshot below)

![image](https://user-images.githubusercontent.com/19333750/180455205-1cf2ee46-e25e-424b-acb9-ee31c89eb2a4.png)
