### PR TITLE
COP-11392 - Targeting indicators bug

### DIFF
--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -15,8 +15,6 @@ from '../../../constants';
 
 import { ApplicationContext } from '../../../context/ApplicationContext';
 
-import { ApplicationContext } from '../../../context/ApplicationContext';
-
 // Utils
 import useAxiosInstance from '../../../utils/axiosInstance';
 import { useKeycloak } from '../../../utils/keycloak';

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -11,6 +11,8 @@ import { TASK_STATUS_NEW,
   MOVEMENT_VARIANT,
   FORM_NAMES } from '../../../constants';
 
+import { ApplicationContext } from '../../../context/ApplicationContext';
+
 // Utils
 import useAxiosInstance from '../../../utils/axiosInstance';
 import { useKeycloak } from '../../../utils/keycloak';
@@ -36,7 +38,6 @@ import '../__assets__/TaskDetailsPage.scss';
 // JSON
 import dismissTask from '../../../cop-forms/dismissTaskCerberus';
 import completeTask from '../../../cop-forms/completeTaskCerberus';
-import { ApplicationContext } from '../../../context/ApplicationContext';
 
 const TaskDetailsPage = () => {
   const { businessKey } = useParams();

--- a/src/routes/airpax/__fixtures__/targetData_AirPax_PrefillData.json
+++ b/src/routes/airpax/__fixtures__/targetData_AirPax_PrefillData.json
@@ -1,170 +1,205 @@
 {
-    "id": "DEV-20220624-781",
-    "movement": {
-        "id": "AIRPAX_344179:CMID=TEST",
-        "mode": "AIR_PASSENGER",
-        "refDataMode": {
-            "id": 2,
-            "mode": "Scheduled Air Passenger",
-            "ien": true,
-            "ca": true,
-            "ct": true,
-            "modecode": "airpass",
-            "crossingtype": [
-                "air"
-            ],
-            "validfrom": "2021-05-28T00:01:01Z",
+  "id": "DEV-20220624-781",
+  "movement": {
+    "id": "AIRPAX_344179:CMID=TEST",
+    "mode": "AIR_PASSENGER",
+    "refDataMode": {
+      "id": 2,
+      "mode": "Scheduled Air Passenger",
+      "ien": true,
+      "ca": true,
+      "ct": true,
+      "modecode": "airpass",
+      "crossingtype": [
+        "air"
+      ],
+      "validfrom": "2021-05-28T00:01:01Z",
+      "validto": null,
+      "updatedby": "Mohammed Abdul Odud"
+    },
+    "vessel": null,
+    "vehicle": null,
+    "trailer": null,
+    "journey": {
+      "id": "BA0103",
+      "direction": null,
+      "route": "CDG - YYZ - YYC - LHR",
+      "arrival": {
+        "country": null,
+        "location": "YYC",
+        "time": "2022-06-23T11:03:47.440Z"
+      },
+      "departure": {
+        "country": null,
+        "location": "LHR",
+        "time": "2022-06-24T11:03:47.440Z"
+      }
+    },
+    "flight": {
+      "seatNumber": "34A"
+    },
+    "person": {
+      "id": "dab092daf6d33e8fd2bfe5e2bcff8750",
+      "name": {
+        "first": "Testing GivenName",
+        "last": "Testing FamilyName",
+        "full": "FamilyName GivenName"
+      },
+      "dateOfBirth": "1976-12-30T00:00:00Z",
+      "gender": {
+        "id": "F",
+        "name": "Female",
+        "validfrom": "2019-01-01T00:01:00Z",
+        "validto": null,
+        "updatedby": null
+      },
+      "document": {
+        "type": {
+          "id": 7,
+          "code": "P ",
+          "shortdescription": "Passport and Emergency Travel Document",
+          "longdescription": "Passport and Emergency Travel Document (ETD)",
+          "validfrom": "2019-01-01T00:01:00Z",
+          "validto": null,
+          "updatedby": null
+        },
+        "number": "119039375",
+        "expiry": "2023-04-26T00:00:00Z"
+      },
+      "nationality": {
+        "id": 15,
+        "nationality": "Australia",
+        "description": null,
+        "iso31661alpha3": "AUS",
+        "iso31661alpha2": "AU",
+        "visarequired": false,
+        "evwoptional": false,
+        "diplomaticexception": false,
+        "specialexception": false,
+        "countryid": 14,
+        "validfrom": "2019-01-01T00:01:00Z",
+        "validto": null,
+        "updatedby": null
+      },
+      "photograph": null
+    },
+    "otherPersons": [
+      {
+        "id": "dab092daf6d33e8fd2bfe5e2bcff8750",
+        "name": {
+          "first": "ZUES CARLO",
+          "last": "BATZ STOUP",
+          "full": "ZUES CARLO BATZ STOUP"
+        },
+        "dateOfBirth": "1976-12-10T00:00:00Z",
+        "gender": {
+          "id": "M",
+          "name": "Male",
+          "validfrom": "2019-01-01T00:01:00Z",
+          "validto": null,
+          "updatedby": null
+        },
+        "document": {
+          "type": {
+            "id": 7,
+            "code": "P ",
+            "shortdescription": "Passport and Emergency Travel Document",
+            "longdescription": "Passport and Emergency Travel Document (ETD)",
+            "validfrom": "2019-01-01T00:01:00Z",
             "validto": null,
-            "updatedby": "Mohammed Abdul Odud"
+            "updatedby": null
+          },
+          "number": "119039375",
+          "expiry": "2023-04-26T00:00:00Z"
         },
-        "vessel": null,
-        "vehicle": null,
-        "trailer": null,
-        "journey": {
-            "id": "BA0103",
-            "direction": null,
-            "route": "CDG - YYZ - YYC - LHR",
-            "arrival": {
-                "country": null,
-                "location": "YYC",
-                "time": "2022-06-23T11:03:47.440Z"
-            },
-            "departure": {
-                "country": null,
-                "location": "LHR",
-                "time": "2022-06-24T11:03:47.440Z"
-            }
+        "nationality": {
+          "id": 290,
+          "nationality": "British Citizen",
+          "description": null,
+          "iso31661alpha3": "GBR",
+          "iso31661alpha2": "GB",
+          "visarequired": false,
+          "evwoptional": false,
+          "diplomaticexception": false,
+          "specialexception": false,
+          "countryid": 0,
+          "validfrom": "2022-01-25T00:00:01Z",
+          "validto": null,
+          "updatedby": "Ben Milnes"
         },
-        "flight": {
-            "seatNumber": "34A"
-        },
-        "person": {
-            "id": "dab092daf6d33e8fd2bfe5e2bcff8750",
-            "name": {
-                "first": "Testing GivenName",
-                "last": "Testing FamilyName",
-                "full": "FamilyName GivenName"
-            },
-            "dateOfBirth": "1976-12-30T00:00:00Z",
-            "gender": {
-                "id": "F",
-                "name": "Female",
-                "validfrom": "2019-01-01T00:01:00Z",
-                "validto": null,
-                "updatedby": null
-            },
-            "document": {
-                "type": {
-                    "id": 7,
-                    "code": "P ",
-                    "shortdescription": "Passport and Emergency Travel Document",
-                    "longdescription": "Passport and Emergency Travel Document (ETD)",
-                    "validfrom": "2019-01-01T00:01:00Z",
-                    "validto": null,
-                    "updatedby": null
-                },
-                "number": "119039375",
-                "expiry": "2023-04-26T00:00:00Z"
-            },
-            "nationality": {
-                "id": 15,
-                "nationality": "Australia",
-                "description": null,
-                "iso31661alpha3": "AUS",
-                "iso31661alpha2": "AU",
-                "visarequired": false,
-                "evwoptional": false,
-                "diplomaticexception": false,
-                "specialexception": false,
-                "countryid": 14,
-                "validfrom": "2019-01-01T00:01:00Z",
-                "validto": null,
-                "updatedby": null
-            },
-            "photograph": null
-        },
-        "otherPersons": [
-            {
-                "id": "dab092daf6d33e8fd2bfe5e2bcff8750",
-                "name": {
-                    "first": "ZUES CARLO",
-                    "last": "BATZ STOUP",
-                    "full": "ZUES CARLO BATZ STOUP"
-                },
-                "dateOfBirth": "1976-12-10T00:00:00Z",
-                "gender": {
-                    "id": "M",
-                    "name": "Male",
-                    "validfrom": "2019-01-01T00:01:00Z",
-                    "validto": null,
-                    "updatedby": null
-                },
-                "document": {
-                    "type": {
-                        "id": 7,
-                        "code": "P ",
-                        "shortdescription": "Passport and Emergency Travel Document",
-                        "longdescription": "Passport and Emergency Travel Document (ETD)",
-                        "validfrom": "2019-01-01T00:01:00Z",
-                        "validto": null,
-                        "updatedby": null
-                    },
-                    "number": "119039375",
-                    "expiry": "2023-04-26T00:00:00Z"
-                },
-                "nationality": {
-                    "id": 290,
-                    "nationality": "British Citizen",
-                    "description": null,
-                    "iso31661alpha3": "GBR",
-                    "iso31661alpha2": "GB",
-                    "visarequired": false,
-                    "evwoptional": false,
-                    "diplomaticexception": false,
-                    "specialexception": false,
-                    "countryid": 0,
-                    "validfrom": "2022-01-25T00:00:01Z",
-                    "validto": null,
-                    "updatedby": "Ben Milnes"
-                },
-                "photograph": null
-            }
+        "photograph": null
+      }
+    ],
+    "baggage": {
+      "numberOfCheckedBags": 1,
+      "weight": "23kg",
+      "tags": "739238"
+    },
+    "goods": null,
+    "account": null,
+    "consignee": null,
+    "consignor": null,
+    "haulier": null
+  },
+  "risks": {
+    "targetingIndicators": [
+      {
+        "id": 36,
+        "vehicle": false,
+        "driver": false,
+        "person": true,
+        "haulier": false,
+        "trailer": false,
+        "movement": false,
+        "booking": false,
+        "organisation": false,
+        "score": 500,
+        "featurename": "INTELLIGENCE-RECEIVED-PASSENGER",
+        "userfacingtext": "Intelligence Received - Passenger",
+        "validfrom": "2021-10-18T00:00:01Z",
+        "validto": null,
+        "updatedby": "Pedro Curado"
+      },
+      {
+        "id": 46,
+        "vehicle": false,
+        "driver": false,
+        "person": true,
+        "haulier": false,
+        "trailer": false,
+        "movement": false,
+        "booking": false,
+        "organisation": false,
+        "score": 0,
+        "featurename": "PASSENGER-INFREQUENT-PORT-USE",
+        "userfacingtext": "Infrequent trips made through port (person)",
+        "validfrom": "2022-07-14T00:00:01Z",
+        "validto": null,
+        "updatedby": "Hitesh Patel"
+      }
+    ],
+    "selector": {
+      "category": "A",
+      "groupReference": "SR-218",
+      "warning": {
+        "status": "YES",
+        "types": [
+          "CONTAGION"
         ],
-        "baggage": {
-            "numberOfCheckedBags": 1,
-            "weight": "23kg",
-            "tags": "739238"
-        },
-        "goods": null,
-        "account": null,
-        "consignee": null,
-        "consignor": null,
-        "haulier": null
-    },
-    "risks": {
-        "targetingIndicators": [],
-        "selector": {
-            "category": "A",
-            "groupReference": "SR-218",
-            "warning": {
-                "status": "YES",
-                "types": [
-                    "CONTAGION"
-                ],
-                "detail": "Warning details would be shown here"
-            }
-        }
-    },
-    "operation": null,
-    "nominalChecks": [],
-    "controlStrategies": [],
-    "selectionReasoning": null,
-    "remarks": null,
-    "submittingUser": null,
-    "issuingHub": null,
-    "eventPort": null,
-    "teamToReceiveTheTarget": null,
-    "informFreightAndTourist": false,
-    "publicInterestImmunity": false,
-    "form": null
+        "detail": "Warning details would be shown here"
+      }
+    }
+  },
+  "operation": null,
+  "nominalChecks": [],
+  "controlStrategies": [],
+  "selectionReasoning": null,
+  "remarks": null,
+  "submittingUser": null,
+  "issuingHub": null,
+  "eventPort": null,
+  "teamToReceiveTheTarget": null,
+  "informFreightAndTourist": false,
+  "publicInterestImmunity": false,
+  "form": null
 }

--- a/src/routes/airpax/__tests__/utils/TargetInformationUtil.test.js
+++ b/src/routes/airpax/__tests__/utils/TargetInformationUtil.test.js
@@ -33,6 +33,17 @@ describe('Target Information Sheet', () => {
     checkObjects(Object.keys(prefillFormData), EXPECTED_NODE_KEYS);
   });
 
+  it('should varify that targeting indicators auto population data contains value & label', () => {
+    const EXPECTED_NODE_KEYS = [
+      'value',
+      'label',
+    ];
+
+    const prefillFormData = TargetInformationUtil.prefillPayload(PREFILL_DATA);
+
+    checkObjects(Object.keys(prefillFormData.targetingIndicators[0]), EXPECTED_NODE_KEYS);
+  });
+
   it('should generate prefill data when movement node is null', () => {
     PREFILL_DATA.movement = null;
     const EXPECTED_NODE_KEYS = [

--- a/src/routes/airpax/utils/targetInformationUtil.js
+++ b/src/routes/airpax/utils/targetInformationUtil.js
@@ -163,7 +163,13 @@ const toTargetingIndicatorsNode = (formData) => {
   const targetingIndicators = RisksUtil.getIndicators(risks);
   if (targetingIndicators?.length) {
     return {
-      targetingIndicators,
+      targetingIndicators: targetingIndicators.map((ti) => {
+        return {
+          ...ti,
+          value: ti.id,
+          label: ti.userfacingtext,
+        };
+      }),
     };
   }
 };


### PR DESCRIPTION
## Description
This PR addresses a bug shown in the screenshot below where the multi select would not be properly populated with values from RefData when attempting to modify the form data but it would appear as expected on the CYA screen.

![image](https://user-images.githubusercontent.com/19333750/180775652-78fc1495-62bd-4ac8-b329-68d8bb40dad5.png)


## To Test
- Pull & run against dev
- Load up this task (https://www.dev.cerberus.cop.homeoffice.gov.uk/airpax/tasks/DEV-20220725-399) and claim it.
- On the `Selection details` section of the form, click on the `Change` link next to the right of the `Targeting indicators` header.
- It should now take you back to the selection details and the multi select autocomplete should be properly populated.
![image](https://user-images.githubusercontent.com/19333750/180776232-3cb40d23-a1b2-46b6-ba1f-e6ea9f3bfbbe.png)
