### PR TITLE
COP-11453 - Hide action button

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -91,6 +91,9 @@ export const FORM_NAMES = {
   TARGET_INFORMATION_SHEET: 'targetInformationSheet',
   AIRPAX_TARGET_INFORMATION_SHEET: 'cerberus-airpax-target-information-sheet',
 };
+export const FORM_MESSAGES = {
+  ON_CANCELLATION: 'Are you sure you want to cancel?',
+};
 
 export const COMPONENT_TYPES = {
   TYPE_SELECT: 'select',

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -58,7 +58,7 @@ const TaskDetailsPage = () => {
   const [isDismissTaskFormOpen, setDismissTaskFormOpen] = useState();
   const [isIssueTargetFormOpen, setIssueTargetFormOpen] = useState();
   const [refreshNotesForm, setRefreshNotesForm] = useState(false);
-  const [showButtons, setShowButtons] = useState(true);
+  const [showActionButtons, setShowActionButtons] = useState(true);
 
   const clearAccordionStorage = () => {
     _.forIn(window.sessionStorage, (value, key) => {
@@ -174,7 +174,7 @@ const TaskDetailsPage = () => {
           {!isSubmitted && assignee === currentUser
           && formattedTaskStatus.toUpperCase() === TASK_STATUS_IN_PROGRESS.toUpperCase() && (
           <>
-            {showButtons && (
+            {showActionButtons && (
             <>
               <Button
                 className="govuk-!-margin-right-1"
@@ -182,7 +182,7 @@ const TaskDetailsPage = () => {
                   setIssueTargetFormOpen(true);
                   setDismissTaskFormOpen(false);
                   setCompleteFormOpen(false);
-                  setShowButtons(false);
+                  setShowActionButtons(false);
                 }}
               >
                 Issue target
@@ -193,7 +193,7 @@ const TaskDetailsPage = () => {
                   setCompleteFormOpen(true);
                   setDismissTaskFormOpen(false);
                   setIssueTargetFormOpen(false);
-                  setShowButtons(false);
+                  setShowActionButtons(false);
                 }}
               >
                 Assessment complete
@@ -204,7 +204,7 @@ const TaskDetailsPage = () => {
                   setDismissTaskFormOpen(true);
                   setCompleteFormOpen(false);
                   setIssueTargetFormOpen(false);
-                  setShowButtons(false);
+                  setShowActionButtons(false);
                 }}
               >
                 Dismiss
@@ -240,7 +240,7 @@ const TaskDetailsPage = () => {
               }
             }
             onCancel={() => onCancelConfirmation(() => {
-              setShowButtons(true);
+              setShowActionButtons(true);
               setIssueTargetFormOpen();
             })}
             renderer={Renderers.REACT}
@@ -269,7 +269,7 @@ const TaskDetailsPage = () => {
               }
             }
             onCancel={() => onCancelConfirmation(() => {
-              setShowButtons(true);
+              setShowActionButtons(true);
               setCompleteFormOpen();
             })}
             form={completeTask}
@@ -299,7 +299,7 @@ const TaskDetailsPage = () => {
                 }
               }
               onCancel={() => onCancelConfirmation(() => {
-                setShowButtons(true);
+                setShowActionButtons(true);
                 setDismissTaskFormOpen();
               })}
               form={dismissTask}

--- a/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/airpax/TaskDetails/TaskDetailsPage.jsx
@@ -9,7 +9,8 @@ import { TASK_STATUS_NEW,
   TASK_STATUS_TARGET_ISSUED,
   TASK_STATUS_COMPLETED,
   TASK_STATUS_IN_PROGRESS,
-  MOVEMENT_VARIANT }
+  MOVEMENT_VARIANT,
+  FORM_MESSAGES }
 from '../../../constants';
 
 import { ApplicationContext } from '../../../context/ApplicationContext';
@@ -57,6 +58,7 @@ const TaskDetailsPage = () => {
   const [isDismissTaskFormOpen, setDismissTaskFormOpen] = useState();
   const [isIssueTargetFormOpen, setIssueTargetFormOpen] = useState();
   const [refreshNotesForm, setRefreshNotesForm] = useState(false);
+  const [showButtons, setShowButtons] = useState(true);
 
   const clearAccordionStorage = () => {
     _.forIn(window.sessionStorage, (value, key) => {
@@ -124,6 +126,13 @@ const TaskDetailsPage = () => {
     getTaskData();
   }, [refreshNotesForm]);
 
+  const onCancelConfirmation = (onCancel) => {
+    // eslint-disable-next-line no-alert
+    if (confirm(FORM_MESSAGES.ON_CANCELLATION)) {
+      onCancel();
+    }
+  };
+
   if (isLoading) {
     return <LoadingSpinner><br /><br /><br /></LoadingSpinner>;
   }
@@ -162,38 +171,46 @@ const TaskDetailsPage = () => {
             )}
         </div>
         <div className="govuk-grid-column-one-half task-actions--buttons">
-          {!isSubmitted && assignee === currentUser && formattedTaskStatus.toUpperCase() === TASK_STATUS_IN_PROGRESS.toUpperCase() && (
+          {!isSubmitted && assignee === currentUser
+          && formattedTaskStatus.toUpperCase() === TASK_STATUS_IN_PROGRESS.toUpperCase() && (
           <>
-            <Button
-              className="govuk-!-margin-right-1"
-              onClick={() => {
-                setIssueTargetFormOpen(true);
-                setDismissTaskFormOpen(false);
-                setCompleteFormOpen(false);
-              }}
-            >
-              Issue target
-            </Button>
-            <Button
-              className="govuk-button--secondary govuk-!-margin-right-1"
-              onClick={() => {
-                setCompleteFormOpen(true);
-                setDismissTaskFormOpen(false);
-                setIssueTargetFormOpen(false);
-              }}
-            >
-              Assessment complete
-            </Button>
-            <Button
-              className="govuk-button--warning"
-              onClick={() => {
-                setDismissTaskFormOpen(true);
-                setCompleteFormOpen(false);
-                setIssueTargetFormOpen(false);
-              }}
-            >
-              Dismiss
-            </Button>
+            {showButtons && (
+            <>
+              <Button
+                className="govuk-!-margin-right-1"
+                onClick={() => {
+                  setIssueTargetFormOpen(true);
+                  setDismissTaskFormOpen(false);
+                  setCompleteFormOpen(false);
+                  setShowButtons(false);
+                }}
+              >
+                Issue target
+              </Button>
+              <Button
+                className="govuk-button--secondary govuk-!-margin-right-1"
+                onClick={() => {
+                  setCompleteFormOpen(true);
+                  setDismissTaskFormOpen(false);
+                  setIssueTargetFormOpen(false);
+                  setShowButtons(false);
+                }}
+              >
+                Assessment complete
+              </Button>
+              <Button
+                className="govuk-button--warning"
+                onClick={() => {
+                  setDismissTaskFormOpen(true);
+                  setCompleteFormOpen(false);
+                  setIssueTargetFormOpen(false);
+                  setShowButtons(false);
+                }}
+              >
+                Dismiss
+              </Button>
+            </>
+            )}
           </>
           )}
         </div>
@@ -222,7 +239,10 @@ const TaskDetailsPage = () => {
                 }
               }
             }
-            onCancel={() => setIssueTargetFormOpen()}
+            onCancel={() => onCancelConfirmation(() => {
+              setShowButtons(true);
+              setIssueTargetFormOpen();
+            })}
             renderer={Renderers.REACT}
             setError={setError}
           />
@@ -248,7 +268,10 @@ const TaskDetailsPage = () => {
                 setSubmitted(true);
               }
             }
-            onCancel={() => setCompleteFormOpen()}
+            onCancel={() => onCancelConfirmation(() => {
+              setShowButtons(true);
+              setCompleteFormOpen();
+            })}
             form={completeTask}
             renderer={Renderers.REACT}
             setError={setError}
@@ -275,7 +298,10 @@ const TaskDetailsPage = () => {
                   setSubmitted(true);
                 }
               }
-              onCancel={() => setDismissTaskFormOpen()}
+              onCancel={() => onCancelConfirmation(() => {
+                setShowButtons(true);
+                setDismissTaskFormOpen();
+              })}
               form={dismissTask}
               renderer={Renderers.REACT}
               setError={setError}

--- a/src/routes/airpax/TaskDetails/builder/Document.jsx
+++ b/src/routes/airpax/TaskDetails/builder/Document.jsx
@@ -12,10 +12,8 @@ import renderBlock from './helper/common';
 
 const Document = ({ version }) => {
   const person = PersonUtil.get(version);
-  const document = DocumentUtil.get(version.movement.person);
+  const document = DocumentUtil.get(person);
   const journey = getJourney(version);
-  const validFromExpiry = document ? DocumentUtil.calculateExpiry(document.validFrom, getDate()) : 'Unknown';
-  const validToExpiry = document ? DocumentUtil.calculateExpiry(document.expiry, getArrivalTime(journey)) : 'Unknown';
 
   return (
     <div className="task-details-container bottom-border-thin govuk-!-margin-bottom-2">
@@ -25,8 +23,10 @@ const Document = ({ version }) => {
         {renderBlock('Number', [DocumentUtil.docNumber(document)])}
         {renderBlock('Document nationality', [DocumentUtil.docNationality(document, true)])}
         {renderBlock('Country of issue', [DocumentUtil.docCountry(document, true)])}
-        {renderBlock('Valid from', [DocumentUtil.docValidity(document, true), validFromExpiry])}
-        {renderBlock('Valid To', [DocumentUtil.docExpiry(document, true), validToExpiry])}
+        {renderBlock('Valid from', [DocumentUtil.docValidity(document, true),
+          DocumentUtil.calculateExpiry(DocumentUtil.docValidityDate(document), getDate())])}
+        {renderBlock('Valid To', [DocumentUtil.docExpiry(document, true),
+          DocumentUtil.calculateExpiry(DocumentUtil.docExpiryDate(document), getArrivalTime(journey))])}
         {renderBlock('Name', [DocumentUtil.docName(person)])}
         {renderBlock('Date of birth', [PersonUtil.dob(person)])}
       </div>

--- a/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/airpax/__tests__/TaskDetailsPage.test.jsx
@@ -50,6 +50,8 @@ describe('Task details page', () => {
     </MockApplicationContext>,
   );
 
+  const ACTION_BUTTONS = ['Issue target', 'Assessment complete', 'Dismiss'];
+
   it('should render TaskDetailsPage component with a loading state', () => {
     mockAxiosCalls([], {});
 
@@ -217,42 +219,58 @@ describe('Task details page', () => {
     expect(screen.queryByText('Assessment complete')).not.toBeInTheDocument();
   });
 
-  it('should hide the notes form on clicking the assessment complete button', async () => {
-    mockAxiosCalls(dataClaimedTask, {});
+  ACTION_BUTTONS.forEach((button) => {
+    it('should hide the notes form on clicking an action button', async () => {
+      mockAxiosCalls(dataClaimedTask, {});
 
-    await waitFor(() => renderPage());
+      await waitFor(() => renderPage());
 
-    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+      expect(screen.queryByText('Add a new note')).toBeInTheDocument();
 
-    const assessmentCompleteButton = screen.getByRole('button', { name: 'Assessment complete' });
-    fireEvent.click(assessmentCompleteButton);
+      const actionButton = screen.getByRole('button', { name: button });
+      fireEvent.click(actionButton);
 
-    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+      expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+    });
   });
 
-  it('should hide the notes form on clicking the dismiss button', async () => {
-    mockAxiosCalls(dataClaimedTask, {});
+  ACTION_BUTTONS.forEach((button) => {
+    it('should hide the action buttons', async () => {
+      mockAxiosCalls(dataClaimedTask, {});
 
-    await waitFor(() => renderPage());
+      await waitFor(() => renderPage());
 
-    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+      expect(screen.queryByText('Issue target')).toBeInTheDocument();
+      expect(screen.queryByText('Assessment complete')).toBeInTheDocument();
+      expect(screen.queryByText('Dismiss')).toBeInTheDocument();
 
-    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
-    fireEvent.click(dismissButton);
+      const actionButton = screen.getByRole('button', { name: button });
+      fireEvent.click(actionButton);
 
-    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+      expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
+      expect(screen.queryByText('Issue target')).not.toBeInTheDocument();
+      expect(screen.queryByText('Assessment complete')).not.toBeInTheDocument();
+    });
   });
 
-  it('should hide the notes form on clicking the issue target button', async () => {
-    mockAxiosCalls(dataClaimedTask, {});
+  ACTION_BUTTONS.forEach((button) => {
+    it('should call the confirm dialog on cancelling a form', async () => {
+      const confirmMock = jest.spyOn(window, 'confirm').mockImplementation();
+      mockAxiosCalls(dataClaimedTask, {});
 
-    await waitFor(() => renderPage());
+      await waitFor(() => renderPage());
 
-    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+      expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
 
-    const issueTargetButton = screen.getByRole('button', { name: 'Issue target' });
-    fireEvent.click(issueTargetButton);
+      const actionButton = screen.getByRole('button', { name: button });
+      fireEvent.click(actionButton);
 
-    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
+      expect(screen.queryByText('Cancel')).toBeInTheDocument();
+
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+      fireEvent.click(cancelButton);
+
+      expect(confirmMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
+++ b/src/routes/airpax/__tests__/__snapshots__/TaskVersions.test.jsx.snap
@@ -436,7 +436,7 @@ exports[`TaskVersions should render task versions 1`] = `
                     <p
                       className="govuk-!-margin-bottom-0 font__light"
                     >
-                      4 years after travel
+                      Unknown
                     </p>
                   </div>
                   <div

--- a/src/routes/airpax/__tests__/utils/DocumentUtil.test.js
+++ b/src/routes/airpax/__tests__/utils/DocumentUtil.test.js
@@ -203,4 +203,28 @@ describe('DocumentUtil', () => {
     const output = DocumentUtil.docCountryCode(document);
     expect(output).toEqual(UNKNOWN_TEXT);
   });
+
+  it('should return the document expiry date', () => {
+    expect(DocumentUtil.docExpiryDate(document)).toEqual(document.expiry);
+  });
+
+  it('should return undefined for invalid document expiry dates', () => {
+    const INVALID_DATES = [undefined, null, ''];
+    INVALID_DATES.forEach((date) => {
+      document.expiry = date;
+      expect(DocumentUtil.docExpiryDate(document)).toBeUndefined();
+    });
+  });
+
+  it('should return the document valid from date', () => {
+    expect(DocumentUtil.docValidityDate(document)).toEqual(document.validFrom);
+  });
+
+  it('should return undefined for invalid document valid from dates', () => {
+    const INVALID_DATES = [undefined, null, ''];
+    INVALID_DATES.forEach((date) => {
+      document.validFrom = date;
+      expect(DocumentUtil.docValidityDate(document)).toBeUndefined();
+    });
+  });
 });

--- a/src/routes/airpax/utils/datetimeUtil.js
+++ b/src/routes/airpax/utils/datetimeUtil.js
@@ -69,4 +69,4 @@ const DateTimeUtil = {
 
 export default DateTimeUtil;
 
-export { formatToUTCDate, getDate, getFormattedDate, isInPast, toDateTimeList, toRelativeTime };
+export { formatToUTCDate, getDate, getFormattedDate, isInPast, toDateTimeList, toRelativeTime, validateDate };

--- a/src/routes/airpax/utils/documentUtil.js
+++ b/src/routes/airpax/utils/documentUtil.js
@@ -6,28 +6,27 @@ import {
   AGO_TEXT,
   A_SMALL_TEXT,
   AN_SMALL_TEXT,
-  UNKNOWN_TEXT,
   AFTER_TRAVEL_TEXT,
   BEFORE_TRAVEL_TEXT,
   SHORT_DATE_FORMAT_ALT,
+  UNKNOWN_TEXT,
+  UTC_DATE_FORMAT,
 } from '../../../constants';
 import { formatField } from '../../../utils/formatField';
 import Common from './common';
-import { getFormattedDate } from './datetimeUtil';
+import { getFormattedDate, validateDate } from './datetimeUtil';
 
 const calculateExpiry = (passportExpiry, arrivalTime) => {
-  const expiry = arrivalTime
-    && passportExpiry !== 'Unknown'
-    && `${arrivalTime},${moment(passportExpiry).format('YYYY-MM-DDTHH:mm:ss')}`;
-  if (expiry) {
-    return formatField('BOOKING_DATETIME', expiry)
-      .split(', ')[1]
-      .replace(BEFORE_TRAVEL_TEXT, AFTER_TRAVEL_TEXT)
-      .replace(AGO_TEXT, BEFORE_TRAVEL_TEXT)
-      .replace(A_SMALL_TEXT, A_TITLE_CASE_TEXT)
-      .replace(AN_SMALL_TEXT, AN_TITLE_CASE_TEXT);
+  if (!validateDate(passportExpiry) || !validateDate(arrivalTime)) {
+    return UNKNOWN_TEXT;
   }
-  return UNKNOWN_TEXT;
+  const expiry = `${arrivalTime},${moment(passportExpiry).format(UTC_DATE_FORMAT)}`;
+  return formatField('BOOKING_DATETIME', expiry)
+    .split(', ')[1]
+    .replace(BEFORE_TRAVEL_TEXT, AFTER_TRAVEL_TEXT)
+    .replace(AGO_TEXT, BEFORE_TRAVEL_TEXT)
+    .replace(A_SMALL_TEXT, A_TITLE_CASE_TEXT)
+    .replace(AN_SMALL_TEXT, AN_TITLE_CASE_TEXT);
 };
 
 const hasDocument = (person) => {
@@ -41,12 +40,20 @@ const getDocument = (person) => {
   return null;
 };
 
+const getDocumentExpiryDate = (document) => {
+  return document?.expiry || undefined;
+};
+
 const getDocumentExpiry = (document, taskDetails = false) => {
   const expiryPrefix = 'Expires';
   if (!document?.expiry) {
     return taskDetails ? UNKNOWN_TEXT : `${expiryPrefix} ${UNKNOWN_TEXT}`;
   }
   return taskDetails ? `${getFormattedDate(document?.expiry, SHORT_DATE_FORMAT_ALT)}` : `${expiryPrefix} ${getFormattedDate(document?.expiry, SHORT_DATE_FORMAT_ALT)}`;
+};
+
+const getDocumentValidityDate = (document) => {
+  return document?.validFrom || undefined;
 };
 
 const getDocumentValidity = (document, taskDetails = false) => {
@@ -125,7 +132,9 @@ const getDocumentDOB = (document) => {
 const DocumentUtil = {
   get: getDocument,
   docExpiry: getDocumentExpiry,
+  docExpiryDate: getDocumentExpiryDate,
   docValidity: getDocumentValidity,
+  docValidityDate: getDocumentValidityDate,
   docType: getDocumentType,
   docNumber: getDocumentNumber,
   docName: getDocumentName,
@@ -142,7 +151,9 @@ export default DocumentUtil;
 export {
   getDocument,
   getDocumentExpiry,
+  getDocumentExpiryDate,
   getDocumentValidity,
+  getDocumentValidityDate,
   getDocumentType,
   getDocumentNumber,
   getDocumentName,

--- a/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
@@ -87,7 +87,7 @@ const TaskDetailsPage = () => {
   const [isIssueTargetFormOpen, setIssueTargetFormOpen] = useState();
   const [isLoading, setLoading] = useState(true);
   const [refreshNotesForm, setRefreshNotesForm] = useState(false);
-  const [showButtons, setShowButtons] = useState(true);
+  const [showActionButtons, setShowActionButtons] = useState(true);
 
   const toModeCode = (mode) => {
     if (/RORO Accompanied Freight/i.test(mode)) {
@@ -341,7 +341,7 @@ const TaskDetailsPage = () => {
               {assignee === currentUser && targetStatus.toUpperCase() === TASK_STATUS_NEW.toUpperCase()
               && processInstanceData.taskDefinitionKey === 'developTarget' && (
                 <>
-                  {showButtons && (
+                  {showActionButtons && (
                   <>
                     <Button
                       className="govuk-!-margin-right-1"
@@ -349,7 +349,7 @@ const TaskDetailsPage = () => {
                         setIssueTargetFormOpen(true);
                         setCompleteFormOpen(false);
                         setDismissFormOpen(false);
-                        setShowButtons(false);
+                        setShowActionButtons(false);
                       }}
                     >
                       Issue target
@@ -360,7 +360,7 @@ const TaskDetailsPage = () => {
                         setIssueTargetFormOpen(false);
                         setCompleteFormOpen(true);
                         setDismissFormOpen(false);
-                        setShowButtons(false);
+                        setShowActionButtons(false);
                       }}
                     >
                       Assessment complete
@@ -371,7 +371,7 @@ const TaskDetailsPage = () => {
                         setIssueTargetFormOpen(false);
                         setCompleteFormOpen(false);
                         setDismissFormOpen(true);
-                        setShowButtons(false);
+                        setShowActionButtons(false);
                       }}
                     >
                       Dismiss
@@ -388,7 +388,7 @@ const TaskDetailsPage = () => {
                 <TaskManagementForm
                   formName="assessmentComplete"
                   onCancel={() => {
-                    setShowButtons(true);
+                    setShowActionButtons(true);
                     setCompleteFormOpen(false);
                   }}
                   taskId={processInstanceData.id}
@@ -405,7 +405,7 @@ const TaskDetailsPage = () => {
                 <TaskManagementForm
                   formName="dismissTarget"
                   onCancel={() => {
-                    setShowButtons(true);
+                    setShowActionButtons(true);
                     setDismissFormOpen(false);
                   }}
                   taskId={processInstanceData.id}
@@ -430,7 +430,7 @@ const TaskDetailsPage = () => {
                   <TaskManagementForm
                     formName="targetInformationSheet"
                     onCancel={() => {
-                      setShowButtons(true);
+                      setShowActionButtons(true);
                       setIssueTargetFormOpen(false);
                     }}
                     taskId={processInstanceData.id}

--- a/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/roro/TaskDetails/TaskDetailsPage.jsx
@@ -87,6 +87,7 @@ const TaskDetailsPage = () => {
   const [isIssueTargetFormOpen, setIssueTargetFormOpen] = useState();
   const [isLoading, setLoading] = useState(true);
   const [refreshNotesForm, setRefreshNotesForm] = useState(false);
+  const [showButtons, setShowButtons] = useState(true);
 
   const toModeCode = (mode) => {
     if (/RORO Accompanied Freight/i.test(mode)) {
@@ -321,7 +322,8 @@ const TaskDetailsPage = () => {
               <h3 className="govuk-heading-xl govuk-!-margin-bottom-0">Overview</h3>
               {targetStatus.toUpperCase() === TASK_STATUS_NEW.toUpperCase() && (
                 <>
-                  {targetStatus.toUpperCase() === TASK_STATUS_NEW.toUpperCase() && <p className="govuk-tag govuk-tag--newTarget">New</p>}
+                  {targetStatus.toUpperCase() === TASK_STATUS_NEW.toUpperCase()
+                  && <p className="govuk-tag govuk-tag--newTarget">New</p>}
                   <p className="govuk-body">
                     {getAssignee()}
                     <ClaimButton
@@ -336,38 +338,46 @@ const TaskDetailsPage = () => {
               )}
             </div>
             <div className="govuk-grid-column-one-half task-actions--buttons">
-              {assignee === currentUser && targetStatus.toUpperCase() === TASK_STATUS_NEW.toUpperCase() && processInstanceData.taskDefinitionKey === 'developTarget' && (
+              {assignee === currentUser && targetStatus.toUpperCase() === TASK_STATUS_NEW.toUpperCase()
+              && processInstanceData.taskDefinitionKey === 'developTarget' && (
                 <>
-                  <Button
-                    className="govuk-!-margin-right-1"
-                    onClick={() => {
-                      setIssueTargetFormOpen(true);
-                      setCompleteFormOpen(false);
-                      setDismissFormOpen(false);
-                    }}
-                  >
-                    Issue target
-                  </Button>
-                  <Button
-                    className="govuk-button--secondary govuk-!-margin-right-1"
-                    onClick={() => {
-                      setIssueTargetFormOpen(false);
-                      setCompleteFormOpen(true);
-                      setDismissFormOpen(false);
-                    }}
-                  >
-                    Assessment complete
-                  </Button>
-                  <Button
-                    className="govuk-button--warning"
-                    onClick={() => {
-                      setIssueTargetFormOpen(false);
-                      setCompleteFormOpen(false);
-                      setDismissFormOpen(true);
-                    }}
-                  >
-                    Dismiss
-                  </Button>
+                  {showButtons && (
+                  <>
+                    <Button
+                      className="govuk-!-margin-right-1"
+                      onClick={() => {
+                        setIssueTargetFormOpen(true);
+                        setCompleteFormOpen(false);
+                        setDismissFormOpen(false);
+                        setShowButtons(false);
+                      }}
+                    >
+                      Issue target
+                    </Button>
+                    <Button
+                      className="govuk-button--secondary govuk-!-margin-right-1"
+                      onClick={() => {
+                        setIssueTargetFormOpen(false);
+                        setCompleteFormOpen(true);
+                        setDismissFormOpen(false);
+                        setShowButtons(false);
+                      }}
+                    >
+                      Assessment complete
+                    </Button>
+                    <Button
+                      className="govuk-button--warning"
+                      onClick={() => {
+                        setIssueTargetFormOpen(false);
+                        setCompleteFormOpen(false);
+                        setDismissFormOpen(true);
+                        setShowButtons(false);
+                      }}
+                    >
+                      Dismiss
+                    </Button>
+                  </>
+                  )}
                 </>
               )}
             </div>
@@ -377,7 +387,10 @@ const TaskDetailsPage = () => {
               {isCompleteFormOpen && (
                 <TaskManagementForm
                   formName="assessmentComplete"
-                  onCancel={() => setCompleteFormOpen(false)}
+                  onCancel={() => {
+                    setShowButtons(true);
+                    setCompleteFormOpen(false);
+                  }}
                   taskId={processInstanceData.id}
                   actionTarget={false}
                   refreshNotes={() => setRefreshNotesForm(!refreshNotesForm)}
@@ -391,7 +404,10 @@ const TaskDetailsPage = () => {
               {isDismissFormOpen && (
                 <TaskManagementForm
                   formName="dismissTarget"
-                  onCancel={() => setDismissFormOpen(false)}
+                  onCancel={() => {
+                    setShowButtons(true);
+                    setDismissFormOpen(false);
+                  }}
                   taskId={processInstanceData.id}
                   actionTarget={false}
                   refreshNotes={() => setRefreshNotesForm(!refreshNotesForm)}
@@ -413,7 +429,10 @@ const TaskDetailsPage = () => {
                   </div>
                   <TaskManagementForm
                     formName="targetInformationSheet"
-                    onCancel={() => setIssueTargetFormOpen(false)}
+                    onCancel={() => {
+                      setShowButtons(true);
+                      setIssueTargetFormOpen(false);
+                    }}
                     taskId={processInstanceData.id}
                     processInstanceData={targetData.targetInformationSheet}
                     actionTarget

--- a/src/routes/roro/__tests__/TaskDetailsPage.test.jsx
+++ b/src/routes/roro/__tests__/TaskDetailsPage.test.jsx
@@ -41,6 +41,7 @@ describe('TaskDetailsPage', () => {
     timestamp: '2021-04-06T15:30:42.420+0000',
     userId: 'testuser@email.com',
   }];
+
   const taskHistoryFixture = [{
     assignee: 'testuser@email.com',
     startTime: '2021-04-20T10:50:25.869+0000',
@@ -78,6 +79,8 @@ describe('TaskDetailsPage', () => {
       .onGet('/v2/entities/targetmode', { params: { mode: 'dataOnly', filter: `modecode=eq.${modecode}` } })
       .reply(200, targetModeResponse);
   };
+
+  const ACTION_BUTTONS = ['Issue target', 'Assessment complete', 'Dismiss'];
 
   it('should render TaskDetailsPage component with a loading state', () => {
     render(<TaskDetailsPage />);
@@ -519,84 +522,65 @@ describe('TaskDetailsPage', () => {
     expect(screen.queryByText('Assigned to you')).toBeInTheDocument();
   });
 
-  it('should hide the notes form on clicking the assessment complete button', async () => {
-    mockTaskDetailsAxiosCalls({
-      processInstanceResponse: [{ id: '123' }],
-      taskResponse: [{
-        processInstanceId: '123',
-        assignee: 'test',
-        id: 'task123',
-        taskDefinitionKey: 'developTarget',
-      }],
-      variableInstanceResponse: variableInstanceStatusNew,
-      operationsHistoryResponse: operationsHistoryFixture,
-      taskHistoryResponse: taskHistoryFixture,
-      noteFormResponse: noteFormFixure,
-      modecode: 'rorotour',
-      targetModeResponse: targetModeTourist,
+  ACTION_BUTTONS.forEach((button) => {
+    it('should hide the notes form on clicking an action button', async () => {
+      mockTaskDetailsAxiosCalls({
+        processInstanceResponse: [{ id: '123' }],
+        taskResponse: [{
+          processInstanceId: '123',
+          assignee: 'test',
+          id: 'task123',
+          taskDefinitionKey: 'developTarget',
+        }],
+        variableInstanceResponse: variableInstanceStatusNew,
+        operationsHistoryResponse: operationsHistoryFixture,
+        taskHistoryResponse: taskHistoryFixture,
+        noteFormResponse: noteFormFixure,
+        modecode: 'rorotour',
+        targetModeResponse: targetModeTourist,
+      });
+
+      await waitFor(() => render(<TaskDetailsPage />));
+
+      expect(screen.queryByText('Add a new note')).toBeInTheDocument();
+
+      const actionButton = screen.getByRole('button', { name: button });
+      fireEvent.click(actionButton);
+
+      expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
     });
-
-    await waitFor(() => render(<TaskDetailsPage />));
-
-    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
-
-    const assessmentCompleteButton = screen.getByRole('button', { name: 'Assessment complete' });
-    fireEvent.click(assessmentCompleteButton);
-
-    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
   });
 
-  it('should hide the notes form on clicking the dismiss button', async () => {
-    mockTaskDetailsAxiosCalls({
-      processInstanceResponse: [{ id: '123' }],
-      taskResponse: [{
-        processInstanceId: '123',
-        assignee: 'test',
-        id: 'task123',
-        taskDefinitionKey: 'developTarget',
-      }],
-      variableInstanceResponse: variableInstanceStatusNew,
-      operationsHistoryResponse: operationsHistoryFixture,
-      taskHistoryResponse: taskHistoryFixture,
-      noteFormResponse: noteFormFixure,
-      modecode: 'rorotour',
-      targetModeResponse: targetModeTourist,
+  ACTION_BUTTONS.forEach((button) => {
+    it('should hide the action buttons', async () => {
+      mockTaskDetailsAxiosCalls({
+        processInstanceResponse: [{ id: '123' }],
+        taskResponse: [{
+          processInstanceId: '123',
+          assignee: 'test',
+          id: 'task123',
+          taskDefinitionKey: 'developTarget',
+        }],
+        variableInstanceResponse: variableInstanceStatusNew,
+        operationsHistoryResponse: operationsHistoryFixture,
+        taskHistoryResponse: taskHistoryFixture,
+        noteFormResponse: noteFormFixure,
+        modecode: 'rorotour',
+        targetModeResponse: targetModeTourist,
+      });
+
+      await waitFor(() => render(<TaskDetailsPage />));
+
+      expect(screen.queryByText('Issue target')).toBeInTheDocument();
+      expect(screen.queryByText('Assessment complete')).toBeInTheDocument();
+      expect(screen.queryByText('Dismiss')).toBeInTheDocument();
+
+      const actionButton = screen.getByRole('button', { name: button });
+      fireEvent.click(actionButton);
+
+      expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
+      expect(screen.queryByText('Issue target')).not.toBeInTheDocument();
+      expect(screen.queryByText('Assessment complete')).not.toBeInTheDocument();
     });
-
-    await waitFor(() => render(<TaskDetailsPage />));
-
-    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
-
-    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
-    fireEvent.click(dismissButton);
-
-    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
-  });
-
-  it('should hide the notes form on clicking the issue target button', async () => {
-    mockTaskDetailsAxiosCalls({
-      processInstanceResponse: [{ id: '123' }],
-      taskResponse: [{
-        processInstanceId: '123',
-        assignee: 'test',
-        id: 'task123',
-        taskDefinitionKey: 'developTarget',
-      }],
-      variableInstanceResponse: variableInstanceStatusNew,
-      operationsHistoryResponse: operationsHistoryFixture,
-      taskHistoryResponse: taskHistoryFixture,
-      noteFormResponse: noteFormFixure,
-      modecode: 'rorotour',
-      targetModeResponse: targetModeTourist,
-    });
-
-    await waitFor(() => render(<TaskDetailsPage />));
-
-    expect(screen.queryByText('Add a new note')).toBeInTheDocument();
-
-    const issueTargetButton = screen.getByRole('button', { name: 'Issue target' });
-    fireEvent.click(issueTargetButton);
-
-    expect(screen.queryByText('Add a new note')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description
This PR hides the action buttons `Issue Target`, `Assessment complete` & `Dismiss` when any of these is selected which leads to a form rendering.

### Supplemental
This PR also adds a missed behaviour where on form cancellation is triggered, a confirmation dialog is displayed to the user to confirm their action.

## To Test
- Pull & run against dev
- Claim a task
- Clicking on each action button should hide all action buttons.

### To Test (Supplemental feature)
- Clicking on the cancel button should trigger a confirmation dialog that asks the user to confirm their decision.
