### PR TITLE
Fixes code which returns object of a jsx object instead of the jsx object

### DIFF
--- a/src/routes/TaskList/components/roro/TouristMovementSection.jsx
+++ b/src/routes/TaskList/components/roro/TouristMovementSection.jsx
@@ -36,7 +36,7 @@ const TouristMovementSection = ({ targetTask }) => {
       if (index < maxToDisplay) {
         return (
           <li key={index}>
-            {PersonUtil.firstname(_person)}{(index !== maxToDisplay - 1) && (index !== otherPersons.length - 1) ? ',' : ''}
+            {PersonUtil.fullname(_person)}{(index !== maxToDisplay - 1) && (index !== otherPersons.length - 1) ? ',' : ''}
             {(remaining > 0 && index + 1 === maxToDisplay) ? ` plus ${remaining} more` : ''}
           </li>
         );

--- a/src/routes/TaskList/components/roro/TouristMovementSection.jsx
+++ b/src/routes/TaskList/components/roro/TouristMovementSection.jsx
@@ -32,7 +32,7 @@ const TouristMovementSection = ({ targetTask }) => {
     }
     const maxToDisplay = 4;
     const remaining = otherPersons.length > maxToDisplay ? otherPersons.length - maxToDisplay : 0;
-    const coTravellersJsx = otherPersons.map((_person, index) => {
+    return otherPersons.map((_person, index) => {
       if (index < maxToDisplay) {
         return (
           <li key={index}>
@@ -42,9 +42,6 @@ const TouristMovementSection = ({ targetTask }) => {
         );
       }
     });
-    return (
-      { coTravellersJsx }
-    );
   };
 
   const TouristCar = () => {


### PR DESCRIPTION
## Description
This PR addresses a bug which comes about when a task (mainly in RoRo V2 as we can have a tourist task with multiple people) has multiple co-travellers. Somehow the previous code has gone from returning a `JSX` object to returning a `JSX` object that is now wrapped within another object which then causes the UI to trip over itself.

# To Replicate Bug
- Post a Tourist task (group/ vehicle) with multiple persons in the movement.
- Access the RoRo V2 task list page, the UI will then trip over itself.