### PR TITLE
COP-10856 - Adds conditional post params based on view

### DIFF
--- a/src/components/RenderForm/RenderForm.jsx
+++ b/src/components/RenderForm/RenderForm.jsx
@@ -28,6 +28,7 @@ const RenderForm = ({ formName,
   preFillData,
   cacheTisFormData,
   setError,
+  viewOnly,
   children }) => {
   const [form, setForm] = useState(_form);
   const [renderer, setRenderer] = useState(_renderer);
@@ -177,6 +178,7 @@ const RenderForm = ({ formName,
       <FormRenderer
         {...form}
         data={formattedPreFillData?.data}
+        viewOnly={viewOnly}
         hooks={{
           onGetComponent,
           onRequest: (req) => FormUtils.formHooks.onRequest(req, keycloak.token),

--- a/src/routes/TaskDetails/TaskDetailsPage.jsx
+++ b/src/routes/TaskDetails/TaskDetailsPage.jsx
@@ -205,6 +205,7 @@ const TaskDetailsPage = () => {
             <div className="govuk-grid-column-two-thirds">
               {isIssueTargetFormOpen && !isSubmitted && (
                 <RenderForm
+                  viewOnly={false}
                   cacheTisFormData
                   form={getTisForm(getView())}
                   preFillData={tisCache()}

--- a/src/routes/TaskList/TaskListPage.jsx
+++ b/src/routes/TaskList/TaskListPage.jsx
@@ -150,23 +150,21 @@ const TaskListPage = () => {
         journeyDirections: direction.journeyDirections,
         departureStatuses: adaptDepartureStatuses(storedData),
       }));
-      const flightStatuses = DEFAULTS[getView()].filters.flightStatuses.map((status) => ({
-        taskStatuses: [TAB_STATUS_MAPPING[taskStatus]],
-        movementModes: adaptMovementModes(storedData),
-        selectors: storedData.selectors,
-        ruleIds: storedData.ruleIds,
-        searchText: storedData.searchText,
-        assignees: ((taskStatus === TASK_STATUS.IN_PROGRESS)
-          && CommonUtil.hasAssignee(DEFAULTS[getView()].filters.key)) ? [currentUser] : [],
-        journeyDirections: adaptJourneyDirection(storedData),
-        departureStatuses: status.departureStatuses,
-      }));
-
       return [
         ...movementModes,
         ...selectors,
         ...directions,
-        ...flightStatuses,
+        ...(DEFAULTS[getView()]?.filters?.flightStatuses ? DEFAULTS[getView()].filters.flightStatuses.map((status) => ({
+          taskStatuses: [TAB_STATUS_MAPPING[taskStatus]],
+          movementModes: adaptMovementModes(storedData),
+          selectors: storedData.selectors,
+          ruleIds: storedData.ruleIds,
+          searchText: storedData.searchText,
+          assignees: ((taskStatus === TASK_STATUS.IN_PROGRESS)
+            && CommonUtil.hasAssignee(DEFAULTS[getView()].filters.key)) ? [currentUser] : [],
+          journeyDirections: adaptJourneyDirection(storedData),
+          departureStatuses: status.departureStatuses,
+        })) : []),
       ];
     }
     return [
@@ -186,12 +184,12 @@ const TaskListPage = () => {
           taskStatuses: [TAB_STATUS_MAPPING[taskStatus]],
         };
       }),
-      ...DEFAULTS[getView()].filters.flightStatuses.map((status) => {
+      ...(DEFAULTS[getView()]?.filters?.flightStatuses ? DEFAULTS[getView()].filters.flightStatuses.map((status) => {
         return {
           ...status,
           taskStatuses: [TAB_STATUS_MAPPING[taskStatus]],
         };
-      }),
+      }) : []),
     ];
   };
 


### PR DESCRIPTION
## Description
This PR fixes a bug introduced when a page does not contain the required pieces of data for it to make a network call.


### Supplemental
Adds a newly added prop **`viewOnly`** to the form renderer (stops the error summary giving the impression that the prefill data has been wiped out).