### PR TITLE
COP-11414: Made filters sticky on task management page

### DIFF
--- a/src/__assets__/_utilities.scss
+++ b/src/__assets__/_utilities.scss
@@ -1,15 +1,27 @@
 .align-right {
-    text-align: right;
+  text-align: right;
 }
 
 .inline-block {
-    display: inline-block;
+  display: inline-block;
 }
 
 .word-break {
-    overflow-wrap: break-word;  
+  overflow-wrap: break-word;  
 }
 
 .overflow-hidden {
-    overflow: hidden;
+  overflow: hidden;
+}
+
+.sticky {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .sticky {
+    position: relative;
+  }
 }

--- a/src/routes/airpax/TaskLists/TaskListPage.jsx
+++ b/src/routes/airpax/TaskLists/TaskListPage.jsx
@@ -205,7 +205,7 @@ const TaskListPage = () => {
         />
       )}
       <div className="govuk-grid-row">
-        <section className="govuk-grid-column-one-quarter">
+        <section className="govuk-grid-column-one-quarter sticky">
           <div className="cop-filters-container">
             <div className="cop-filters-header">
               <h2 className="govuk-heading-s">Filters</h2>

--- a/src/routes/roro/TaskLists/TaskListPage.jsx
+++ b/src/routes/roro/TaskLists/TaskListPage.jsx
@@ -311,7 +311,7 @@ const TaskListPage = () => {
 
       {!isLoading && authorisedGroup && (
         <div className="govuk-grid-row">
-          <section className="govuk-grid-column-one-quarter">
+          <section className="govuk-grid-column-one-quarter sticky">
             <div className="cop-filters-container">
               <div className="cop-filters-header">
                 <h2 className="govuk-heading-s">Filters</h2>


### PR DESCRIPTION
## Description
On Task Management Page

## To Test
The Filters(Mode & Selectors) on tasklist page would stick and always be visible to the user while scrolling

![image](https://user-images.githubusercontent.com/1534608/182856062-9f242a18-22d4-4821-a5a4-749d1cdcf26a.png)


## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
