### PR TITLE
COP-10789 - Hide Enrichment Count

### DIFF
--- a/src/routes/roro/TaskDetails/TaskVersionsMode/EnrichmentCount.jsx
+++ b/src/routes/roro/TaskDetails/TaskVersionsMode/EnrichmentCount.jsx
@@ -1,32 +1,35 @@
 import React from 'react';
+import { VisuallyHidden } from '@ukhomeoffice/cop-react-components';
 import numberWithCommas from '../../../../utils/numberWithCommas';
 
 const EnrichmentCount = ({ enrichmentCount }) => {
   return (
-    <div className="govuk-grid-row enrichment-counts">
-      <div className="labels">
-        <div className="govuk-grid-column-one-third">
-          <span className="font__light">Previous RoRo movements</span>
+    <VisuallyHidden>
+      <div className="govuk-grid-row enrichment-counts">
+        <div className="labels">
+          <div className="govuk-grid-column-one-third">
+            <span className="font__light">Previous RoRo movements</span>
+          </div>
+          <div className="govuk-grid-column-one-third">
+            <span className="font__light">Examinations</span>
+          </div>
+          <div className="govuk-grid-column-one-third">
+            <span className="font__light">Seizures</span>
+          </div>
         </div>
-        <div className="govuk-grid-column-one-third">
-          <span className="font__light">Examinations</span>
-        </div>
-        <div className="govuk-grid-column-one-third">
-          <span className="font__light">Seizures</span>
+        <div className="values">
+          <div className="govuk-grid-column-one-third">
+            <span className="font__bold">{numberWithCommas(enrichmentCount?.split('/')[0]) || '-' }</span>
+          </div>
+          <div className="govuk-grid-column-one-third">
+            <span className="font__bold">{numberWithCommas(enrichmentCount?.split('/')[1]) || '-' }</span>
+          </div>
+          <div className="govuk-grid-column-one-third">
+            <span className="font__bold">{numberWithCommas(enrichmentCount?.split('/')[2]) || '-' }</span>
+          </div>
         </div>
       </div>
-      <div className="values">
-        <div className="govuk-grid-column-one-third">
-          <span className="font__bold">{numberWithCommas(enrichmentCount?.split('/')[0]) || '-' }</span>
-        </div>
-        <div className="govuk-grid-column-one-third">
-          <span className="font__bold">{numberWithCommas(enrichmentCount?.split('/')[1]) || '-' }</span>
-        </div>
-        <div className="govuk-grid-column-one-third">
-          <span className="font__bold">{numberWithCommas(enrichmentCount?.split('/')[2]) || '-' }</span>
-        </div>
-      </div>
-    </div>
+    </VisuallyHidden>
   );
 };
 

