### PR TITLE
COP-11335: Add test for Port dropdown not showing all RoRo ports

### DIFF
--- a/cypress/integration/airpax/filter-airpax-tasks-by-selectors.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-selectors.spec.js
@@ -1,6 +1,3 @@
-/// <reference types="Cypress"/>
-/// <reference path="../support/index.d.ts" />
-
 describe('Filter airpax tasks by Selectors on task management Page', () => {
   const filterOptions = [
     'NOT_PRESENT',
@@ -211,6 +208,7 @@ describe('Filter airpax tasks by Selectors on task management Page', () => {
   });
 
   after(() => {
+    cy.deleteAutomationTestData();
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -725,7 +725,7 @@ Cypress.Commands.add('checkTaskSummary', (registrationNumber, bookingDateTime) =
 Cypress.Commands.add('deleteAutomationTestData', () => {
   let dateNowFormatted;
   if (Cypress.dayjs().day() === 1) {
-    dateNowFormatted = Cypress.dayjs().subtract(3, 'day').format('DD-MM-YYYY');
+    dateNowFormatted = Cypress.dayjs().subtract(1, 'day').format('DD-MM-YYYY');
   } else {
     dateNowFormatted = Cypress.dayjs().subtract(1, 'day').format('DD-MM-YYYY');
   }


### PR DESCRIPTION
## Description
Add test for Port dropdown not showing all RoRo ports
## To Test
npm run cypress:test:local -- --spec cypress/integration/cerberus/issue-a-target.spec.js
Should verify event ports are available in target information sheet
## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
