### PR TITLE
COP-11362 - Form data storage

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -8,17 +8,25 @@ import { Form, Formio } from 'react-formio';
 
 // Local imports
 import config from '../config';
-import { FORM_ACTIONS } from '../constants';
+import { FORM_ACTIONS, FORM_TIS_CACHE_STORE } from '../constants';
 import ErrorSummary from '../govuk/ErrorSummary';
 import useAxiosInstance from '../utils/axiosInstance';
 import FormUtils, { Renderers } from '../utils/Form';
 import { augmentRequest, interpolate } from '../utils/formioSupport';
 import { useKeycloak } from '../utils/keycloak';
 import LoadingSpinner from './LoadingSpinner';
+import { TargetInformationUtil } from '../routes/airpax/utils';
 
 Formio.use(gds);
 
-const RenderForm = ({ formName, form: _form, renderer: _renderer, onSubmit, onCancel, preFillData, children }) => {
+const RenderForm = ({ formName,
+  form: _form,
+  renderer: _renderer,
+  onSubmit,
+  onCancel,
+  preFillData,
+  cacheTisFormData,
+  children }) => {
   const [error, setError] = useState(null);
   const [form, setForm] = useState(_form);
   const [renderer, setRenderer] = useState(_renderer);
@@ -181,6 +189,10 @@ const RenderForm = ({ formName, form: _form, renderer: _renderer, onSubmit, onCa
                     return onCancel();
                   }
                   if (type === FORM_ACTIONS.NEXT) {
+                    if (cacheTisFormData) {
+                      TargetInformationUtil.cache.store(FORM_TIS_CACHE_STORE,
+                        TargetInformationUtil.convertToPrefill(payload));
+                    }
                     // Do nothing.
                     return onSuccess(payload);
                   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -86,6 +86,7 @@ export const RULES_FIELD_DESCRIPTION = {
 };
 
 export const BUSINESS_KEY_PATH = '/businessKey/generate';
+export const FORM_TIS_CACHE_STORE = 'form-tis-cache-store';
 export const FORM_NAMES = {
   NOTE_CERBERUS: 'noteCerberus',
   TARGET_INFORMATION_SHEET: 'targetInformationSheet',

--- a/src/routes/airpax/__tests__/utils/TargetInformationUtil.test.js
+++ b/src/routes/airpax/__tests__/utils/TargetInformationUtil.test.js
@@ -7,6 +7,7 @@ import tisSubmissionData from '../../__fixtures__/targetData_AirPax_SubmissionDa
 
 describe('Target Information Sheet', () => {
   let PREFILL_DATA = {};
+  const TEST_KEY = 'test-key';
 
   beforeEach(() => {
     PREFILL_DATA = {
@@ -101,5 +102,27 @@ describe('Target Information Sheet', () => {
     const prefillFormData = TargetInformationUtil.convertToPrefill(targetPrefillData);
 
     checkObjects(Object.keys(prefillFormData), EXPECTED_NODE_KEYS);
+  });
+
+  it('should store to local storage', () => {
+    const GIVEN = { alpha: 'alpha', bravo: 'bravo' };
+    TargetInformationUtil.cache.store(TEST_KEY, GIVEN);
+    expect(localStorage.getItem(TEST_KEY)).not.toBeNull();
+  });
+
+  it('should retrieve stored data', () => {
+    const GIVEN = { alpha: 'alpha', bravo: 'bravo' };
+    TargetInformationUtil.cache.store(TEST_KEY, GIVEN);
+    expect(TargetInformationUtil.cache.get(TEST_KEY)).toMatchObject(GIVEN);
+  });
+
+  it('should remove stored data', () => {
+    const GIVEN = { alpha: 'alpha', bravo: 'bravo' };
+    TargetInformationUtil.cache.store(TEST_KEY, GIVEN);
+
+    expect(TargetInformationUtil.cache.get(TEST_KEY)).toMatchObject(GIVEN);
+
+    TargetInformationUtil.cache.remove(TEST_KEY);
+    expect(localStorage.getItem(TEST_KEY)).toBeNull();
   });
 });

--- a/src/routes/airpax/utils/targetInformationUtil.js
+++ b/src/routes/airpax/utils/targetInformationUtil.js
@@ -6,6 +6,18 @@ import MovementUtil from './movementUtil';
 import PersonUtil from './personUtil';
 import RisksUtil from './risksUtil';
 
+const toLocalCache = (key, payload) => {
+  localStorage.setItem(key, JSON.stringify(payload));
+};
+
+const getLocalCache = (key) => {
+  return JSON.parse(localStorage.getItem(key));
+};
+
+const removeLocalCache = (key) => {
+  localStorage.removeItem(key);
+};
+
 const toPersonSubmissionNode = (person, index) => {
   if (person) {
     return {
@@ -362,6 +374,11 @@ const TargetInformationUtil = {
   prefillPayload: toTisPrefillPayload,
   submissionPayload: toTisSubmissionPayload,
   convertToPrefill: submissionToPrefillPayload,
+  cache: {
+    get: getLocalCache,
+    remove: removeLocalCache,
+    store: toLocalCache,
+  },
 };
 
 export default TargetInformationUtil;


### PR DESCRIPTION
## Description
This PR changes the logic at which stage the form data is temporarily stored to handle error events which can happen within the form renderer (including the consuming application), to avoid user loosing the data contained within the form (both auto population data and options selected by the user).

## To Test
- Pull & run against dev
- Claim a task
- Click on `Issue target`
- The form loaded will contain pre-population data, add more to the form by filling in more data.
- There are two ways to simulate an error within the form 
  - One way would be to wait at least  15+ minutes after filling out the mandatory fields
  - Another would be to fill out the mandatory fields and perform a page refresh.
- If you opt for the first option, on submitting the form, an error will be thrown however, observe that the form data has not been reset.
- If you opt for the second option, on page refresh, click on `Issue target` and observe that the form data has not been reset.