--- a/src/routes/roro/TaskLists/EnrichmentCount.jsx
+++ b/src/routes/roro/TaskLists/EnrichmentCount.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { VisuallyHidden } from '@ukhomeoffice/cop-react-components';
 
 const hasPreviousSeizures = (enrichmentCounts) => {
   const seizure = enrichmentCounts?.split('/')[2];
@@ -9,7 +10,14 @@ const EnrichmentCount = ({ labelText, enrichmentCountText }) => {
   return (
     <h3 className="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-font-size-16 govuk-!-font-weight-regular">
       {labelText}
-      {enrichmentCountText && <span className={`govuk-!-margin-left-3 ${hasPreviousSeizures(enrichmentCountText) ? 'font--red' : ''}`}>({enrichmentCountText})</span>}
+      <VisuallyHidden>
+        {enrichmentCountText && (
+        <span className={`govuk-!-margin-left-3 ${hasPreviousSeizures(enrichmentCountText)
+          ? 'font--red' : ''}`}
+        >({enrichmentCountText})
+        </span>
+        )}
+      </VisuallyHidden>
     </h3>
   );
 };

--- a/src/routes/roro/TaskLists/TaskListMode.jsx
+++ b/src/routes/roro/TaskLists/TaskListMode.jsx
@@ -8,7 +8,7 @@ import * as constants from '../../../constants';
 import { calculateTimeDifference } from '../../../utils/DatetimeUtil';
 import formatGender from '../../../utils/genderFormatter';
 import { hasVehicleMake, hasVehicleModel, hasVehicle, hasTrailer, filterKnownPassengers } from '../../../utils/roroDataUtil';
-import EnrichmentCount from './TaskListEnrichmentCount';
+import EnrichmentCount from './EnrichmentCount';
 import { formatVoyageText } from '../../../utils/stringConversion';
 
 const getMovementModeTypeText = (movementModeIcon) => {

--- a/src/routes/roro/__tests__/TaskVersionsMode/__snapshots__/SectionRenderer.test.jsx.snap
+++ b/src/routes/roro/__tests__/TaskVersionsMode/__snapshots__/SectionRenderer.test.jsx.snap
@@ -424,72 +424,76 @@ exports[`SectionRenderer renderOccupantsSection should not render hidden fields 
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -614,72 +618,76 @@ exports[`SectionRenderer renderOccupantsSection should not render hidden fields 
         <div
           className="govuk-!-margin-bottom-4 bottom-border"
         >
-          <div
-            className="govuk-grid-row enrichment-counts"
+          <span
+            className="govuk-visually-hidden"
           >
             <div
-              className="labels"
+              className="govuk-grid-row enrichment-counts"
             >
               <div
-                className="govuk-grid-column-one-third"
+                className="labels"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Previous RoRo movements
-                </span>
+                  <span
+                    className="font__light"
+                  >
+                    Previous RoRo movements
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Examinations
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Seizures
+                  </span>
+                </div>
               </div>
               <div
-                className="govuk-grid-column-one-third"
+                className="values"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Examinations
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__light"
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Seizures
-                </span>
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
               </div>
             </div>
-            <div
-              className="values"
-            >
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-            </div>
-          </div>
+          </span>
           <div
             className="govuk-grid-row govuk-!-margin-bottom-2"
           >
@@ -788,72 +796,76 @@ exports[`SectionRenderer renderOccupantsSection should not render hidden fields 
         <div
           className="govuk-!-margin-bottom-4 bottom-border"
         >
-          <div
-            className="govuk-grid-row enrichment-counts"
+          <span
+            className="govuk-visually-hidden"
           >
             <div
-              className="labels"
+              className="govuk-grid-row enrichment-counts"
             >
               <div
-                className="govuk-grid-column-one-third"
+                className="labels"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Previous RoRo movements
-                </span>
+                  <span
+                    className="font__light"
+                  >
+                    Previous RoRo movements
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Examinations
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Seizures
+                  </span>
+                </div>
               </div>
               <div
-                className="govuk-grid-column-one-third"
+                className="values"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Examinations
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__light"
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Seizures
-                </span>
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
               </div>
             </div>
-            <div
-              className="values"
-            >
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-            </div>
-          </div>
+          </span>
           <div
             className="govuk-grid-row govuk-!-margin-bottom-2"
           >
@@ -971,72 +983,76 @@ exports[`SectionRenderer renderOccupantsSection should not show passenger headin
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -1152,72 +1168,76 @@ exports[`SectionRenderer renderOccupantsSection should render occupants when boo
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -1342,72 +1362,76 @@ exports[`SectionRenderer renderOccupantsSection should render occupants when boo
         <div
           className="govuk-!-margin-bottom-4 bottom-border"
         >
-          <div
-            className="govuk-grid-row enrichment-counts"
+          <span
+            className="govuk-visually-hidden"
           >
             <div
-              className="labels"
+              className="govuk-grid-row enrichment-counts"
             >
               <div
-                className="govuk-grid-column-one-third"
+                className="labels"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Previous RoRo movements
-                </span>
+                  <span
+                    className="font__light"
+                  >
+                    Previous RoRo movements
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Examinations
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Seizures
+                  </span>
+                </div>
               </div>
               <div
-                className="govuk-grid-column-one-third"
+                className="values"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Examinations
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__light"
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Seizures
-                </span>
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
               </div>
             </div>
-            <div
-              className="values"
-            >
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-            </div>
-          </div>
+          </span>
           <div
             className="govuk-grid-row govuk-!-margin-bottom-2"
           >
@@ -1531,72 +1555,76 @@ exports[`SectionRenderer renderOccupantsSection should return mulitple other pas
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -1721,72 +1749,76 @@ exports[`SectionRenderer renderOccupantsSection should return mulitple other pas
         <div
           className="govuk-!-margin-bottom-4 bottom-border"
         >
-          <div
-            className="govuk-grid-row enrichment-counts"
+          <span
+            className="govuk-visually-hidden"
           >
             <div
-              className="labels"
+              className="govuk-grid-row enrichment-counts"
             >
               <div
-                className="govuk-grid-column-one-third"
+                className="labels"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Previous RoRo movements
-                </span>
+                  <span
+                    className="font__light"
+                  >
+                    Previous RoRo movements
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Examinations
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Seizures
+                  </span>
+                </div>
               </div>
               <div
-                className="govuk-grid-column-one-third"
+                className="values"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Examinations
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__light"
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Seizures
-                </span>
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
               </div>
             </div>
-            <div
-              className="values"
-            >
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-            </div>
-          </div>
+          </span>
           <div
             className="govuk-grid-row govuk-!-margin-bottom-2"
           >
@@ -1895,72 +1927,76 @@ exports[`SectionRenderer renderOccupantsSection should return mulitple other pas
         <div
           className="govuk-!-margin-bottom-4 bottom-border"
         >
-          <div
-            className="govuk-grid-row enrichment-counts"
+          <span
+            className="govuk-visually-hidden"
           >
             <div
-              className="labels"
+              className="govuk-grid-row enrichment-counts"
             >
               <div
-                className="govuk-grid-column-one-third"
+                className="labels"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Previous RoRo movements
-                </span>
+                  <span
+                    className="font__light"
+                  >
+                    Previous RoRo movements
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Examinations
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Seizures
+                  </span>
+                </div>
               </div>
               <div
-                className="govuk-grid-column-one-third"
+                className="values"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Examinations
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__light"
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Seizures
-                </span>
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
               </div>
             </div>
-            <div
-              className="values"
-            >
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-            </div>
-          </div>
+          </span>
           <div
             className="govuk-grid-row govuk-!-margin-bottom-2"
           >
@@ -2078,72 +2114,76 @@ exports[`SectionRenderer renderOccupantsSection should return other passenger en
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -2268,72 +2308,76 @@ exports[`SectionRenderer renderOccupantsSection should return other passenger en
         <div
           className="govuk-!-margin-bottom-4 bottom-border"
         >
-          <div
-            className="govuk-grid-row enrichment-counts"
+          <span
+            className="govuk-visually-hidden"
           >
             <div
-              className="labels"
+              className="govuk-grid-row enrichment-counts"
             >
               <div
-                className="govuk-grid-column-one-third"
+                className="labels"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Previous RoRo movements
-                </span>
+                  <span
+                    className="font__light"
+                  >
+                    Previous RoRo movements
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Examinations
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Seizures
+                  </span>
+                </div>
               </div>
               <div
-                className="govuk-grid-column-one-third"
+                className="values"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Examinations
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__light"
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Seizures
-                </span>
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
               </div>
             </div>
-            <div
-              className="values"
-            >
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-            </div>
-          </div>
+          </span>
           <div
             className="govuk-grid-row govuk-!-margin-bottom-2"
           >
@@ -2457,72 +2501,76 @@ exports[`SectionRenderer renderOccupantsSection should return other passenger fi
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -2647,72 +2695,76 @@ exports[`SectionRenderer renderOccupantsSection should return other passenger fi
         <div
           className="govuk-!-margin-bottom-4 bottom-border"
         >
-          <div
-            className="govuk-grid-row enrichment-counts"
+          <span
+            className="govuk-visually-hidden"
           >
             <div
-              className="labels"
+              className="govuk-grid-row enrichment-counts"
             >
               <div
-                className="govuk-grid-column-one-third"
+                className="labels"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Previous RoRo movements
-                </span>
+                  <span
+                    className="font__light"
+                  >
+                    Previous RoRo movements
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Examinations
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__light"
+                  >
+                    Seizures
+                  </span>
+                </div>
               </div>
               <div
-                className="govuk-grid-column-one-third"
+                className="values"
               >
-                <span
-                  className="font__light"
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Examinations
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__light"
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
                 >
-                  Seizures
-                </span>
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  className="govuk-grid-column-one-third"
+                >
+                  <span
+                    className="font__bold"
+                  >
+                    -
+                  </span>
+                </div>
               </div>
             </div>
-            <div
-              className="values"
-            >
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-              <div
-                className="govuk-grid-column-one-third"
-              >
-                <span
-                  className="font__bold"
-                >
-                  -
-                </span>
-              </div>
-            </div>
-          </div>
+          </span>
           <div
             className="govuk-grid-row govuk-!-margin-bottom-2"
           >
@@ -2830,72 +2882,76 @@ exports[`SectionRenderer renderOccupantsSection should return second passenger e
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -3017,72 +3073,76 @@ exports[`SectionRenderer renderOccupantsSection should return second passenger f
     <div
       className="govuk-!-margin-bottom-4 bottom-border"
     >
-      <div
-        className="govuk-grid-row enrichment-counts"
+      <span
+        className="govuk-visually-hidden"
       >
         <div
-          className="labels"
+          className="govuk-grid-row enrichment-counts"
         >
           <div
-            className="govuk-grid-column-one-third"
+            className="labels"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Previous RoRo movements
-            </span>
+              <span
+                className="font__light"
+              >
+                Previous RoRo movements
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Examinations
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__light"
+              >
+                Seizures
+              </span>
+            </div>
           </div>
           <div
-            className="govuk-grid-column-one-third"
+            className="values"
           >
-            <span
-              className="font__light"
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Examinations
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__light"
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
             >
-              Seizures
-            </span>
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <span
+                className="font__bold"
+              >
+                -
+              </span>
+            </div>
           </div>
         </div>
-        <div
-          className="values"
-        >
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-          <div
-            className="govuk-grid-column-one-third"
-          >
-            <span
-              className="font__bold"
-            >
-              -
-            </span>
-          </div>
-        </div>
-      </div>
+      </span>
       <div
         className="govuk-grid-row govuk-!-margin-bottom-2"
       >
@@ -3199,72 +3259,76 @@ exports[`SectionRenderer renderPrimaryTraveller should only render traveller fie
   >
     Primary Traveller
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   >
@@ -3361,72 +3425,76 @@ exports[`SectionRenderer renderPrimaryTraveller should render primary traveller 
   >
     Primary Traveller
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   >
@@ -3469,72 +3537,76 @@ exports[`SectionRenderer renderPrimaryTraveller should render traveller and docu
   >
     Primary Traveller
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   >
@@ -3767,72 +3839,76 @@ exports[`SectionRenderer renderTrailerSection should not render hidden fields 1`
   >
     Trailer
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   />
@@ -3848,72 +3924,76 @@ exports[`SectionRenderer renderTrailerSection should render entity search link i
   >
     Trailer
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   >
@@ -3956,72 +4036,76 @@ exports[`SectionRenderer renderTrailerSection should return fields if not hidden
   >
     Trailer
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   >
@@ -4158,72 +4242,76 @@ exports[`SectionRenderer renderVehicleSection should not render hidden fields 1`
   >
     Vehicle
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   />
@@ -4239,72 +4327,76 @@ exports[`SectionRenderer renderVehicleSection should render entity search link i
   >
     Vehicle
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   >
@@ -4347,72 +4439,76 @@ exports[`SectionRenderer renderVehicleSection should return fields if not hidden
   >
     Vehicle
   </h3>
-  <div
-    className="govuk-grid-row enrichment-counts"
+  <span
+    className="govuk-visually-hidden"
   >
     <div
-      className="labels"
+      className="govuk-grid-row enrichment-counts"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="labels"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Previous RoRo movements
-        </span>
+          <span
+            className="font__light"
+          >
+            Previous RoRo movements
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Examinations
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__light"
+          >
+            Seizures
+          </span>
+        </div>
       </div>
       <div
-        className="govuk-grid-column-one-third"
+        className="values"
       >
-        <span
-          className="font__light"
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Examinations
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__light"
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
         >
-          Seizures
-        </span>
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="govuk-grid-column-one-third"
+        >
+          <span
+            className="font__bold"
+          >
+            -
+          </span>
+        </div>
       </div>
     </div>
-    <div
-      className="values"
-    >
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-      <div
-        className="govuk-grid-column-one-third"
-      >
-        <span
-          className="font__bold"
-        >
-          -
-        </span>
-      </div>
-    </div>
-  </div>
+  </span>
   <div
     className="govuk-task-details-grid-column"
   >


### PR DESCRIPTION
## Description
This PR hides the enrichment counts rendered on the task list page & task details page.

## To Test
- Pull & run against dev
- Go to the RoRo task list
- On the **task list** page, the enrichment counts (shown in the screenshot below) will not be rendered on each task list card
<img width="429" alt="image" src="https://user-images.githubusercontent.com/19333750/181117210-76afe69b-142a-4449-a91f-55f3818f5493.png">

- On the **task details** page, the enrichment headers including the counts (shown in the screenshot below) will not be rendered on screen e.g. 
<img width="352" alt="image" src="https://user-images.githubusercontent.com/19333750/181117595-cbd5b649-99d5-4387-9d86-532fdeb0104c.png">

