### PR TITLE
COP-11412: getting refreshed keycloak token after expiry

### DIFF
--- a/src/components/__tests__/RenderForm.test.jsx
+++ b/src/components/__tests__/RenderForm.test.jsx
@@ -37,7 +37,8 @@ describe('RenderForm', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    expect(ON_CANCEL_CALLS).toHaveLength(1);
+    expect(true).toBe(true);
+    // expect(ON_CANCEL_CALLS).toHaveLength(1);
   });
 
   it('should render the dismiss task form', () => {

--- a/src/components/__tests__/RenderForm.test.jsx
+++ b/src/components/__tests__/RenderForm.test.jsx
@@ -37,8 +37,7 @@ describe('RenderForm', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    expect(true).toBe(true);
-    // expect(ON_CANCEL_CALLS).toHaveLength(1);
+    expect(ON_CANCEL_CALLS).toHaveLength(1);
   });
 
   it('should render the dismiss task form', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,8 @@ const config = {
       onLoad: 'login-required',
       checkLoginIframe: false,
     },
+    minExpiryValidity: 30,
+    pollingInterval: 6000,
   },
   refdataApiUrl: process.env.REFDATA_API_URL,
   fileUploadApiUrl: process.env.FILE_UPLOAD_SERVICE_URL,

--- a/src/routes/airpax/__tests__/TaskListPageFilters.test.jsx
+++ b/src/routes/airpax/__tests__/TaskListPageFilters.test.jsx
@@ -146,7 +146,7 @@ describe('TaskListFilters', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
-    expect(JSON.parse(mockAxios.history.post[6].data)).toMatchObject(EXPECTED_POST_PARAMS);
+    expect(JSON.parse(mockAxios.history.post[3].data)).toMatchObject(EXPECTED_POST_PARAMS);
   });
 
   it('should verify post param ruleIds array when options array id is 0', async () => {
@@ -168,6 +168,7 @@ describe('TaskListFilters', () => {
         taskStatuses: [
           'NEW',
         ],
+        searchText: null,
       },
       sortParams: [
         {
@@ -191,6 +192,6 @@ describe('TaskListFilters', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
-    expect(JSON.parse(mockAxios.history.post[6].data)).toMatchObject(EXPECTED_POST_PARAMS);
+    expect(JSON.parse(mockAxios.history.post[3].data)).toMatchObject(EXPECTED_POST_PARAMS);
   });
 });

--- a/src/routes/roro/TaskLists/TasksTab.jsx
+++ b/src/routes/roro/TaskLists/TasksTab.jsx
@@ -100,6 +100,7 @@ const TasksTab = ({
           },
         });
         if (!isMounted.current) return null;
+        setError(null);
         setTargetTasks(tasks.data);
       } catch (e) {
         if (!isMounted.current) return null;

--- a/src/utils/__tests__/axiosInstance.test.js
+++ b/src/utils/__tests__/axiosInstance.test.js
@@ -5,6 +5,11 @@ import useAxiosInstance from '../axiosInstance';
 
 describe('axios hooks', () => {
   const mockAxios = new MockAdapter(axios);
+
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
   test('can perform a API call', async () => {
     mockAxios.onGet('/api/data').reply(200, [{ id: 'test' }]);
     const axiosInstance = renderHook(() => useAxiosInstance());
@@ -12,5 +17,13 @@ describe('axios hooks', () => {
     const result = await axiosInstance.result.current.get('/api/data');
     expect(result.status).toBe(200);
     expect(result.data.length).toBe(1);
+  });
+
+  test('should have an access Bearer token for API calls', async () => {
+    const keycloak = { token: 'test-token' };
+    mockAxios.onGet('/api/data').reply(200, [{ id: 'test' }]);
+    const axiosInstance = renderHook(() => useAxiosInstance(keycloak));
+    await axiosInstance.result.current.get('/api/data');
+    expect(mockAxios.history.get[0].headers.Authorization).toEqual(`Bearer ${keycloak.token}`);
   });
 });

--- a/src/utils/axiosInstance.js
+++ b/src/utils/axiosInstance.js
@@ -1,10 +1,19 @@
 import axios from 'axios';
 
-const useAxiosInstance = (keycloak, baseURL = '/') => axios.create({
-  baseURL,
-  headers: {
-    Authorization: keycloak ? `Bearer ${keycloak.token}` : undefined,
-  },
-});
+const useAxiosInstance = (keycloak, baseURL = '/') => {
+  const axiosInstance = axios.create({
+    baseURL,
+    headers: {
+      Authorization: keycloak ? `Bearer ${keycloak.token}` : undefined,
+    },
+  });
+
+  axiosInstance.interceptors.request.use((config) => {
+    config.headers.Authorization = `Bearer ${keycloak?.token}`;
+    return config;
+  });
+
+  return axiosInstance;
+};
 
 export default useAxiosInstance;

--- a/src/utils/axiosInstance.js
+++ b/src/utils/axiosInstance.js
@@ -8,6 +8,7 @@ const useAxiosInstance = (keycloak, baseURL = '/') => {
     },
   });
 
+  // This interceptor would get the new keycloak token after it expires
   axiosInstance.interceptors.request.use((config) => {
     config.headers.Authorization = `Bearer ${keycloak?.token}`;
     return config;

--- a/src/utils/keycloak.jsx
+++ b/src/utils/keycloak.jsx
@@ -10,28 +10,34 @@ const KeycloakContext = createContext();
 
 const KeycloakProvider = ({ children }) => {
   const [keycloak, setKeycloak] = useState(null);
-  const [timeToExpire, setTimeToExpire] = useState(null);
-
+  const [refreshToken, setRefreshToken] = useState(false);
   const keycloakInstance = Keycloak(config.keycloak.clientConfig);
 
   useInterval(() => {
-    keycloak
-      .updateToken()
-      .catch(() => {
-        keycloak.logout();
-      });
-  }, keycloak ? timeToExpire : null);
+    /**
+    * isTokenExpired(minValidity)
+    * Returns true if the token has less than minValidity seconds left before
+    * it expires (minValidity is optional, if not specified 0 is used)
+    */
+    if (keycloak.isTokenExpired(config.keycloak.minExpiryValidity)) {
+      setRefreshToken(!refreshToken);
+    }
+  }, config.keycloak.pollingInterval);
+
+  useEffect(() => {
+    if (keycloak) {
+      keycloak
+        .updateToken()
+        .catch(() => {
+          keycloak.logout();
+        });
+    }
+  }, [refreshToken]);
 
   useEffect(() => {
     keycloakInstance.init(config.keycloak.initOptions).then((authenticated) => {
       if (authenticated) {
         setKeycloak(keycloakInstance);
-        /*
-         * Multiplies the unix timestamp (keycloackInstance.tokenParsed.exp) in the token by 1000 milliseconds
-         * e.g: new Date(795601416 * 1000) and subtract it from the current date
-         * timeToExpire then equals the difference between the 2 dates in milliseconds
-        */
-        setTimeToExpire(new Date(keycloakInstance.tokenParsed.exp * 1000) - new Date());
       } else {
         keycloakInstance.login();
       }


### PR DESCRIPTION
## Description
Pull & run against dev.

## To Test
## Task List Page

1. Load the task list page and monitor the Network tab
2. Don't do anything on task list page for 15 minutes
3. The new token would be fetched from keycloak and subsequent API calls would be using the refreshed token to get the data

## Task Details Page

1. Claim the task on task list page on Airpax mode
2. Click issue target to see cya page
3. Fill all required fields clicking on change link
4. Wait for token to be refreshed (15 minutes)
5. Click on Accept and send button to submit the TIS

## Developer Checklist

\* Required

- [*] Up-to-date with main branch? \*

- [*] Does it have tests?

- [*] Pull request URL linked to JIRA ticket? \*

- [*] All reviewer comments resolved/answered? \*
