### PR TITLE
COP-11456 - Form data caching

### DIFF
--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -3,12 +3,14 @@ import FormRenderer, { Utils } from '@ukhomeoffice/cop-react-form-renderer';
 import { MultiSelectAutocomplete } from '@ukhomeoffice/cop-react-components';
 import gds from '@ukhomeoffice/formio-gds-template/lib';
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Form, Formio } from 'react-formio';
+
+import { ApplicationContext } from '../context/ApplicationContext';
 
 // Local imports
 import config from '../config';
-import { FORM_ACTIONS, FORM_TIS_CACHE_STORE } from '../constants';
+import { FORM_ACTIONS } from '../constants';
 import useAxiosInstance from '../utils/axiosInstance';
 import FormUtils, { Renderers } from '../utils/Form';
 import { augmentRequest, interpolate } from '../utils/formioSupport';
@@ -33,6 +35,7 @@ const RenderForm = ({ formName,
   const [formattedPreFillData, setFormattedPreFillData] = useState();
   const [submitted, setSubmitted] = useState(false);
   const keycloak = useKeycloak();
+  const { setAirPaxTisCache } = useContext(ApplicationContext);
   const formApiClient = useAxiosInstance(keycloak, config.formApiUrl);
   const uploadApiClient = useAxiosInstance(keycloak, config.fileUploadApiUrl);
 
@@ -183,8 +186,7 @@ const RenderForm = ({ formName,
             }
             if (type === FORM_ACTIONS.NEXT) {
               if (cacheTisFormData) {
-                TargetInformationUtil.cache.store(FORM_TIS_CACHE_STORE,
-                  TargetInformationUtil.convertToPrefill(payload));
+                setAirPaxTisCache(TargetInformationUtil.convertToPrefill(payload));
               }
               // Do nothing.
               return onSuccess(payload);

--- a/src/constants.js
+++ b/src/constants.js
@@ -86,7 +86,6 @@ export const RULES_FIELD_DESCRIPTION = {
 };
 
 export const BUSINESS_KEY_PATH = '/businessKey/generate';
-export const FORM_TIS_CACHE_STORE = 'form-tis-cache-store';
 export const FORM_NAMES = {
   NOTE_CERBERUS: 'noteCerberus',
   TARGET_INFORMATION_SHEET: 'targetInformationSheet',

--- a/src/context/ApplicationContext.jsx
+++ b/src/context/ApplicationContext.jsx
@@ -1,4 +1,4 @@
-import React, { useState, createContext } from 'react';
+import React, { createContext, useState } from 'react';
 
 const ApplicationContext = createContext({});
 
@@ -9,9 +9,16 @@ const ApplicationContext = createContext({});
 const ApplicationContextProvider = ({ children }) => {
   const [refDataAirlineCodes, setRefDataAirlineCodes] = useState([]);
   const [airPaxRefDataMode, setAirpaxRefDataMode] = useState({});
+  const [airPaxTisCache, setAirPaxTisCache] = useState({});
 
   return (
-    <ApplicationContext.Provider value={{ refDataAirlineCodes, setRefDataAirlineCodes, airPaxRefDataMode, setAirpaxRefDataMode }}>
+    <ApplicationContext.Provider value={{ refDataAirlineCodes,
+      setRefDataAirlineCodes,
+      airPaxRefDataMode,
+      setAirpaxRefDataMode,
+      airPaxTisCache,
+      setAirPaxTisCache }}
+    >
       {children}
     </ApplicationContext.Provider>
   );

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -208,8 +208,8 @@ const TaskDetailsPage = () => {
             onSubmit={
               async ({ data }) => {
                 try {
-                  const submissionPayload = TargetInformationUtil.submissionPayload(taskData, data, keycloak, airPaxRefDataMode);
-                  await apiClient.post('/targets', submissionPayload);
+                  await apiClient.post('/targets',
+                    TargetInformationUtil.submissionPayload(taskData, data, keycloak, airPaxRefDataMode));
                   data?.meta?.documents.forEach((document) => delete document.file);
                   setAirPaxTisCache({});
                   setSubmitted(true);

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -10,8 +10,7 @@ import { TASK_STATUS_NEW,
   TASK_STATUS_COMPLETED,
   TASK_STATUS_IN_PROGRESS,
   MOVEMENT_VARIANT,
-  FORM_NAMES,
-  FORM_TIS_CACHE_STORE }
+  FORM_NAMES }
 from '../../../constants';
 
 import { ApplicationContext } from '../../../context/ApplicationContext';
@@ -46,7 +45,7 @@ const TaskDetailsPage = () => {
   const { businessKey } = useParams();
   const keycloak = useKeycloak();
   const apiClient = useAxiosInstance(keycloak, config.taskApiUrl);
-  const { airPaxRefDataMode } = useContext(ApplicationContext);
+  const { airPaxRefDataMode, airPaxTisCache, setAirPaxTisCache } = useContext(ApplicationContext);
   const currentUser = keycloak.tokenParsed.email;
   const [error, setError] = useState(null);
   const [assignee, setAssignee] = useState();
@@ -84,15 +83,12 @@ const TaskDetailsPage = () => {
   const getPrefillData = async () => {
     let response;
     try {
-      const storedCache = TargetInformationUtil.cache.get(FORM_TIS_CACHE_STORE);
-      if (storedCache?.id !== businessKey) {
-        TargetInformationUtil.cache.remove(FORM_TIS_CACHE_STORE);
+      if (airPaxTisCache?.id !== businessKey) {
         response = await apiClient.get(`/targeting-tasks/${businessKey}/information-sheets`);
-        TargetInformationUtil.cache.store(FORM_TIS_CACHE_STORE,
-          TargetInformationUtil.prefillPayload(response.data));
+        setAirPaxTisCache(TargetInformationUtil.prefillPayload(response.data));
       }
     } catch (e) {
-      TargetInformationUtil.cache.remove(FORM_TIS_CACHE_STORE);
+      setAirPaxTisCache({});
     }
   };
 
@@ -208,18 +204,20 @@ const TaskDetailsPage = () => {
           <RenderForm
             cacheTisFormData
             formName={FORM_NAMES.AIRPAX_TARGET_INFORMATION_SHEET}
-            preFillData={TargetInformationUtil.cache.get(FORM_TIS_CACHE_STORE)}
+            preFillData={airPaxTisCache}
             onSubmit={
               async ({ data }) => {
                 try {
-                  await apiClient.post('/targets',
-                    TargetInformationUtil.submissionPayload(taskData, data, keycloak, airPaxRefDataMode));
-                  TargetInformationUtil.cache.remove(FORM_TIS_CACHE_STORE);
+                  const submissionPayload = TargetInformationUtil.submissionPayload(taskData, data, keycloak, airPaxRefDataMode);
+                  await apiClient.post('/targets', submissionPayload);
+                  data?.meta?.documents.forEach((document) => delete document.file);
+                  setAirPaxTisCache({});
                   setSubmitted(true);
                   if (error) {
                     setError(null);
                   }
                 } catch (e) {
+                  setAirPaxTisCache(TargetInformationUtil.convertToPrefill(data));
                   setError(e.response?.status === 404 ? "Task doesn't exist." : e.message);
                 }
               }

--- a/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
@@ -39,7 +39,7 @@ describe('Task details page', () => {
   };
 
   const MockApplicationContext = ({ children }) => (
-    <ApplicationContext.Provider value={{ refDataAirlineCodes }}>
+    <ApplicationContext.Provider value={{ refDataAirlineCodes, airPaxTisCache: {}, setAirPaxTisCache: jest.fn() }}>
       {children}
     </ApplicationContext.Provider>
   );

--- a/src/routes/airpax/__tests__/utils/TargetInformationUtil.test.js
+++ b/src/routes/airpax/__tests__/utils/TargetInformationUtil.test.js
@@ -7,7 +7,6 @@ import tisSubmissionData from '../../__fixtures__/targetData_AirPax_SubmissionDa
 
 describe('Target Information Sheet', () => {
   let PREFILL_DATA = {};
-  const TEST_KEY = 'test-key';
 
   beforeEach(() => {
     PREFILL_DATA = {
@@ -113,27 +112,5 @@ describe('Target Information Sheet', () => {
     const prefillFormData = TargetInformationUtil.convertToPrefill(targetPrefillData);
 
     checkObjects(Object.keys(prefillFormData), EXPECTED_NODE_KEYS);
-  });
-
-  it('should store to local storage', () => {
-    const GIVEN = { alpha: 'alpha', bravo: 'bravo' };
-    TargetInformationUtil.cache.store(TEST_KEY, GIVEN);
-    expect(localStorage.getItem(TEST_KEY)).not.toBeNull();
-  });
-
-  it('should retrieve stored data', () => {
-    const GIVEN = { alpha: 'alpha', bravo: 'bravo' };
-    TargetInformationUtil.cache.store(TEST_KEY, GIVEN);
-    expect(TargetInformationUtil.cache.get(TEST_KEY)).toMatchObject(GIVEN);
-  });
-
-  it('should remove stored data', () => {
-    const GIVEN = { alpha: 'alpha', bravo: 'bravo' };
-    TargetInformationUtil.cache.store(TEST_KEY, GIVEN);
-
-    expect(TargetInformationUtil.cache.get(TEST_KEY)).toMatchObject(GIVEN);
-
-    TargetInformationUtil.cache.remove(TEST_KEY);
-    expect(localStorage.getItem(TEST_KEY)).toBeNull();
   });
 });

--- a/src/routes/airpax/utils/targetInformationUtil.js
+++ b/src/routes/airpax/utils/targetInformationUtil.js
@@ -354,14 +354,13 @@ const addThumbUrl = (person) => {
   if (!person?.photograph?.photograph?.url || !person?.photograph?.photograph?.url?.startsWith('blob:')) {
     const file = person?.photograph?.photograph?.file;
     if (file) {
-      const thumbUrl = URL.createObjectURL(file);
       return {
         ...person,
         photograph: {
           ...person.photograph,
           photograph: {
             ...person.photograph.photograph,
-            url: thumbUrl,
+            url: URL.createObjectURL(file),
           },
         },
       };

--- a/src/utils/Form/uploadDocuments.js
+++ b/src/utils/Form/uploadDocuments.js
@@ -6,8 +6,7 @@ const uploadDocument = async (client, submissionData, document) => {
   const { data } = await client.post(submissionData.businessKey, formData);
   if (data) {
     document.url = data.url;
-    delete document.file;
-    Utils.Data.setDataItem(submissionData, document.field, { ...document, field: undefined });
+    Utils.Data.setDataItem(submissionData, document.field, { ...document });
   }
   return document;
 };


### PR DESCRIPTION
## Description
This PR changes how we are temporarily caching the prefill data from the form in the event of submission failure. 

Initially was being stored in local storage however `file` data (uploaded images) cannot be serialised hence the change to context.
