### PR TITLE
COP-10955: Added test for When the weight is blank, we can still see the kg being displayed in the weight section

### DIFF
--- a/cypress/integration/airpax/filter-airpax-tasks-by-assignedToMe.spec.js
+++ b/cypress/integration/airpax/filter-airpax-tasks-by-assignedToMe.spec.js
@@ -9,7 +9,7 @@ describe('Filter airpax tasks by Assignee', () => {
     const userId = Cypress.env('userName');
     const taskName = 'AIRPAX';
     cy.fixture('airpax/task-airpax.json').then((task) => {
-      cy.createMovementId(task, taskName);
+      cy.createMovementId(task, taskName, null);
       cy.createTargetingApiTask(task).then((taskResponse) => {
         cy.wait(3000);
         const businessKey = taskResponse.id;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2374,6 +2374,10 @@ Cypress.Commands.add('verifyFindTaskId', (businessKey) => {
   searchTaskList(businessKey);
 });
 
-Cypress.Commands.add('createMovementId', (task, taskName) => {
-  task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+Cypress.Commands.add('createMovementId', (task, taskName, movementId) => {
+  if (movementId === null) {
+    task.data.movementId = `${taskName}_${Math.floor((Math.random() * 1000000) + 1)}:CMID=TEST`;
+  } else {
+    task.data.movementId = movementId;
+  }
 });


### PR DESCRIPTION
## Description
Added test for When the weight is blank, we can still see the kg being displayed in the weight section.

npm run cypress:test:local -- --spec cypress/integration/airpax/airpax-task-details.spec.js

Should verify Baggage details of an AirPax task


## To Test

## Developer Checklist

\* Required

- [ ] Up-to-date with main branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
