### PR TITLE
COP-11477 - onCancel action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6076,9 +6076,9 @@
       }
     },
     "@ukhomeoffice/cop-react-form-renderer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/cop-react-form-renderer/-/cop-react-form-renderer-3.12.0.tgz",
-      "integrity": "sha512-juBuu42/YbYSXL4AMoTzDUmecuWfp6UL9FikxkjjXHMRaqZbJCMGgrtHEpyp0R1B9dTQ/uhdxP3DD/7WU4y7JA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/cop-react-form-renderer/-/cop-react-form-renderer-3.13.0.tgz",
+      "integrity": "sha512-9yFDiqq7cyYv13BZvUKasK9lguJzjVdJEsznA0mR78k3IGDhWdj80DNuASZYclK1UmyNrILlnCMiUO+4KVXtfQ==",
       "requires": {
         "@ukhomeoffice/cop-react-components": "1.10.0",
         "axios": "^0.23.0",
@@ -6089,18 +6089,6 @@
         "webpack": "4.44.2"
       },
       "dependencies": {
-        "@ukhomeoffice/cop-react-components": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/@ukhomeoffice/cop-react-components/-/cop-react-components-1.10.0.tgz",
-          "integrity": "sha512-wQDZDA/TDRgTE4w9otIvIUqP0ZybHI7OAjHMhiZ99/p4fj3ktoLfTULj1GC0th1gpChZKg1aWg+q8szsSrEWEQ==",
-          "requires": {
-            "accessible-autocomplete": "2.0.3",
-            "govuk-frontend": "^3.13.0",
-            "html-react-parser": "^0.10.5",
-            "react-select": "^5.3.2",
-            "web-vitals": "^1.0.1"
-          }
-        },
         "@webassemblyjs/ast": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -6456,20 +6444,6 @@
           "optional": true,
           "requires": {
             "find-up": "^3.0.0"
-          }
-        },
-        "react-select": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.4.0.tgz",
-          "integrity": "sha512-CjE9RFLUvChd5SdlfG4vqxZd55AZJRrLrHzkQyTYeHlpOztqcgnyftYAolJ0SGsBev6zAs6qFrjm6KU3eo2hzg==",
-          "requires": {
-            "@babel/runtime": "^7.12.0",
-            "@emotion/cache": "^11.4.0",
-            "@emotion/react": "^11.8.1",
-            "@types/react-transition-group": "^4.4.0",
-            "memoize-one": "^5.0.0",
-            "prop-types": "^15.6.0",
-            "react-transition-group": "^4.3.0"
           }
         },
         "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/client-secrets-manager": "^3.37.0",
     "@nitro-land/airport-codes": "^1.0.4",
     "@ukhomeoffice/cop-react-components": "^1.10.0",
-    "@ukhomeoffice/cop-react-form-renderer": "^3.12.0",
+    "@ukhomeoffice/cop-react-form-renderer": "^3.13.0",
     "@ukhomeoffice/formio-gds-template": "^1.0.12",
     "axios": "^0.23.0",
     "browserlist": "^1.0.1",

--- a/src/components/RenderForm.jsx
+++ b/src/components/RenderForm.jsx
@@ -181,9 +181,6 @@ const RenderForm = ({ formName,
           onGetComponent,
           onRequest: (req) => FormUtils.formHooks.onRequest(req, keycloak.token),
           onSubmit: async (type, payload, onSuccess) => {
-            if (type === FORM_ACTIONS.CANCEL) {
-              return onCancel();
-            }
             if (type === FORM_ACTIONS.NEXT) {
               if (cacheTisFormData) {
                 setAirPaxTisCache(TargetInformationUtil.convertToPrefill(payload));
@@ -209,6 +206,7 @@ const RenderForm = ({ formName,
               setLoaderVisibility(false);
             }
           },
+          onCancel,
         }}
       />
       )}

--- a/src/components/__tests__/RenderForm.test.jsx
+++ b/src/components/__tests__/RenderForm.test.jsx
@@ -18,8 +18,8 @@ describe('RenderForm', () => {
 
   const ON_CANCEL_CALLS = [];
 
-  const ON_CANCEL = (action) => {
-    ON_CANCEL_CALLS.push(action);
+  const ON_CANCEL = () => {
+    ON_CANCEL_CALLS.push(undefined);
   };
 
   beforeEach(() => {

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -222,6 +222,7 @@ const TaskDetailsPage = () => {
                 }
               }
             }
+            onCancel={() => setIssueTargetFormOpen()}
             renderer={Renderers.REACT}
             setError={setError}
           />

--- a/src/routes/airpax/utils/targetInformationUtil.js
+++ b/src/routes/airpax/utils/targetInformationUtil.js
@@ -26,7 +26,11 @@ const addThumbUrl = (person) => {
 const toNorminalChecksSubmissionNode = (formData) => {
   return {
     nominalChecks: formData?.nominalChecks?.map((nominalCheck) => {
-      return nominalCheck;
+      return {
+        type: nominalCheck.nominalType.value,
+        checks: nominalCheck.systemsCheck,
+        comments: nominalCheck.comments,
+      };
     }) || [],
   };
 };


### PR DESCRIPTION
## Description
Code refactoring to pass a cancel action to the newly added onCancel hook within the form renderer.


### Supplemental
This PR also fixes the incorrectly generated `nominalChecks` node within the submission payload.