### PR TITLE
Cop 11477: Added test for Code refactor in relation to the spike for form cancellation

### DIFF
--- a/cypress/fixtures/airpax/airpax-TIS-details.json
+++ b/cypress/fixtures/airpax/airpax-TIS-details.json
@@ -15,13 +15,7 @@
             "Route to UK": "CDG - YYZ - YYC - LHR"
         },
         {
-            "Inbound or Outbound": "Outbound"
-        },
-        {
-            "Estimated date of arrival": "10 July 2022"
-        },
-        {
-            "Estimated time of arrival": "15:30"
+            "Inbound or outbound": ""
         }
     ],
     "Passenger1Details": [

--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -712,6 +712,51 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
+  it('Should cancel issue target and return to task overview page', () => {
+    cy.acceptPNRTerms();
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createTargetingApiTask(task).then((response) => {
+        let businessKey = response.id;
+        cy.wait(3000);
+        cy.checkAirPaxTaskDisplayed(businessKey);
+        cy.get('.govuk-heading-l').should('not.exist');
+        cy.claimAirPaxTask();
+        cy.contains('Issue target').click();
+        cy.wait(2000);
+        cy.get('.govuk-heading-l').should('have.text', 'Target Information Sheet (AirPax)');
+        cy.contains('Cancel').click();
+        cy.wait(2000);
+        cy.get('.govuk-heading-l').should('not.exist');
+        cy.contains('Issue target').click();
+        cy.wait(2000);
+        cy.fixture('airpax/airpax-TIS-details.json').then((expectedDetails) => {
+          cy.contains('h2', 'Movement details').next().within((elements) => {
+            cy.getairPaxTISDetails(elements).then((actualMovementDetails) => {
+              expect(actualMovementDetails).to.deep.equal(expectedDetails.MovementDetails);
+            });
+          });
+          cy.contains('h2', 'Passenger 1 details').next().within((elements) => {
+            cy.getairPaxTISDetails(elements).then((actualMovementDetails) => {
+              expect(actualMovementDetails).to.deep.equal(expectedDetails.Passenger1Details);
+            });
+          });
+          cy.contains('h2', 'Warnings').next().within((elements) => {
+            cy.getairPaxTISDetails(elements).then((actualMovementDetails) => {
+              expect(actualMovementDetails).to.deep.equal(expectedDetails.Warnings);
+            });
+          });
+          cy.contains('h2', 'Selection details').next().within((elements) => {
+            cy.getairPaxTISDetails(elements).then((actualMovementDetails) => {
+              expect(actualMovementDetails).to.deep.equal(expectedDetails.SelectionDetails);
+            });
+          });
+        });
+      });
+    });
+  });
+
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));

--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -712,7 +712,7 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
-  it('Should cancel issue target and return to task overview page', () => {
+  it('Should cancel issue target successfully but still retail auto populated values in target information sheet', () => {
     cy.acceptPNRTerms();
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {

--- a/cypress/integration/airpax/airpax-task-details.spec.js
+++ b/cypress/integration/airpax/airpax-task-details.spec.js
@@ -712,7 +712,7 @@ describe('Verify AirPax task details of different sections', () => {
     });
   });
 
-  it('Should cancel issue target successfully but still retail auto populated values in target information sheet', () => {
+  it('Should cancel issue target successfully but still retain auto populated values in target information sheet', () => {
     cy.acceptPNRTerms();
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {

--- a/cypress/integration/airpax/issue-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/issue-aipax-tasks.spec.js
@@ -339,26 +339,6 @@ describe('Create AirPax task and issue target', () => {
     });
   });
 
-  it('Should cancel issue target and return to task overview page', () => {
-    const taskName = 'AIRPAX';
-    cy.fixture('airpax/task-airpax.json').then((task) => {
-      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
-      cy.createTargetingApiTask(task).then((response) => {
-        let businessKey = response.id;
-        cy.wait(3000);
-        cy.checkAirPaxTaskDisplayed(businessKey);
-        cy.get('.govuk-heading-l').should('not.exist');
-        cy.claimAirPaxTask();
-        cy.contains('Issue target').click();
-        cy.wait(2000);
-        cy.get('.govuk-heading-l').should('have.text', 'Target Information Sheet (AirPax)');
-        cy.contains('Cancel').click();
-        cy.wait(2000);
-        cy.get('.govuk-heading-l').should('not.exist');
-      });
-    });
-  });
-
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));

--- a/cypress/integration/airpax/issue-aipax-tasks.spec.js
+++ b/cypress/integration/airpax/issue-aipax-tasks.spec.js
@@ -339,6 +339,26 @@ describe('Create AirPax task and issue target', () => {
     });
   });
 
+  it('Should cancel issue target and return to task overview page', () => {
+    const taskName = 'AIRPAX';
+    cy.fixture('airpax/task-airpax.json').then((task) => {
+      task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+      cy.createTargetingApiTask(task).then((response) => {
+        let businessKey = response.id;
+        cy.wait(3000);
+        cy.checkAirPaxTaskDisplayed(businessKey);
+        cy.get('.govuk-heading-l').should('not.exist');
+        cy.claimAirPaxTask();
+        cy.contains('Issue target').click();
+        cy.wait(2000);
+        cy.get('.govuk-heading-l').should('have.text', 'Target Information Sheet (AirPax)');
+        cy.contains('Cancel').click();
+        cy.wait(2000);
+        cy.get('.govuk-heading-l').should('not.exist');
+      });
+    });
+  });
+
   after(() => {
     cy.contains('Sign out').click();
     cy.url().should('include', Cypress.env('auth_realm'));


### PR DESCRIPTION
 Added test for Code refactor in relation to the spike for form cancellation
## To Test
npm run cypress:test:local -- --spec cypress/integration/airpax/aipax-tasks-details.spec.js

Should cancel issue target successfully but still retail auto populated values in target information sheet
## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
